### PR TITLE
func param completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The following Visual Studio Code settings are available for the Go extension.  T
 	"go.buildFlags": [],
 	"go.lintFlags": [],
 	"go.vetFlags": [],
+	"go.useCodeSnippetsOnFunctionSuggest": false,
 	"go.formatOnSave": false,
 	"go.formatTool": "goreturns",
 	"go.goroot": "/usr/local/go",

--- a/package.json
+++ b/package.json
@@ -225,6 +225,11 @@
           "default": "goreturns",
           "description": "Pick 'gofmt', 'goimports' or 'goreturns' to run on format."
         },
+		"go.useCodeSnippetsOnFunctionSuggest": {
+			"type": "string",
+			"default": false,
+			"description": "Complete functions with their parameter signature"
+		},
         "go.gopath": {
           "type": "string",
           "default": null,

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -89,6 +89,20 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 							var item = new vscode.CompletionItem(suggest.name);
 							item.kind = vscodeKindFromGoCodeClass(suggest.class);
 							item.detail = suggest.type;
+							let conf = vscode.workspace.getConfiguration('go');
+							if(conf.get("useCodeSnippetsOnFunctionSuggest") && suggest.class == "func") {
+								let bOpen = suggest.type.indexOf('('),
+									bClose = suggest.type.indexOf(')'); 
+								let params = suggest.type.substring(bOpen+1, bClose).split(/,\s*/);
+								let paramSnippets = [];
+								for(let i in params) {
+									let param = params[i].trim();
+									if(param) {
+										paramSnippets.push("{{" + param + "}}");
+									}
+								}
+								item.insertText = suggest.name + '(' + paramSnippets.join(", ") + '){{}}';
+							}
 							return item;
 						})
 						resolve(suggestions);


### PR DESCRIPTION
Func parameter completion or hinting is a bit old but significant issue mentioned at #9, #128 and #135.

This change solves this issue by inserting a complete snippet of the function or method selected from the suggestions.

An example:
![Example func snippet](http://i.imgur.com/r95WDdd.png)

At last argument, tab would set the cursor after the closing bracket.

This takes the same approach as Atom's go-plus and GoSublime.

Personally, I like this approach better than a pop-up that hides my code as I'm filling parameters.