### PR TITLE
Update to latest vscode development setup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,12 +6,11 @@
 			"type": "extensionHost",
 			// path to VSCode executable
 			"runtimeExecutable": "${execPath}",
-			// force VSCode to create a new window and pass this project as an additonal plugin location
-			// add workspace path to %GOPATH% so that there is some meaningful contents
-			"args": [ "--new-window", "--extensionDevelopmentPath=${workspaceRoot}" ],
+			"args": [ "--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out"
+			"outDir": "out",
+			"preLaunchTask": "npm"
 		},
 		{
 			"name": "debug-debugger",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,19 +11,21 @@
 {
 	"version": "0.1.0",
 
-	// The command is tsc. Assumes that tsc 1.5.x or higher has been installed using npm install -g typescript
-	"command": "node_modules/.bin/tsc",
+	// we want to run npm
+	"command": "npm",
 
-	// The command is a shell script
+	// the command is a shell script
 	"isShellCommand": true,
 
-	// Show the output window only if unrecognized errors occur.
+	// show the output window only if unrecognized errors occur.
 	"showOutput": "silent",
 
-	// args is the HelloWorld program to compile.
-	"args": ["-w"],
+	// we run the custom script "compile" as defined in package.json
+	"args": ["run", "compile"],
 
-	// use the standard tsc problem matcher to find compile problems
-	// in the output.
-	"problemMatcher": "$tsc"
+	// The tsc compiler is started in watching mode
+	"isWatching": true,
+
+	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
+	"problemMatcher": "$tsc-watch"
 }

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
 	"publisher": "lukehoban",
 	"description": "Go support for Visual Studio Code",
 	"author": {
-		"name": "Microsoft Corporation"
+		"name": "Microsoft Corporation - Development Labs"
 	},
 	"private": true,
 	"repository": {
 		"type": "git",
-		"url": "https://monacotools.visualstudio.com/DefaultCollection/Monaco/_git/go-code"
+		"url": "https://github.com/Microsoft/vscode-go.git"
 	},
 	"scripts": {
-		"prepublish": "tsc"
+		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
+		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
 	},
 	"extensionDependencies": [
 		"vscode.go"
@@ -21,7 +22,7 @@
 		"json-rpc2": "^1.0.2"
 	},
 	"devDependencies": {
-		"typescript": "^1.6.2"
+		"vscode": "*"
 	},
 	"engines": {
 		"vscode": "*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
 		"target": "es5"
 	},
 	"exclude": [
-		"node_modules"	
+		"node_modules"
 	]
 }


### PR DESCRIPTION
In the latest setup you get the typings for vscode from a 'vscode' node module. This node module also pre-reqs the matching typescript version. The version of the vscode node module is defined in the package.json as a devDependency.

In the latest development setup the TS watching is setup automatically. The preLaunchTask in launch.json starts the watching task.
