### PR TITLE
Disable the delve --log option by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,11 @@
                 },
                 "default": []
               },
+              "showLog": {
+                "type": "boolean",
+                "description": "Show log output from the delve debugger.",
+                "default": false
+              },
               "cwd": {
                 "type": "string",
                 "description": "Workspace relative or absolute path to the working directory of the program being debugged. Default is the current workspace.",

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -339,7 +339,7 @@ class GoDebugSession extends DebugSession {
 				log('StoppedEvent("breakpoint")');
 				this.sendResponse(response);
 			} else {
-				this.continueRequest(response);
+				this.continueRequest(<DebugProtocol.ContinueResponse>response);
 			}
 		}, err => {
 			this.sendErrorResponse(response, 3000, 'Failed to continue: "{e}"', { e: err.toString() });


### PR DESCRIPTION
This is a small patch that makes it possible to toggle delve's debugging output.

I've found it to introduce a lot of pointless noise, distracting from *meaningful* stderr output.