### PR TITLE
Make sure tmp file for go code cover exists

### DIFF
--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -92,7 +92,7 @@ export function getCoverage(filename: string): Promise<any[]> {
 		let args = ['test', '-coverprofile=' + tmppath];
 
 		// make sure tmppath exists
-		fs.closeSync(fs.openSync(tmppath, "a"))
+		fs.closeSync(fs.openSync(tmppath, 'a'));
 
 		cp.execFile(getGoRuntimePath(), args, { cwd: cwd }, (err, stdout, stderr) => {
 			try {

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -90,6 +90,10 @@ export function getCoverage(filename: string): Promise<any[]> {
 		let tmppath = path.normalize(path.join(os.tmpdir(), 'go-code-cover'));
 		let cwd = path.dirname(filename);
 		let args = ['test', '-coverprofile=' + tmppath];
+
+		// make sure tmppath exists
+		fs.closeSync(fs.openSync(tmppath, "a"))
+
 		cp.execFile(getGoRuntimePath(), args, { cwd: cwd }, (err, stdout, stderr) => {
 			try {
 				// Clear existing coverage files


### PR DESCRIPTION
This fixes an issue on OSX where the temporary file used by the go code cover integration doesn't exist. This in turn breaks other tasks run on save.