### PR TITLE
Use tabs instead of spaces by default in workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
 		"**/node_modules": true,
 		"**/bower_components": true,
 		"out/": true
-	}
+	},
+	"editor.insertSpaces": false
 }


### PR DESCRIPTION
Help enforce formatting conventions by disabling spaces-as-tabs.

If hard tabs aren't actually the convention, please let me know. :grin: 