### PR TITLE
Replace godef with guru

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install:
   - npm install
   - npm run vscode:prepublish
   - go get -u -v github.com/nsf/gocode
-  - go get -u -v github.com/rogpeppe/godef
   - go get -u -v github.com/golang/lint/golint
   - go get -u -v github.com/lukehoban/go-outline
   - go get -u -v sourcegraph.com/sqs/goreturns

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This extension adds rich language support for the Go language to VS Code, includ
 - Completion Lists (using `gocode`)
 - Signature Help (using `godoc`)
 - Snippets
-- Quick Info (using `godef`)
-- Goto Definition (using `godef`)
+- Quick Info (using `guru`)
+- Goto Definition (using `guru`)
 - Find References (using `guru`)
 - File outline (using `go-outline`)
 - Workspace symbol search (using `go-symbols`)
@@ -163,7 +163,6 @@ To debug the debugger, see [the debugAdapter readme](src/debugAdapter/Readme.md)
 The extension uses the following tools, installed in the current GOPATH.  If any tools are missing, you will see an "Analysis Tools Missing" warning in the bottom right corner of the editor.  Clicking it will offer to install the missing tools for you. 
 
 - gocode: `go get -u -v github.com/nsf/gocode`
-- godef: `go get -u -v github.com/rogpeppe/godef`
 - golint: `go get -u -v github.com/golang/lint/golint`
 - go-outline: `go get -u -v github.com/lukehoban/go-outline`
 - goreturns: `go get -u -v sourcegraph.com/sqs/goreturns`
@@ -175,7 +174,6 @@ The extension uses the following tools, installed in the current GOPATH.  If any
 To install them just paste and run:
 ```bash
 go get -u -v github.com/nsf/gocode
-go get -u -v github.com/rogpeppe/godef
 go get -u -v github.com/golang/lint/golint
 go get -u -v github.com/lukehoban/go-outline
 go get -u -v sourcegraph.com/sqs/goreturns

--- a/src/goExtraInfo.ts
+++ b/src/goExtraInfo.ts
@@ -12,7 +12,7 @@ export class GoHoverProvider implements HoverProvider {
 	public provideHover(document: TextDocument, position: Position, token: CancellationToken): Thenable<Hover> {
 		return definitionLocation(document, position, false).then(definitionInfo => {
 			if (definitionInfo == null) return null;
-			let lines = definitionInfo.lines;
+			let lines = [definitionInfo.desc];
 			lines = lines.map(line => {
 				if (line.indexOf('\t') === 0) {
 					line = line.slice(1);

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -20,7 +20,6 @@ let tools: { [key: string]: string } = {
 	gopkgs: 'github.com/tpng/gopkgs',
 	gocode: 'github.com/nsf/gocode',
 	goreturns: 'sourcegraph.com/sqs/goreturns',
-	godef: 'github.com/rogpeppe/godef',
 	golint: 'github.com/golang/lint/golint',
 	'go-outline': 'github.com/lukehoban/go-outline',
 	'go-symbols': 'github.com/newhook/go-symbols',

--- a/src/goSignature.ts
+++ b/src/goSignature.ts
@@ -30,7 +30,7 @@ export class GoSignatureHelpProvider implements SignatureHelpProvider {
 				return null;
 			}
 			let result = new SignatureHelp();
-			let text = res.lines[1];
+			let text = res.desc;
 			let nameEnd = text.indexOf(' ');
 			let sigStart = nameEnd + 5; // ' func'
 			let funcName = text.substring(0, nameEnd);


### PR DESCRIPTION
Replace the `godef` command with `guru`. The `guru` tool offers
improved definition lookups which are compatible with Go 1.5+
vendoring. Performance seems to be comparable.

This eliminates `godef` as a vscode-go dependency.