### PR TITLE
Add support for coverage markup

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
 		"onCommand:go.gopath",
 		"onCommand:go.test.cursor",
 		"onCommand:go.test.package",
-		"onCommand:go.test.file"
+		"onCommand:go.test.file",
+		"onCommand:go.test.coverage"
 	],
 	"main": "./out/src/goMain",
 	"contributes": {
@@ -94,6 +95,11 @@
 				"command": "go.test.file",
 				"title": "Go: Run tests in file",
 				"description": "Runs all unit tests in the current file."
+			},
+			{
+				"command": "go.test.coverage",
+				"title": "Go: Test coverage in file",
+				"description": "Displays test coverage in the current file."
 			}
 		],
 		"debuggers": [
@@ -178,7 +184,7 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Run 'go build'/'go test' on save."
-				},
+				},				
 				"go.lintOnSave": {
 					"type": "boolean",
 					"default": true,
@@ -208,6 +214,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "[EXPERIMENTAL] Run formatting tool on save."
+				},
+				"go.coverOnSave": {
+					"type": "boolean",
+					"default": false,
+					"description": "Run 'go test -coverprofile' on save"	
 				},
 				"go.testTimeout": {
 					"type": "string",

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -108,5 +108,5 @@ export function check(filename: string, buildOnSave = true, lintOnSave = true, v
 	
 	var gocover = !coverOnSave ? Promise.resolve([]) : getCoverage(filename);
 
-	return Promise.all([gobuild, golint, govet,  getCoverage(filename)]).then(resultSets => [].concat.apply([], resultSets));
+	return Promise.all([gobuild, golint, govet, gocover]).then(resultSets => [].concat.apply([], resultSets));
 }

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -10,8 +10,7 @@ import path = require('path');
 import os = require('os');
 import fs = require('fs');
 import { getBinPath, getGoRuntimePath } from './goPath';
-import rl = require('readline');
-import { getCoverage, ICoverResult } from './goCover';
+import { getCoverage } from './goCover';
 
 if (!getGoRuntimePath()) {
 	vscode.window.showInformationMessage("No 'go' binary could be found on PATH or in GOROOT.");

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+'use strict';
+
+import vscode = require('vscode');
+import cp = require('child_process');
+import path = require('path');
+import os = require('os');
+import fs = require('fs');
+import { getBinPath, getGoRuntimePath } from './goPath';
+import rl = require('readline');
+
+if (!getGoRuntimePath()) {
+	vscode.window.showInformationMessage("No 'go' binary could be found on PATH or in GOROOT.");
+}
+
+export function coverageCurrentFile() {
+	var editor = vscode.window.activeTextEditor;
+	if (!editor) {
+		vscode.window.showInformationMessage("No editor is active.");
+		return;
+	}
+	getCoverage(editor.document.uri.fsPath);
+}
+
+export function getCoverage(filename: string): Promise<any[]> {
+	return  new Promise((resolve, reject) => {
+		var tmppath = path.normalize(path.join(os.tmpdir(), "go-code-cover"))
+		var cwd = path.dirname(filename)
+		var args = ["test", "-coverprofile=" + tmppath];		
+		cp.execFile(getGoRuntimePath(), args, { cwd: cwd }, (err, stdout, stderr) => {
+			try {
+				if (err && (<any>err).code == "ENOENT") {
+					vscode.window.showInformationMessage("Could not generate coverage report.  Install Go from http://golang.org/dl/.");
+					return resolve([]);
+				}
+				var ret = [];
+				
+				var lines = rl.createInterface({
+					input: fs.createReadStream(tmppath),
+					output: undefined
+				});
+				
+				var coveredRange = [], 
+					uncoveredRange =[],
+					uncoveredHighLight = vscode.window.createTextEditorDecorationType({
+					// Red
+					backgroundColor: 'rgba(128,64,64,0.5)',
+					isWholeLine: false
+				}), coveredHighLight = vscode.window.createTextEditorDecorationType({
+					// Green
+					backgroundColor: 'rgba(64,128,64,0.5)',
+					isWholeLine: false
+				});
+
+				lines.on('line', function(data: string) {
+					// go test coverageprofile generates output: 
+					//    filename:StartLine.StartColumn,EndLine.EndColumn Hits IsCovered
+					var fileRange = data.match(/([^:]+)\:([\d]+)\.([\d]+)\,([\d]+)\.([\d]+)\s([\d]+)\s([\d]+)/);
+					if (fileRange) {
+						// If line matches active file
+						if (filename.endsWith(fileRange[1])) {
+							var range = { 
+								range: new vscode.Range(
+									// Start Line converted to zero based
+									parseInt(fileRange[2]) - 1,
+									// Start Column converted to zero based
+									parseInt(fileRange[3]) - 1, 
+									// End Line converted to zero based
+									parseInt(fileRange[4]) - 1,
+									// End Column converted to zero based
+									parseInt(fileRange[5]) - 1
+								) 
+							};
+							// If is Covered
+							if (parseInt(fileRange[7]) === 1) {
+								coveredRange.push(range);	
+							} 
+							// Not Covered
+							else {
+								uncoveredRange.push(range);	
+							}
+						}							
+					}					
+				});
+				lines.on('close', function(data) {
+					// Highlight lines in current editor.
+					vscode.window.activeTextEditor.setDecorations(uncoveredHighLight, uncoveredRange);
+					vscode.window.activeTextEditor.setDecorations(coveredHighLight, coveredRange);
+					resolve(ret);
+				});
+			} catch (e) {
+				vscode.window.showInformationMessage(e.msg);
+				reject(e);
+			}
+		});
+	});
+}

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -19,6 +19,7 @@ import { check, ICheckResult } from './goCheck';
 import { setupGoPathAndOfferToInstallTools } from './goInstallTools'
 import { GO_MODE } from './goMode'
 import { showHideStatus } from './goStatus'
+import { coverageCurrentFile } from './goCover';
 import { testAtCursor, testCurrentPackage, testCurrentFile } from './goTest'
 
 let diagnosticCollection: vscode.DiagnosticCollection;
@@ -58,6 +59,10 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.commands.registerCommand("go.test.file", () => {
 		let goConfig = vscode.workspace.getConfiguration('go');
 		testCurrentFile(goConfig['testTimeout']);
+	}));
+	
+	ctx.subscriptions.push(vscode.commands.registerCommand("go.test.coverage", () => {
+		coverageCurrentFile();
 	}));
 
 	vscode.languages.setLanguageConfiguration(GO_MODE.language, {
@@ -119,9 +124,9 @@ function runBuilds(document: vscode.TextDocument, goConfig: vscode.WorkspaceConf
 	if (document.languageId != "go") {
 		return;
 	}
-
+	
 	var uri = document.uri;
-	check(uri.fsPath, goConfig['buildOnSave'], goConfig['lintOnSave'], goConfig['vetOnSave']).then(errors => {
+	check(uri.fsPath, goConfig['buildOnSave'], goConfig['lintOnSave'], goConfig['vetOnSave'], goConfig['coverOnSave']).then(errors => {
 		diagnosticCollection.clear();
 
 		let diagnosticMap: Map<vscode.Uri, vscode.Diagnostic[]> = new Map();;


### PR DESCRIPTION
First attempt at addressing #80, need to add timeout for go test.

Broke out goCover.ts from goCheck just for maintainability... file seems to be getting large.