### PR TITLE
Introduce gocode autobuild setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,6 +282,11 @@
           "type": "string",
           "default": "30s",
           "description": "Specifies the timeout for go test in ParseDuration format."
+        },
+        "go.gocodeAutoBuild": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable gocode's autobuild feature"
         }
       }
     }

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -125,14 +125,18 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 		});
 	}
 
+	// TODO: Shouldn't lib-path also be set?
 	private ensureGoCodeConfigured(): Thenable<void> {
 		return new Promise<void>((resolve, reject) => {
+			// TODO: Since the gocode daemon is shared amongst clients, shouldn't settings be
+			// adjusted per-invocation to avoid conflicts from other gocode-using programs?
 			if (this.gocodeConfigurationComplete) {
 				return resolve();
 			}
 			let gocode = getBinPath('gocode');
+			let autobuild = vscode.workspace.getConfiguration('go')['gocodeAutoBuild'];
 			cp.execFile(gocode, ['set', 'propose-builtins', 'true'], {}, (err, stdout, stderr) => {
-				cp.execFile(gocode, ['set', 'autobuild', 'true'], {}, (err, stdout, stderr) => {
+				cp.execFile(gocode, ['set', 'autobuild', autobuild], {}, (err, stdout, stderr) => {
 					resolve();
 				});
 			});


### PR DESCRIPTION
Introduce a setting to allow disabling gocode's experimental autobuild
support. Enabling it can cause performance issues in large codebases,
and users should have the capability to assume full control over when
go build and install is invoked.