### PR TITLE
Introduce command to run test at cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
 				"command": "go.gopath",
 				"title": "Go: Current GOPATH",
 				"description": "See the currently set GOPATH."
+			},
+			{
+				"command": "go.test.cursor",
+				"title": "Go: Run test at cursor",
+				"description": "Runs a unit test at the cursor."
 			}
 		],
 		"debuggers": [
@@ -184,6 +189,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "[EXPERIMENTAL] Run formatting tool on save."
+				},
+				"go.testTimeout": {
+					"type": "string",
+					"default": "30s",
+					"description": "Specifies the timeout for go test in ParseDuration format."
 				}
 			}
 		}

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -9,17 +9,9 @@ import cp = require('child_process');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
-import { getBinPath } from './goPath'
+import { getBinPath, getGoRuntimePath } from './goPath'
 
-//TODO: Less hacky?
-var go: string;
-if (process.env.GOROOT) {
-	go = path.join(process.env["GOROOT"], "bin", "go");
-} else if (process.env.PATH) {
-	var pathparts = (<string>process.env.PATH).split((<any>path).delimiter);
-	go = pathparts.map(dir => path.join(dir, 'go' + (os.platform() == "win32" ? ".exe" : ""))).filter(candidate => fs.existsSync(candidate))[0];
-}
-if (!go) {
+if (!getGoRuntimePath()) {
 	vscode.window.showInformationMessage("No 'go' binary could be found on PATH or in GOROOT.");
 }
 
@@ -38,7 +30,7 @@ export function check(filename: string, buildOnSave = true, lintOnSave = true, v
 		if (filename.match(/_test.go$/i)) {
 			args = ['test', '-copybinary', '-o', tmppath, '-c', '.']
 		}
-		cp.execFile(go, args, { cwd: cwd }, (err, stdout, stderr) => {
+		cp.execFile(getGoRuntimePath(), args, { cwd: cwd }, (err, stdout, stderr) => {
 			try {
 				if (err && (<any>err).code == "ENOENT") {
 					vscode.window.showInformationMessage("The 'go' compiler is not available.  Install Go from http://golang.org/dl/.");
@@ -91,7 +83,7 @@ export function check(filename: string, buildOnSave = true, lintOnSave = true, v
 
 	var govet = !vetOnSave ? Promise.resolve([]) : new Promise((resolve, reject) => {
 		var cwd = path.dirname(filename)
-		cp.execFile(go, ["tool", "vet", filename], { cwd: cwd }, (err, stdout, stderr) => {
+		cp.execFile(getGoRuntimePath(), ["tool", "vet", filename], { cwd: cwd }, (err, stdout, stderr) => {
 			try {
 				if (err && (<any>err).code == "ENOENT") {
 					vscode.window.showInformationMessage("The 'go tool vet' compiler is not available.  Install Go from http://golang.org/dl/.");

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -19,6 +19,7 @@ import { check, ICheckResult } from './goCheck';
 import { setupGoPathAndOfferToInstallTools } from './goInstallTools'
 import { GO_MODE } from './goMode'
 import { showHideStatus } from './goStatus'
+import { testAtCursor } from './goTest'
 
 let diagnosticCollection: vscode.DiagnosticCollection;
 
@@ -44,7 +45,12 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		vscode.window.showInformationMessage("Current GOPATH:" + gopath);
 	}));
 
-    vscode.languages.setLanguageConfiguration(GO_MODE.language, {
+	ctx.subscriptions.push(vscode.commands.registerCommand("go.test.cursor", () => {
+		let goConfig = vscode.workspace.getConfiguration('go');
+		testAtCursor(goConfig['testTimeout']);
+	}));
+
+	vscode.languages.setLanguageConfiguration(GO_MODE.language, {
 		indentationRules: {
 			// ^(.*\*/)?\s*\}.*$
 			decreaseIndentPattern: /^(.*\*\/)?\s*\}.*$/,
@@ -79,7 +85,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 				{ open: '\'', close: '\'', notIn: ['string', 'comment'] }
 			]
 		}
-    });
+	});
 
 	if(vscode.window.activeTextEditor) {
 		let goConfig = vscode.workspace.getConfiguration('go');

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -6,15 +6,17 @@
 
 import fs = require('fs');
 import path = require('path');
+import os = require('os');
 
 var binPathCache: { [bin: string]: string; } = {}
+var runtimePathCache: string = null
 
 export function getBinPath(binname: string) {
 	binname = correctBinname(binname);
 	if (binPathCache[binname]) return binPathCache[binname];
 
 	// First search each GOPATH workspace's bin folder
-	if(process.env["GOPATH"]) {
+	if (process.env["GOPATH"]) {
 		var workspaces = process.env["GOPATH"].split(path.delimiter);
 		for (var i = 0; i < workspaces.length; i++) {
 			let binpath = path.join(workspaces[i], "bin", binname);
@@ -26,7 +28,7 @@ export function getBinPath(binname: string) {
 	}
 
 	// Then search PATH parts
-	if(process.env["PATH"]) {
+	if (process.env["PATH"]) {
 		var pathparts = process.env["PATH"].split(path.delimiter);
 		for (var i = 0; i < pathparts.length; i++) {
 			let binpath = path.join(pathparts[i], binname);
@@ -56,4 +58,20 @@ function correctBinname(binname: string) {
 		return binname + ".exe";
 	else
 		return binname
+}
+
+/**
+ * Returns Go runtime binary path.
+ * 
+ * @return the path to the Go binary. 
+ */
+export function getGoRuntimePath(): string {
+	if (runtimePathCache) return runtimePathCache;
+	if (process.env.GOROOT) {
+		runtimePathCache = path.join(process.env["GOROOT"], "bin", "go");
+	} else if (process.env.PATH) {
+		var pathparts = (<string>process.env.PATH).split((<any>path).delimiter);
+		runtimePathCache = pathparts.map(dir => path.join(dir, 'go' + (os.platform() == "win32" ? ".exe" : ""))).filter(candidate => fs.existsSync(candidate))[0];
+	}
+	return runtimePathCache;
 }

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -1,0 +1,82 @@
+'use strict';
+
+import cp = require('child_process');
+import path = require('path');
+import vscode = require('vscode');
+import util = require('util');
+import { getGoRuntimePath } from './goPath'
+
+/**
+* Executes the unit test at the primary cursor using `go test`. Output
+* is sent to the 'Go' channel.
+* 
+* @param timeout an optional ParseDuration formatted timeout string for the tests.
+*
+* TODO: go test returns filenames with no path information for failures,
+* so output doesn't produce navigable line references.
+*/
+export function testAtCursor(timeout: string) {
+	var editor = vscode.window.activeTextEditor;
+	if (!editor) {
+		vscode.window.showInformationMessage("No editor is active.");
+		return;
+	}
+	// TODO: This command should be returning a SymbolInformation[] but is instead
+	// returning an object with slightly different fields which must be adapted.
+	vscode.commands.executeCommand<any[]>('vscode.executeDocumentSymbolProvider', editor.document.uri).then(res => {
+		var testFunction: string;
+		// Find any test function containing the cursor.
+		for (let obj of res) {
+			var sym = newSymbolInformation(obj);
+			// Skip anything that's not a test function.
+			if (sym.kind != vscode.SymbolKind.Function) continue;
+			if (!/Test.*/.exec(sym.name)) continue;
+			// Determine if the function contains the primary cursor.
+			var selection = editor.selection;
+			if (selection && sym.location.range.contains(selection.start)) {
+				testFunction = sym.name;
+				break;
+			}
+		};
+		if (!testFunction) {
+			vscode.window.setStatusBarMessage('No test function found at cursor.', 5000);
+			return;
+		}
+		// Run the test and present the output in a channel.
+		var channel = vscode.window.createOutputChannel('Go');
+		channel.show();
+		var args = ['test', '-v', '-timeout', timeout, '-run', util.format('^%s$', testFunction)];
+		cp.execFile(getGoRuntimePath(), args, { env: process.env, cwd: path.dirname(editor.document.fileName) }, (err, stdout, stderr) => {
+			channel.append(stdout.toString());
+			channel.append(stderr.toString());
+			if (err) {
+				channel.append(util.format("Error executing test '%s': %s", testFunction, err));
+			}
+		});
+	}, err => {
+		console.error(err);
+	})
+}
+
+/**
+* Converts the output of the vscode.executeDocumentSymbolProvider command to
+* a vscode.SymbolInformation.
+* 
+* Warning: This implementation is far from complete.
+* 
+* TODO: This shouldn't be necessary; see https://github.com/Microsoft/vscode/issues/769
+* 
+* @param obj an object returned from executeDocumentSymbolProvider.
+* @return the converted SymbolInformation.
+*/
+function newSymbolInformation(obj: any): vscode.SymbolInformation {
+	var kind: vscode.SymbolKind
+	switch (obj.type) {
+		case 'function':
+			kind = vscode.SymbolKind.Function;
+	}
+	var startPosition = new vscode.Position(obj.range.startLineNumber, obj.range.startColumn);
+	var endPosition = new vscode.Position(obj.range.endLineNumber, obj.range.endColumn);
+	var range = new vscode.Range(startPosition, endPosition);
+	return new vscode.SymbolInformation(obj.label, kind, range, null, obj.containerName);
+}


### PR DESCRIPTION
Introduce a 'go.test.cursor' command which executes the unit test at
the primary cursor location. Output is placed in the 'Go' channel.

Refactor references to the Go runtime path.

Closes #88