### PR TITLE
gorename: fix incorrect path logic.

### DIFF
--- a/src/goRename.ts
+++ b/src/goRename.ts
@@ -22,17 +22,17 @@ export class GoRenameProvider implements vscode.RenameProvider {
 			var filename = this.canonicalizeForWindows(document.fileName);
 			var offset = document.offsetAt(position);
 
-			var gorename = path.join(process.env["GOPATH"], "bin", "gorename");
+			var gorename = getBinPath("gorename");
 
 			cp.execFile(gorename, ["-offset", filename + ":#" + offset, "-to", newName], {}, (err, stdout, stderr) => {
 				try {
 					if (err && (<any>err).code == "ENOENT") {
 						vscode.window.showInformationMessage("The 'gorename' command is not available.  Use 'go get golang.org/x/tools/cmd/gorename' to install.");
-						return resolve(null);
+						return Promise.resolve<vscode.WorkspaceEdit>(null);
 					}
 					if (err) return reject("Cannot rename due to errors: " + err);
 					// TODO: 'gorename' makes the edits in the files out of proc.
-					// Would be better if we coudl get the list of edits.
+					// Would be better if we could get the list of edits.
 					return Promise.resolve<vscode.WorkspaceEdit>(null);
 				} catch (e) {
 					reject(e);


### PR DESCRIPTION
Also don't return a null thenable if gorename isn't found.

https://github.com/Microsoft/vscode-go/issues/71