### PR TITLE
Make HoverProvider tolerate missing locations

### DIFF
--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -83,6 +83,7 @@ export class GoDefinitionProvider implements vscode.DefinitionProvider {
 
 	public provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Location> {
 		return definitionLocation(document, position).then(definitionInfo => {
+			if (definitionInfo == null) return null;
 			let definitionResource = vscode.Uri.file(definitionInfo.file);
 			let pos = new vscode.Position(definitionInfo.line, definitionInfo.col);
 			return new vscode.Location(definitionResource, pos);

--- a/src/goExtraInfo.ts
+++ b/src/goExtraInfo.ts
@@ -11,6 +11,7 @@ import { definitionLocation } from './goDeclaration';
 export class GoHoverProvider implements HoverProvider {
 	public provideHover(document: TextDocument, position: Position, token: CancellationToken): Thenable<Hover> {
 		return definitionLocation(document, position).then(definitionInfo => {
+			if (definitionInfo == null) return;
 			let lines = definitionInfo.lines;
 			lines = lines.map(line => {
 				if (line.indexOf('\t') === 0) {


### PR DESCRIPTION
GoHoverProvider was throwing a TypeError trying to read a property
from null definition locations. It may be more appropriate to try
and prevent the hover provider from entering its handler function if
definitionLocation finds no match, but rejecting the Promise didn't
see to do the trick. This patch makes the HoverProvider call a no-op
when no definition is found.

Fixes https://github.com/Microsoft/vscode-go/issues/255