### PR TITLE
Allow Go tools to be installed in a separate GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ The extension uses the following tools, installed in the current GOPATH.  If any
 - guru: `go get -u -v golang.org/x/tools/cmd/guru`
 - gotests: `go get -u -v github.com/cweill/gotests/...`
 
-To install them just paste and run:
+If you wish to have the extension use a separate GOPATH for its tools, set the VSCODE_GOTOOLS environment variable to the desired path.
+
+To install the tools manually in the current GOPATH, just paste and run:
 ```bash
 go get -u -v github.com/nsf/gocode
 go get -u -v github.com/rogpeppe/godef

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -126,6 +126,14 @@ function installTools(goVersion: SemVersion, missing?: string[]) {
 			HTTPS_PROXY: httpProxy,
 		});
 	}
+
+	// If the VSCODE_GOTOOLS environment variable is set, use 
+ 	// its value as the GOPATH for the "go get" child precess.
+	let toolsGoPath = process.env['VSCODE_GOTOOLS'];
+	if (toolsGoPath) {
+		env['GOPATH'] = toolsGoPath;
+	}
+
 	missing.reduce((res: Promise<string[]>, tool: string) => {
 		return res.then(sofar => new Promise<string[]>((resolve, reject) => {
 			cp.execFile(goRuntimePath, ['get', '-u', '-v', tools[tool]], { env }, (err, stdout, stderr) => {

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -33,7 +33,13 @@ export function getBinPathFromEnvVar(toolName: string, envVar: string, appendBin
 export function getBinPath(binname: string) {
 	if (binPathCache[correctBinname(binname)]) return binPathCache[correctBinname(binname)];
 
-	// First search each GOPATH workspace's bin folder
+	// First search VSCODE_GOTOOLS' bin folder
+	let pathFromToolsGoPath = getBinPathFromEnvVar(binname, 'VSCODE_GOTOOLS', true);
+	if (pathFromToolsGoPath) {
+		return pathFromToolsGoPath;
+	}
+
+	// Then search each GOPATH workspace's bin folder
 	let pathFromGoPath = getBinPathFromEnvVar(binname, 'GOPATH', true);
 	if (pathFromGoPath) {
 		return pathFromGoPath;


### PR DESCRIPTION
This is a prototype for issue #5.

The approach used in this prototype allows users to install the Go tools in a separate GOPATH by setting a VSCODE_GOTOOLS env variable to the directory of where they want to install the tools. 
1. What do you think of the overall approach?
2. Is VSCODE_GOTOOLS a good name for the env variable?
