### PR TITLE
Introduce more unit test commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,16 @@
 				"command": "go.test.cursor",
 				"title": "Go: Run test at cursor",
 				"description": "Runs a unit test at the cursor."
+			},
+			{
+				"command": "go.test.package",
+				"title": "Go: Run tests in current package",
+				"description": "Runs all unit tests in the package of the current file."
+			},
+			{
+				"command": "go.test.file",
+				"title": "Go: Run tests in file",
+				"description": "Runs all unit tests in the current file."
 			}
 		],
 		"debuggers": [

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -19,7 +19,7 @@ import { check, ICheckResult } from './goCheck';
 import { setupGoPathAndOfferToInstallTools } from './goInstallTools'
 import { GO_MODE } from './goMode'
 import { showHideStatus } from './goStatus'
-import { testAtCursor } from './goTest'
+import { testAtCursor, testCurrentPackage, testCurrentFile } from './goTest'
 
 let diagnosticCollection: vscode.DiagnosticCollection;
 
@@ -48,6 +48,16 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.commands.registerCommand("go.test.cursor", () => {
 		let goConfig = vscode.workspace.getConfiguration('go');
 		testAtCursor(goConfig['testTimeout']);
+	}));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand("go.test.package", () => {
+		let goConfig = vscode.workspace.getConfiguration('go');
+		testCurrentPackage(goConfig['testTimeout']);
+	}));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand("go.test.file", () => {
+		let goConfig = vscode.workspace.getConfiguration('go');
+		testCurrentFile(goConfig['testTimeout']);
 	}));
 
 	vscode.languages.setLanguageConfiguration(GO_MODE.language, {


### PR DESCRIPTION
Introduce 'go.test.package' and 'go.test.file' commands.

Closes #89.