### PR TITLE
append cwd to gopath when debug program

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
             "remotePath": "",
             "port": 2345,
             "host": "127.0.0.1",
-            "program": "${workspaceRoot}",
+            "cwd": "${workspaceRoot}",
+            "program": "${workspaceName}",
             "env": {},
             "args": []
           }

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -207,10 +207,6 @@ class Delve {
 					dlvCwd = program;
 				}
 			} catch (e) { }
-			log('cwd:', cwd);
-			log('program:', program);
-			log('dlvArgs:', dlvArgs);
-			log('dlvCwd:', dlvCwd);
 			
 			this.debugProcess = spawn(dlv, dlvArgs, {
 				cwd: cwd,

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -9,7 +9,7 @@ import { readFileSync, existsSync, lstatSync } from 'fs';
 import { basename, dirname } from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { Client, RPCConnection } from 'json-rpc2';
-import { getBinPath } from '../goPath';
+import { getBinPath, appendGoPath } from '../goPath';
 
 require('console-stamp')(console);
 
@@ -172,6 +172,10 @@ class Delve {
 			if (!existsSync(dlv)) {
 				return reject('Cannot find Delve debugger. Ensure it is in your `GOPATH/bin` or `PATH`.');
 			}
+			
+			// append cwd to gopath
+			appendGoPath(cwd);
+									
 			let dlvEnv: Object = null;
 			if (env) {
 				dlvEnv = {};
@@ -183,7 +187,7 @@ class Delve {
 				}
 			}
 			let dlvArgs = [mode || 'debug'];
-			if (mode === 'exec') {
+			if (mode === 'exec' || mode === 'debug') {
 				dlvArgs = dlvArgs.concat([program]);
 			}
 			dlvArgs = dlvArgs.concat(['--headless=true', '--listen=' + host + ':' + port.toString(), '--log']);
@@ -196,15 +200,20 @@ class Delve {
 			if (args) {
 				dlvArgs = dlvArgs.concat(['--', ...args]);
 			}
-
-			let dlvCwd = dirname(program);
+						
+			let dlvCwd = dirname(program);			
 			try {
 				if (lstatSync(program).isDirectory()) {
 					dlvCwd = program;
 				}
 			} catch (e) { }
+			log('cwd:', cwd);
+			log('program:', program);
+			log('dlvArgs:', dlvArgs);
+			log('dlvCwd:', dlvCwd);
+			
 			this.debugProcess = spawn(dlv, dlvArgs, {
-				cwd: dlvCwd,
+				cwd: cwd,
 				env: dlvEnv,
 			});
 

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -77,6 +77,10 @@ export function getGoRuntimePath(): string {
 	return runtimePathCache;
 }
 
+/**
+ * Append current workspace path to go path
+ * 
+ */
 export function appendGoPath(cwd: string) {
 	let pathparts = process.env['GOPATH'].split(path.delimiter);
 	let gopath = new Array(cwd);

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -76,3 +76,13 @@ export function getGoRuntimePath(): string {
 	}
 	return runtimePathCache;
 }
+
+export function appendGoPath(cwd: string) {
+	let pathparts = process.env['GOPATH'].split(path.delimiter);
+	let gopath = new Array(cwd);
+	gopath = gopath.concat(pathparts);
+	
+	let str = gopath.join(path.delimiter);
+	console.log(str);
+	process.env['GOPATH'] = gopath.join(path.delimiter);
+}


### PR DESCRIPTION
adjust current workspace path for debug path
set current workspace path to go path, like eclipse.
add cwd to debugger initialConfigurations 
