### PR TITLE
[WIP] Add a go install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,11 @@
 				"command": "go.test.file",
 				"title": "Go: Run tests in file",
 				"description": "Runs all unit tests in the current file."
+			},
+			{
+				"command": "go.install",
+				"title": "Go: Install packages",
+				"description": "Installs all configured packages for the workspace."
 			}
 		],
 		"debuggers": [
@@ -213,6 +218,14 @@
 					"type": "string",
 					"default": "30s",
 					"description": "Specifies the timeout for go test in ParseDuration format."
+				},
+				"go.installPackages": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": ["./.."],
+					"description": "Specifies the packages to install when using the install command."
 				}
 			}
 		}

--- a/src/goInstall.ts
+++ b/src/goInstall.ts
@@ -1,0 +1,29 @@
+'use strict';
+
+import cp = require('child_process');
+import path = require('path');
+import vscode = require('vscode');
+import util = require('util');
+import { getGoRuntimePath } from './goPath'
+
+export function goInstall(packages: string[]) {
+	let editor = vscode.window.activeTextEditor;
+	if (!editor) {
+		vscode.window.showInformationMessage("No editor is active.");
+		return;
+	}
+	let channel = vscode.window.createOutputChannel('Go');
+	channel.clear();
+	channel.show(2);
+	let args = ['install', '-v', packages.join(' ')];
+	let proc = cp.spawn(getGoRuntimePath(), args, { env: process.env, cwd: vscode.workspace.rootPath });
+	proc.stdout.on('data', chunk => channel.append(chunk.toString()));
+	proc.stderr.on('data', chunk => channel.append(chunk.toString()));
+	proc.on('close', code => {
+		if (code) {
+			channel.append("Error: Install failed.");
+		} else {
+			channel.append("Success: Install completed.");
+		}
+	});
+}

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -20,6 +20,7 @@ import { setupGoPathAndOfferToInstallTools } from './goInstallTools'
 import { GO_MODE } from './goMode'
 import { showHideStatus } from './goStatus'
 import { testAtCursor, testCurrentPackage, testCurrentFile } from './goTest'
+import { goInstall } from './goInstall'
 
 let diagnosticCollection: vscode.DiagnosticCollection;
 
@@ -58,6 +59,11 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.commands.registerCommand("go.test.file", () => {
 		let goConfig = vscode.workspace.getConfiguration('go');
 		testCurrentFile(goConfig['testTimeout']);
+	}));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand("go.install", () => {
+		let goConfig = vscode.workspace.getConfiguration('go');
+		goInstall(goConfig['installPackages']);
 	}));
 
 	vscode.languages.setLanguageConfiguration(GO_MODE.language, {


### PR DESCRIPTION
### :construction: WIP :construction: 
Introduce a 'go.install' command which executes 'go install' for a
configurable list of packages.

Related to #21 and #69.

Outstanding design questions:

* Can file references in channel output be made clickable? I didn't see any way to achieve it in the API.
  * Note that the file references emitted by `go install` are relative to the workspace root
* Should this integrate with the diagnostics collection?
