### PR TITLE
incorporating gopkgs for quick lookup of available packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This extension adds rich language support for the Go language to VS Code, includ
 - Rename (using `gorename`)
 - Build-on-save (using `go build` and `go test`)
 - Format (using `goreturns` or `goimports` or `gofmt`)
-- Add Imports (using `go list`)
+- Add Imports (using `gopkgs`)
 - [_partially implemented_] Debugging (using `delve`)
 
 ### IDE Features
@@ -127,6 +127,7 @@ The extension uses the following tools, installed in the current GOPATH.  If any
 - go-outline: `go get -u -v github.com/lukehoban/go-outline`
 - goreturns: `go get -u -v sourcegraph.com/sqs/goreturns`
 - gorename: `go get -u -v golang.org/x/tools/cmd/gorename`
+- gopkgs: `go get -u -v github.com/tpng/gopkgs`
 
 To install them just paste and run:
 ```bash
@@ -137,6 +138,7 @@ go get -u -v github.com/lukehoban/go-find-references
 go get -u -v github.com/lukehoban/go-outline
 go get -u -v sourcegraph.com/sqs/goreturns
 go get -u -v golang.org/x/tools/cmd/gorename
+go get -u -v github.com/tpng/gopkgs
 ```
 
 And for debugging:

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -6,14 +6,14 @@
 
 import vscode = require('vscode');
 import cp = require('child_process');
-import { getGoRuntimePath } from './goPath'
+import { getBinPath } from './goPath'
 import { parseFilePrelude } from './util'
 
 export function listPackages(): Thenable<string[]> {
 	return new Promise<string[]>((resolve, reject) => {
-		cp.execFile(getGoRuntimePath(), ["list", "all"], (err, stdout, stderr) => {
+		cp.execFile(getBinPath("gopkgs"), [], (err, stdout, stderr) => {
 			if (err && (<any>err).code == "ENOENT") {
-				vscode.window.showInformationMessage("The 'go' compiler is not available.  Install Go from http://golang.org/dl/.");
+				vscode.window.showInformationMessage("The 'gopkgs' command is not available.  Use 'go get github.com/tpng/gopkgs' to install.");
 				return reject();
 			}
 			var lines = stdout.toString().split('\n');

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -36,6 +36,7 @@ export function setupGoPathAndOfferToInstallTools() {
 	// Offer to install any missing tools
 	var tools: { [key: string]: string } = {
 		gorename: "golang.org/x/tools/cmd/gorename",
+		gopkgs: "github.com/tpng/gopkgs",
 		gocode: "github.com/nsf/gocode",
 		goreturns: "sourcegraph.com/sqs/goreturns",
 		godef: "github.com/rogpeppe/godef",


### PR DESCRIPTION
This solves the slow "Add import" as discussed at #159 by incorporating gopkgs suggested and provided by tpng.