### PR TITLE
Format on save

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,11 @@
 					"type": "string",
 					"default": null,
 					"description": "Specifies the GOPATH to use when no environment variable is set."
+				},
+				"go.formatOnSave": {
+					"type": "boolean",
+					"default": false,
+					"description": "[EXPERIMENTAL] Run formatting tool on save."
 				}
 			}
 		}

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -37,12 +37,8 @@ class Edit {
 	}
 }
 
-export class GoDocumentFormattingEditProvider implements vscode.DocumentFormattingEditProvider {
-
+export class Formatter {
 	private formatCommand = "goreturns";
-
-	// Not used?
-	public autoFormatTriggerCharacters: string[] = [';', '}', '\n'];
 
 	constructor() {
 		let formatTool = vscode.workspace.getConfiguration('go')['formatTool'];
@@ -51,13 +47,7 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 		}
 	}
 
-	public provideDocumentFormattingEdits(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken): Thenable<vscode.TextEdit[]> {
-		return document.save().then(() => {
-			return this.doFormatDocument(document, options, token);
-		});
-	}
-
-	private doFormatDocument(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken): Thenable<vscode.TextEdit[]> {
+	public formatDocument(document: vscode.TextDocument): Thenable<vscode.TextEdit[]> {
 		return new Promise((resolve, reject) => {
 			var filename = document.fileName;
 
@@ -136,4 +126,18 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 			});
 		});
 	}
+}
+
+export class GoDocumentFormattingEditProvider implements vscode.DocumentFormattingEditProvider {
+	private formatter: Formatter;
+	
+	constructor() {
+		this.formatter = new Formatter();	
+	}
+	
+	public provideDocumentFormattingEdits(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken): Thenable<vscode.TextEdit[]> {
+		return document.save().then(() => {
+			return this.formatter.formatDocument(document);
+		});
+	}	
 }


### PR DESCRIPTION
Adds a new "go.formatOnSave" which is off by default.  Turning this feature on will cause 'save' to format using the currently selected `go.formatTool` and then error check.

Note that using this feature along with `AutoSave` will result in some fairly aggressive reformatting of your code in the middle of typing.  It is suggested that you use one or the other but not both concurrently.

Fixes #14.