### PR TITLE
Allow user refresh currently GOPATH.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "onCommand:go.gopath",
     "onCommand:go.test.cursor",
     "onCommand:go.test.package",
-    "onCommand:go.test.file"
+    "onCommand:go.test.file",
+	"onCommand:go.gopath.refresh"
   ],
   "main": "./out/src/goMain",
   "contributes": {
@@ -101,7 +102,12 @@
         "command": "go.import.add",
         "title": "Go: Add Import",
         "description": "Add an import declaration"
-      }
+      },
+	  {
+		"command": "go.gopath.refresh",
+        "title": "Go: Refresh GOPATH",
+        "description": "Load currently GOPATH"
+	  }
     ],
     "debuggers": [
       {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "onCommand:go.test.cursor",
     "onCommand:go.test.package",
     "onCommand:go.test.file",
-	"onCommand:go.gopath.refresh"
+	"onCommand:go.gopath.refresh",
+	"onCommand:go.build"
   ],
   "main": "./out/src/goMain",
   "contributes": {
@@ -107,6 +108,11 @@
 		"command": "go.gopath.refresh",
         "title": "Go: Refresh GOPATH",
         "description": "Load currently GOPATH"
+	  },
+	  {
+		"command": "go.build",
+        "title": "Go: Build",
+        "description": "Build currently project"
 	  }
     ],
     "debuggers": [
@@ -250,7 +256,17 @@
           "type": "string",
           "default": "30s",
           "description": "Specifies the timeout for go test in ParseDuration format."
-        }
+        },
+		"go.outfile":{
+		  "type": "string",
+          "default": "a.out",
+          "description": "Specifies the name of the execute file"
+		},
+		"go.mainfolder":{
+		  "type": "string",
+          "default": ".",
+          "description": "Specifies the folder path of the main function"
+		}
       }
     }
   }

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -20,7 +20,14 @@ export function setupGoPathAndOfferToInstallTools() {
 
 	var gopath = vscode.workspace.getConfiguration('go')['gopath'];
 	if (gopath) {
-		process.env["GOPATH"] = gopath;
+		var gopathbak = process.env["GOPATHBAK"];
+		if(gopathbak){
+			
+		}else{
+			process.env["GOPATHBAK"] = process.env["GOPATH"];
+			gopathbak = process.env["GOPATHBAK"];
+		}
+		process.env["GOPATH"] = (gopathbak.charAt(gopathbak.length - 1) == ':' ? gopathbak:gopathbak + ":")+gopath;
 	}
 
 	if (!process.env["GOPATH"]) {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -22,6 +22,7 @@ import { GO_MODE } from './goMode'
 import { showHideStatus } from './goStatus'
 import { testAtCursor, testCurrentPackage, testCurrentFile } from './goTest'
 import { addImport } from './goImport'
+import {buildProject} from './util'
 
 let diagnosticCollection: vscode.DiagnosticCollection;
 
@@ -43,12 +44,22 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	setupGoPathAndOfferToInstallTools();
 	startBuildOnSaveWatcher(ctx.subscriptions);
 		
+
+		
 	ctx.subscriptions.push(vscode.commands.registerCommand("go.gopath.refresh",()=>{
 		setupGoPathAndOfferToInstallTools();
 		var gopath = process.env["GOPATH"];
 		vscode.window.showInformationMessage("Current GOPATH:" + gopath);
 	}));
 
+	ctx.subscriptions.push(vscode.commands.registerCommand("go.build",()=>{
+		var outfile = vscode.workspace.getConfiguration('go')['outfile'];
+		var mainfolder = vscode.workspace.getConfiguration('go')['mainfolder'];
+		var rootPath = vscode.workspace.rootPath;
+		var result = buildProject(outfile,rootPath+"/"+mainfolder);
+		// vscode.window.showInformationMessage("Begin Build ...");
+	}));	
+	
 	ctx.subscriptions.push(vscode.commands.registerCommand("go.gopath", () => {
 		var gopath = process.env["GOPATH"];
 		vscode.window.showInformationMessage("Current GOPATH:" + gopath);

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -42,6 +42,12 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	vscode.window.onDidChangeActiveTextEditor(showHideStatus, null, ctx.subscriptions);
 	setupGoPathAndOfferToInstallTools();
 	startBuildOnSaveWatcher(ctx.subscriptions);
+		
+	ctx.subscriptions.push(vscode.commands.registerCommand("go.gopath.refresh",()=>{
+		setupGoPathAndOfferToInstallTools();
+		var gopath = process.env["GOPATH"];
+		vscode.window.showInformationMessage("Current GOPATH:" + gopath);
+	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand("go.gopath", () => {
 		var gopath = process.env["GOPATH"];

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,10 @@
 
 import { TextDocument, Position } from 'vscode';
+import { getBinPath } from './goPath'
+import { basename, dirname } from 'path';
+import { spawn, ChildProcess } from 'child_process';
+import vscode = require('vscode');
+import fs = require('fs');
 
 export function byteOffsetAt(document: TextDocument, position: Position): number {
 	let offset = document.offsetAt(position);
@@ -41,4 +46,49 @@ export function parseFilePrelude(text: string): Prelude {
 		}
 	}
 	return ret;
+}
+
+export function buildProject(outFile: string, mainFile:string) {
+	
+	var goBuild = getBinPath("go");
+	var buildArgs = ["build"];
+	buildArgs = buildArgs.concat(["-o"]);
+	buildArgs = buildArgs.concat([outFile]);
+	buildArgs = buildArgs.concat(["-a"]);
+
+	if(!fs.existsSync(mainFile)){
+		printResultError("-1");
+		return;
+	}
+	
+
+	var buildEnv = process.env["GOPATH"];
+	
+	
+	this.buildProcess = spawn(goBuild, buildArgs, {
+				cwd: mainFile,
+				env: buildEnv,
+			});
+			
+	this.buildProcess.stderr.on('data',printResultError);
+	
+	this.buildProcess.stdout.on('data',printResultInfo);
+	
+	this.buildProcess.on('exit', printResultInfo);
+	
+	this.buildProcess.on('error', printResultError);
+
+}
+
+function printResultInfo(data:string){
+	console.log("Process exiting with : " + data);
+	data = (data == "0"?"Success!":data);
+	vscode.window.showInformationMessage("Build Output :["+data+"]");
+}
+
+function printResultError(data:string){
+	console.error("Process exiting with : " + data);
+	vscode.window.showErrorMessage("Build Failed. ["+data+"]");
+	vscode.window.showErrorMessage("Please check go.mainfolder in settings.json ");
+	
 }


### PR DESCRIPTION
If user needs modify currently GOPATH, user could use this command (go:
refresh gopath) to refresh it rather than restart vscode.

Signed-off-by: Andy Zhang andy.zhangtao@hotmail.com