### PR TITLE
Replace oracle with guru

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This extension adds rich language support for the Go language to VS Code, includ
 - Snippets
 - Quick Info (using `godef`)
 - Goto Definition (using `godef`)
-- Find References (using `oracle`)
+- Find References (using `guru`)
 - File outline (using `go-outline`)
 - Workspace symbol search (using `go-symbols`)
 - Rename (using `gorename`)
@@ -135,7 +135,7 @@ The extension uses the following tools, installed in the current GOPATH.  If any
 - gorename: `go get -u -v golang.org/x/tools/cmd/gorename`
 - gopkgs: `go get -u -v github.com/tpng/gopkgs`
 - go-symbols: `go get -u -v github.com/newhook/go-symbols`
-- oracle: `go get -u -v golang.org/x/tools/cmd/oracle`
+- guru: `go get -u -v golang.org/x/tools/cmd/guru`
 
 To install them just paste and run:
 ```bash
@@ -147,7 +147,7 @@ go get -u -v sourcegraph.com/sqs/goreturns
 go get -u -v golang.org/x/tools/cmd/gorename
 go get -u -v github.com/tpng/gopkgs
 go get -u -v github.com/newhook/go-symbols
-go get -u -v golang.org/x/tools/cmd/oracle
+go get -u -v golang.org/x/tools/cmd/guru
 ```
 
 And for debugging:

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -24,7 +24,7 @@ let tools: { [key: string]: string } = {
 	golint: 'github.com/golang/lint/golint',
 	'go-outline': 'github.com/lukehoban/go-outline',
 	'go-symbols': 'github.com/newhook/go-symbols',
-	oracle: 'golang.org/x/tools/cmd/oracle'
+	guru: 'golang.org/x/tools/cmd/guru'
 };
 
 export function installTool(tool: string) {

--- a/src/goReferences.ts
+++ b/src/goReferences.ts
@@ -33,13 +33,13 @@ export class GoReferenceProvider implements vscode.ReferenceProvider {
 
 			let offset = byteOffsetAt(document, position);
 
-			let goOracle = getBinPath('oracle');
+			let goGuru = getBinPath('guru');
 
-			let process = cp.execFile(goOracle, [`-pos=${filename}:#${offset.toString()}`, 'referrers'], {}, (err, stdout, stderr) => {
+			let process = cp.execFile(goGuru, ['referrers', `${filename}:#${offset.toString()}`], {}, (err, stdout, stderr) => {
 				try {
 					if (err && (<any>err).code === 'ENOENT') {
-						vscode.window.showInformationMessage('The "oracle" command is not available.  Use "go get -v golang.org/x/tools/cmd/oracle" to install.', 'Install').then(selected => {
-							installTool('oracle');
+						vscode.window.showInformationMessage('The "guru" command is not available.  Use "go get -v golang.org/x/tools/cmd/guru" to install.', 'Install').then(selected => {
+							installTool('guru');
 						});
 						return resolve(null);
 					}


### PR DESCRIPTION
The oracle tool has been forked and replaced with the guru tool.
Switch vscode-go to use guru instead of oracle to take advantage
of the revived progress on the tool.

Fixes #284 