### PR TITLE
Expands ${workspaceRoot} in go.gopath configuration

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -21,7 +21,7 @@ export function setupGoPathAndOfferToInstallTools() {
 
 	let gopath = vscode.workspace.getConfiguration('go')['gopath'];
 	if (gopath) {
-		process.env['GOPATH'] = gopath;
+		process.env['GOPATH'] = gopath.replace(/\${workspaceRoot}/g, vscode.workspace.rootPath);
 	}
 
 	if (!process.env['GOPATH']) {


### PR DESCRIPTION
fixes #237

When I launch `code` from my shell, it does not respect GOPATH environment variable of **current shell**, which sets GOPATH to:

```sh
export GOPATH="${PWD}/deps:${PWD}"
```

So, I set `go.gopath` in `.vscode/settings.json`:

```json
{
  "go.gopath": "deps:."
}
```

Then, Go To Definition tries to open `/deps/src/{somefile}` and fails.

With this pull request, I can set `go.gopath` as:

```json
{
    "go.gopath": "${workspaceRoot}/deps:${workspaceRoot}"
}
```

And,  Go To Definition functions as expected.


