### PR TITLE
Fix gopath bin location search and error in error line parsing in windows

### DIFF
--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -47,9 +47,9 @@ export function check(filename: string, buildOnSave = true, lintOnSave = true, v
 				var lines = stderr.toString().split('\n');
 				var ret: ICheckResult[] = [];
 				for(var i = 1; i < lines.length; i++) {
-					var match = /(.*):(\d+): (.*)/.exec(lines[i]);
+					var match = /([^:]*):(\d+)(:\d+)?: (.*)/.exec(lines[i]);
 					if(!match) continue;
-					var [_, file, lineStr, msg] = match;
+					var [_, file, lineStr, charStr, msg] = match;
 					var line = +lineStr;
 					ret.push({ file: path.resolve(cwd, file), line, msg, severity: "error" });
 				}

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -14,6 +14,7 @@ import { showGoStatus, hideGoStatus } from './goStatus'
 var binPathCache : { [bin: string]: string;} = {}
 
 export function getBinPath(binname) {
+	binname = correctBinname(binname)
 	if(binPathCache[binname]) return binPathCache[binname];
 	var workspaces = getGOPATHWorkspaces();
 	var binpath: string;
@@ -25,6 +26,13 @@ export function getBinPath(binname) {
 	}
 	console.log("Couldn't find a binary in any GOPATH workspaces: ", binname, " ", workspaces)
 	return path.join(process.env["GOPATH"], "bin", binname);
+}
+
+function correctBinname(binname) {
+	if (process.platform === 'win32')
+		return binname + ".exe";
+	else
+		return binname
 }
 
 function getGOPATHWorkspaces() {
@@ -75,9 +83,7 @@ export function setupGoPathAndOfferToInstallTools() {
 	}
 	var keys = Object.keys(tools)
 	Promise.all(keys.map(tool => new Promise<string>((resolve, reject) => {
-		let toolPath = path.join(process.env["GOPATH"], 'bin', tool);
-		if (process.platform === 'win32')
-			toolPath = toolPath + ".exe";
+		let toolPath = getBinPath(tool);
 		fs.exists(toolPath, exists => {
 			resolve(exists ? null : tools[tool])
 		});


### PR DESCRIPTION
I request to merge to correction tested for windows plugin usage. 
First bin path extraction from gopath should be consistent, and in windows it is required to test file with it's extension
Build tool will emit errors like: myfile.go:4:6: expected 'STRING', found newline
where 4 is the line number and not 6