### PR TITLE
Migrate mis-use of setExceptionBreakPointsRequest to configurationDon…

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "fs-extra": "^0.26.0",
     "tslint": "^3.3.0",
-    "typescript": "^1.6.2",
+    "typescript": "1.8.7",
     "vscode": "^0.10.7"
   },
   "engines": {

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -272,6 +272,8 @@ class GoDebugSession extends DebugSession {
 
 	protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
 		log('InitializeRequest');
+		// This debug adapter implements the configurationDoneRequest.
+		response.body.supportsConfigurationDoneRequest = true;
 		this.sendResponse(response);
 		log('InitializeResponse');
 		this.sendEvent(new InitializedEvent());
@@ -311,15 +313,11 @@ class GoDebugSession extends DebugSession {
 		log('DisconnectResponse');
 	}
 
-	protected setExceptionBreakPointsRequest(response: DebugProtocol.SetExceptionBreakpointsResponse, args: DebugProtocol.SetExceptionBreakpointsArguments): void {
-		log('ExceptionBreakPointsRequest');
-		// Wow - this is subtle - it appears that this event will always get 
-		// sent during intiail breakpoint initialization even if there are not
-		// user breakpoints - so we use this as the indicator to signal 
-		// that breakpoints have been set and we can continue
+	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
+		log('ConfigurationDoneRequest');
 		this.signalInitialBreakpointsSet();
 		this.sendResponse(response);
-		log('ExceptionBreakPointsResponse');
+		log('ConfigurationDoneRequest');
 	}
 
 	protected setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments): void {


### PR DESCRIPTION
Since VS Code 0.10.11 (February) VS Code no longer calls `setExceptionBreakPointsRequest` if no breakpoints filters are returned from the `initializeRequest`. Since you are using `setExceptionBreakPointsRequest` to set the initial breakpoints, 'go-debug' no longer works with the latest version (alpha) of VS Code (and it will not work the GA version of VS Code).
Since January we are warning about this and suggested to migrate this special use of `setExceptionBreakPointsRequest` to the `configurationDoneRequest` and return a corresponding flag from the `initializeRequest`. This PR fixes this issue.
As a nice side effect, you will no longer see the 'All Exception' and 'Uncaught Exceptions' checkboxes that were no-ops for go-debug anyway.
