### PR TITLE
Add command to extract method out of selected code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ install:
   - go get -u -v github.com/tpng/gopkgs
   - go get -u -v github.com/newhook/go-symbols
   - go get -u -v golang.org/x/tools/cmd/guru
-
+  - go get -u -v github.com/godoctor/godoctor
+  
 script:
   - npm run lint
   - npm test --silent

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,4 @@ script:
 
 env:
   - GO15VENDOREXPERIMENT=1
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,10 @@ install:
   - go get -u -v github.com/newhook/go-symbols
   - go get -u -v golang.org/x/tools/cmd/guru
   - go get -u -v github.com/godoctor/godoctor
-  
+
 script:
   - npm run lint
   - npm test --silent
+
+env:
+  - GO15VENDOREXPERIMENT=1

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The extension uses the following tools, installed in the current GOPATH.  If any
 - guru: `go get -u -v golang.org/x/tools/cmd/guru`
 - godoctor: `go get -u -v github.com/godoctor/godoctor`
 
-To install them just paste and run:
+To install them yourself, just paste and run:
 ```bash
 go get -u -v github.com/nsf/gocode
 go get -u -v github.com/rogpeppe/godef
@@ -187,6 +187,8 @@ go get -u -v github.com/newhook/go-symbols
 go get -u -v golang.org/x/tools/cmd/guru
 go get -u -v github.com/godoctor/godoctor
 ```
+
+*Note*: If the version of Go you are using is less than 1.6, then `set GO15VENDOREXPERIMENT=1` to support godoctor
 
 And for debugging:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This extension adds rich language support for the Go language to VS Code, includ
 - Format (using `goreturns` or `goimports` or `gofmt`)
 - Add Imports (using `gopkgs`)
 - [_partially implemented_] Debugging (using `delve`)
+- Extract Method (using `godoctor`)
 
 ### IDE Features
 ![IDE](http://i.giphy.com/xTiTndDHV3GeIy6aNa.gif)
@@ -171,6 +172,7 @@ The extension uses the following tools, installed in the current GOPATH.  If any
 - gopkgs: `go get -u -v github.com/tpng/gopkgs`
 - go-symbols: `go get -u -v github.com/newhook/go-symbols`
 - guru: `go get -u -v golang.org/x/tools/cmd/guru`
+- godoctor: `go get -u -v github.com/godoctor/godoctor`
 
 To install them just paste and run:
 ```bash
@@ -183,6 +185,7 @@ go get -u -v golang.org/x/tools/cmd/gorename
 go get -u -v github.com/tpng/gopkgs
 go get -u -v github.com/newhook/go-symbols
 go get -u -v golang.org/x/tools/cmd/guru
+go get -u -v github.com/godoctor/godoctor
 ```
 
 And for debugging:

--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
         "command": "go.import.add",
         "title": "Go: Add Import",
         "description": "Add an import declaration"
+      },
+      {
+        "command": "go.method.extract",
+        "title": "Go: Extract Method",
+        "description": "Extract Method from current selection"
       }
     ],
     "debuggers": [

--- a/src/goExtractMethod.ts
+++ b/src/goExtractMethod.ts
@@ -68,13 +68,6 @@ export function extractMethodUsingGoDoctor(methodName: string, selection: Select
 	let position = `${selection.start.line + 1},${selection.start.character + 1}:${selection.end.line + 1},${selection.end.character + 1}`;
 	
 	return new Promise((resolve, reject) => {
-
-		methodName = methodName.trim();
-		// TODO: Add other checks for methodName
-		if (methodName.indexOf(' ') > -1){
-			return resolve('Invalid name for method');		
-		}
-
 		var process = cp.execFile(godoctor, ['-pos', position, 'extract', methodName], {},(err, stdout, stderr) => {
 			if (err){
 				var errorMessageIndex = stderr.indexOf('Error:');				
@@ -93,7 +86,7 @@ export function extractMethodUsingGoDoctor(methodName: string, selection: Select
 			}
 					
 			applypatches(patches, editor).then(validEdit => {
-				return validEdit? resolve(null): resolve('Edits could not be applied to the document');				
+				return resolve (validEdit? null: 'Edits could not be applied to the document');				
 			});;
 				
 		});

--- a/src/goExtractMethod.ts
+++ b/src/goExtractMethod.ts
@@ -15,138 +15,138 @@ import dmp = require('diff-match-patch');
  * Extracts method out of current selection and replaces the current selection with a call to the extracted method.
  */
 export function extractMethod() {
-	
+
 	let editor = window.activeTextEditor;
 	if (!editor) {
 		window.showInformationMessage('No editor is active.');
 		return;
 	}
-	if (editor.selections.length != 1){
+	if (editor.selections.length !== 1) {
 		window.showInformationMessage('You need to have a single selection for extracting method');
 		return;
 	}
-		
+
 	let showInputBoxPromise = window.showInputBox({placeHolder: 'Please enter the name for the extracted method'});
-	showInputBoxPromise.then((methodName: string) => {		
+	showInputBoxPromise.then((methodName: string) => {
 		extractMethodUsingGoDoctor(methodName, editor.selection, editor).then(errorMessage => {
-			if (errorMessage){
+			if (errorMessage) {
 				window.showErrorMessage(errorMessage);
 			}
-		});				
-	});		
+		});
+	});
 }
 
 /**
  * Extracts method out of current selection and replaces the current selection with a call to the extracted method using godoctor.
- * 
+ *
  * @param methodName name for the extracted method
  * @param selection the editor selection from which method is to be extracted
- * @param editor the editor that will be used to apply the changes from godoctor 
+ * @param editor the editor that will be used to apply the changes from godoctor
  * @returns errorMessage in case the method fails, null otherwise
  */
-export function extractMethodUsingGoDoctor(methodName: string, selection: Selection, editor: TextEditor): Thenable<string>{
-	let godoctor = getBinPath('godoctor');		
+export function extractMethodUsingGoDoctor(methodName: string, selection: Selection, editor: TextEditor): Thenable<string> {
+	let godoctor = getBinPath('godoctor');
 	let position = `${selection.start.line + 1},${selection.start.character + 1}:${selection.end.line + 1},${selection.end.character + 1}`;
-	
+
 	return new Promise((resolve, reject) => {
-		var process = cp.execFile(godoctor, ['-pos', position, 'extract', methodName], {},(err, stdout, stderr) => {
-			if (err){
-				var errorMessageIndex = stderr.indexOf('Error:');				
-				return resolve(errorMessageIndex > -1 ? stderr.substr(errorMessageIndex) : stderr);				
-			}	
-			
+		let process = cp.execFile(godoctor, ['-pos', position, 'extract', methodName], {}, (err, stdout, stderr) => {
+			if (err) {
+				let errorMessageIndex = stderr.indexOf('Error:');
+				return resolve(errorMessageIndex > -1 ? stderr.substr(errorMessageIndex) : stderr);
+			}
+
 			let d = new dmp.diff_match_patch();
 			let patchText = stdout.substr(stdout.indexOf('@@'));
 			let patches: dmp.Patch[];
-			
+
 			try {
 				patches = d.patch_fromText(patchText);
 			}
-			catch(e){	
+			catch (e) {
 				return resolve(`Failed to parse the patches from godoctor: ${e.message}`);
 			}
-					
+
 			applypatches(patches, editor).then(validEdit => {
-				return resolve (validEdit? null: 'Edits could not be applied to the document');				
-			});;
-				
+				return resolve (validEdit ? null : 'Edits could not be applied to the document');
+			});
+
 		});
-		process.stdin.end(editor.document.getText());	
+		process.stdin.end(editor.document.getText());
 	});
 }
 
 /**
  * Applies the given set of patches to the document in the given editor
- * 
+ *
  * @param patches array of patches to be applied
  * @param editor the TextEditor whose document will be updated
  */
-function applypatches(patches: dmp.Patch[], editor: TextEditor): Thenable<boolean>{
-	let totalEdits: Edit[] = [];	
+function applypatches(patches: dmp.Patch[], editor: TextEditor): Thenable<boolean> {
+	let totalEdits: Edit[] = [];
 	patches.reverse().forEach((patch: dmp.Patch) => {
 		let edits = getEditsFromPatch(patch);
 		totalEdits = totalEdits.concat(edits);
-	})
-	var editPromise = editor.edit((editBuilder) => {		
+	});
+	let editPromise = editor.edit((editBuilder) => {
 		totalEdits.forEach((edit) => {
 			switch (edit.action) {
 				case EditTypes.EDIT_INSERT:
-					editBuilder.insert(edit.start, edit.text);											
+					editBuilder.insert(edit.start, edit.text);
 					break;
 				case EditTypes.EDIT_DELETE:
 					editBuilder.delete(new Range(edit.start, edit.end));
-					break;								
+					break;
 				case EditTypes.EDIT_REPLACE:
 					editBuilder.replace(new Range(edit.start, edit.end), edit.text);
-					break;								
-			}	
-		})			
-	})
+					break;
+			}
+		});
+	});
 
 	// While inserting the extracted method, the end of line char (\n) at the end of the document might get replaced.
 	// If this happens, the next time godoctor is called, it adds "No End of Line" char which will fail diff_match_patch.patch_fromtext()
 	// Therefore, add the end of line char at the end of the document if it does not exists.
 	return editPromise.then(done => {
-		if (done && !editor.document.getText().endsWith("\n")){
+		if (done && !editor.document.getText().endsWith('\n')) {
 			return editor.edit((editBuilder) => {
-				editBuilder.insert(new Position(editor.document.lineCount, 0), "\n");
+				editBuilder.insert(new Position(editor.document.lineCount, 0), '\n');
 			});
 		}
 		return Promise.resolve(done);
-	});	
+	});
 }
 
 /**
  * Gets Edits from given patch
- * 
+ *
  * @param patch The patch from which the diffs are translated to edits
  * @returns Array of Edits that can be applied to the document
  */
-function getEditsFromPatch(patch: dmp.Patch): Edit[]{
+function getEditsFromPatch(patch: dmp.Patch): Edit[] {
 	let line: number = patch.start1;
 	let edits: Edit[] = [];
-	let edit: Edit = null;	
-	
+	let edit: Edit = null;
+
 	// Loop through each diff, coalesce consecutive inserts/deletes into single edit of type insert/delete
 	// If insert follows a delete, then create a edit of type replace
-	for (let i = 0; i < patch.diffs.length; i++) {		
+	for (let i = 0; i < patch.diffs.length; i++) {
 		switch (patch.diffs[i][0]) {
 			case dmp.DIFF_DELETE:
-				if (edit == null) {					
+				if (edit == null) {
 					edit = new Edit(EditTypes.EDIT_DELETE, new Position(line, 0));
-				} 
-				edit.end = new Position(line, patch.diffs[i][1].length);	
-				line++;								
+				}
+				edit.end = new Position(line, patch.diffs[i][1].length);
+				line++;
 				break;
 			case dmp.DIFF_INSERT:
-				if (edit == null) {					
+				if (edit == null) {
 					edit = new Edit(EditTypes.EDIT_INSERT, new Position(line, 0));
 				} else if (edit.action === EditTypes.EDIT_DELETE) {
-					edit.action = EditTypes.EDIT_REPLACE;					
+					edit.action = EditTypes.EDIT_REPLACE;
 				} else {
-					edit.text += "\n";
+					edit.text += '\n';
 				}
-				if (edit.action == EditTypes.EDIT_INSERT){
+				if (edit.action === EditTypes.EDIT_INSERT) {
 					line++;
 				}
 				edit.text += patch.diffs[i][1];
@@ -155,11 +155,11 @@ function getEditsFromPatch(patch: dmp.Patch): Edit[]{
 			case dmp.DIFF_EQUAL:
 				if (edit != null) {
 					edits.push(edit);
-					edit = null;					
-				}	
-				line++;							
+					edit = null;
+				}
+				line++;
 				break;
-		}				
+		}
 	}
 
 	if (edit != null) {
@@ -167,8 +167,6 @@ function getEditsFromPatch(patch: dmp.Patch): Edit[]{
 	}
 
 	return edits;
-
-	
 }
 
 

--- a/src/goExtractMethod.ts
+++ b/src/goExtractMethod.ts
@@ -1,0 +1,189 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------*/
+
+'use strict';
+
+import { window, Position, Selection, Range, TextEditor } from 'vscode';
+import { getBinPath } from './goPath';
+import { EditTypes, Edit } from './util';
+import cp = require('child_process');
+import dmp = require('diff-match-patch');
+
+/**
+ * Extracts method out of current selection and replaces the current selection with a call to the extracted method.
+ */
+export function extractMethod() {
+	
+	let editor = window.activeTextEditor;
+	if (!editor) {
+		window.showInformationMessage('No editor is active.');
+		return;
+	}
+	if (editor.selections.length != 1){
+		window.showInformationMessage('You need to have a single selection for extracting method');
+		return;
+	}
+		
+	let showInputBoxPromise = window.showInputBox({placeHolder: 'Please enter the name for the extracted method'});
+	showInputBoxPromise.then((methodName: string) => {		
+
+		// Ensure there is always an eol char at the end of the document	
+		// Else "No End of Line" char gets added by godoctor which will fail diff_match_patch.patch_fromtext()
+		let editPromise: Thenable<boolean>;
+		if(!editor.document.getText().endsWith("\n")){			
+			editPromise = editor.edit((editBuilder) => {
+				editBuilder.insert(new Position(editor.document.lineCount, 0), "\n");
+			});
+		} else {
+			editPromise = Promise.resolve(true);
+		}
+	
+		editPromise.then((validEdit) => {
+			if (!validEdit) {
+				window.showErrorMessage('Edits could not be applied to the document');
+				return;
+			}
+			extractMethodUsingGoDoctor(methodName, editor.selection, editor).then(errorMessage => {
+				if (errorMessage){
+					window.showErrorMessage(errorMessage);
+				}
+			});;
+		});
+				
+	});		
+}
+
+/**
+ * Extracts method out of current selection and replaces the current selection with a call to the extracted method using godoctor.
+ * 
+ * @param methodName name for the extracted method
+ * @param selection the editor selection from which method is to be extracted
+ * @param editor the editor that will be used to apply the changes from godoctor 
+ * @returns errorMessage in case the method fails, null otherwise
+ */
+export function extractMethodUsingGoDoctor(methodName: string, selection: Selection, editor: TextEditor): Thenable<string>{
+	let godoctor = getBinPath('godoctor');		
+	let position = `${selection.start.line + 1},${selection.start.character + 1}:${selection.end.line + 1},${selection.end.character + 1}`;
+	
+	return new Promise((resolve, reject) => {
+
+		methodName = methodName.trim();
+		// TODO: Add other checks for methodName
+		if (methodName.indexOf(' ') > -1){
+			return resolve('Invalid name for method');		
+		}
+
+		var process = cp.execFile(godoctor, ['-pos', position, 'extract', methodName], {},(err, stdout, stderr) => {
+			if (err){
+				var errorMessageIndex = stderr.indexOf('Error:');				
+				return resolve(errorMessageIndex > -1 ? stderr.substr(errorMessageIndex) : stderr);				
+			}	
+			
+			let d = new dmp.diff_match_patch();
+			let patchText = stdout.substr(stdout.indexOf('@@'));
+			let patches: dmp.Patch[];
+			
+			try {
+				patches = d.patch_fromText(patchText);
+			}
+			catch(e){	
+				return resolve(`Failed to parse the patches from godoctor: ${e.message}`);
+			}
+					
+			applypatches(patches, editor).then(validEdit => {
+				return validEdit? resolve(null): resolve('Edits could not be applied to the document');				
+			});;
+				
+		});
+		process.stdin.end(editor.document.getText());	
+	});
+}
+
+/**
+ * Applies the given set of patches to the document in the given editor
+ * 
+ * @param patches array of patches to be applied
+ * @param editor the TextEditor whose document will be updated
+ */
+function applypatches(patches: dmp.Patch[], editor: TextEditor): Thenable<boolean>{
+	let totalEdits: Edit[] = [];	
+	patches.reverse().forEach((patch: dmp.Patch) => {
+		let edits = getEditsFromPatch(patch);
+		totalEdits = totalEdits.concat(edits);
+	})
+	var editPromise = editor.edit((editBuilder) => {		
+		totalEdits.forEach((edit) => {
+			switch (edit.action) {
+				case EditTypes.EDIT_INSERT:
+					editBuilder.insert(edit.start, edit.text);											
+					break;
+				case EditTypes.EDIT_DELETE:
+					editBuilder.delete(new Range(edit.start, edit.end));
+					break;								
+				case EditTypes.EDIT_REPLACE:
+					editBuilder.replace(new Range(edit.start, edit.end), edit.text);
+					break;								
+			}	
+		})			
+	})
+	return editPromise;	
+}
+
+/**
+ * Gets Edits from given patch
+ * 
+ * @param patch The patch from which the diffs are translated to edits
+ * @returns Array of Edits that can be applied to the document
+ */
+function getEditsFromPatch(patch: dmp.Patch): Edit[]{
+	let line: number = patch.start1;
+	let edits: Edit[] = [];
+	let edit: Edit = null;	
+	
+	// Loop through each diff, coalesce consecutive inserts/deletes into single edit of type insert/delete
+	// If insert follows a delete, then create a edit of type replace
+	for (let i = 0; i < patch.diffs.length; i++) {		
+		switch (patch.diffs[i][0]) {
+			case dmp.DIFF_DELETE:
+				if (edit == null) {					
+					edit = new Edit(EditTypes.EDIT_DELETE, new Position(line, 0));
+				} 
+				edit.end = new Position(line, patch.diffs[i][1].length);	
+				line++;								
+				break;
+			case dmp.DIFF_INSERT:
+				if (edit == null) {					
+					edit = new Edit(EditTypes.EDIT_INSERT, new Position(line, 0));
+				} else if (edit.action === EditTypes.EDIT_DELETE) {
+					edit.action = EditTypes.EDIT_REPLACE;					
+				} else {
+					edit.text += "\n";
+				}
+				if (edit.action == EditTypes.EDIT_INSERT){
+					line++;
+				}
+				edit.text += patch.diffs[i][1];
+				break;
+
+			case dmp.DIFF_EQUAL:
+				if (edit != null) {
+					edits.push(edit);
+					edit = null;					
+				}	
+				line++;							
+				break;
+		}				
+	}
+
+	if (edit != null) {
+		edits.push(edit);
+	}
+
+	return edits;
+
+	
+}
+
+

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -10,33 +10,7 @@ import cp = require('child_process');
 import path = require('path');
 import dmp = require('diff-match-patch');
 import { getBinPath } from './goPath';
-
-let EDIT_DELETE = 0;
-let EDIT_INSERT = 1;
-let EDIT_REPLACE = 2;
-class Edit {
-	action: number;
-	start: vscode.Position;
-	end: vscode.Position;
-	text: string;
-
-	constructor(action: number, start: vscode.Position) {
-		this.action = action;
-		this.start = start;
-		this.text = '';
-	}
-
-	apply(): vscode.TextEdit {
-		switch (this.action) {
-			case EDIT_INSERT:
-				return vscode.TextEdit.insert(this.start, this.text);
-			case EDIT_DELETE:
-				return vscode.TextEdit.delete(new vscode.Range(this.start, this.end));
-			case EDIT_REPLACE:
-				return vscode.TextEdit.replace(new vscode.Range(this.start, this.end), this.text);
-		}
-	}
-}
+import { EditTypes, Edit } from './util';
 
 export class Formatter {
 	private formatCommand = 'goreturns';
@@ -86,8 +60,8 @@ export class Formatter {
 						switch (diffs[i][0]) {
 							case dmp.DIFF_DELETE:
 								if (edit == null) {
-									edit = new Edit(EDIT_DELETE, start);
-								} else if (edit.action !== EDIT_DELETE) {
+									edit = new Edit(EditTypes.EDIT_DELETE, start);
+								} else if (edit.action !== EditTypes.EDIT_DELETE) {
 									return reject('cannot format due to an internal error.');
 								}
 								edit.end = new vscode.Position(line, character);
@@ -95,9 +69,9 @@ export class Formatter {
 
 							case dmp.DIFF_INSERT:
 								if (edit == null) {
-									edit = new Edit(EDIT_INSERT, start);
-								} else if (edit.action === EDIT_DELETE) {
-									edit.action = EDIT_REPLACE;
+									edit = new Edit(EditTypes.EDIT_INSERT, start);
+								} else if (edit.action === EditTypes.EDIT_DELETE) {
+									edit.action = EditTypes.EDIT_REPLACE;
 								}
 								// insert and replace edits are all relative to the original state
 								// of the document, so inserts should reset the current line/character

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -10,7 +10,7 @@ import cp = require('child_process');
 import path = require('path');
 import dmp = require('diff-match-patch');
 import { getBinPath } from './goPath';
-import { EditTypes, Edit } from './util';
+import { EditTypes, Edit, GetEditsFromDiffs } from './util';
 
 export class Formatter {
 	private formatCommand = 'goreturns';
@@ -39,62 +39,18 @@ export class Formatter {
 					let d = new dmp.diff_match_patch();
 
 					let diffs = d.diff_main(document.getText(), text);
-					let line = 0;
-					let character = 0;
-					let edits: vscode.TextEdit[] = [];
-					let edit: Edit = null;
+					let edits: Edit[] = GetEditsFromDiffs(diffs, 0);
+					let textEdits: vscode.TextEdit[] = [];
+
+					if (!edits){
+						return reject('Cannot format due to internal errors');
+					}
 
 					for (let i = 0; i < diffs.length; i++) {
-						let start = new vscode.Position(line, character);
-
-						// Compute the line/character after the diff is applied.
-						for (let curr = 0; curr < diffs[i][1].length; curr++) {
-							if (diffs[i][1][curr] !== '\n') {
-								character++;
-							} else {
-								character = 0;
-								line++;
-							}
-						}
-
-						switch (diffs[i][0]) {
-							case dmp.DIFF_DELETE:
-								if (edit == null) {
-									edit = new Edit(EditTypes.EDIT_DELETE, start);
-								} else if (edit.action !== EditTypes.EDIT_DELETE) {
-									return reject('cannot format due to an internal error.');
-								}
-								edit.end = new vscode.Position(line, character);
-								break;
-
-							case dmp.DIFF_INSERT:
-								if (edit == null) {
-									edit = new Edit(EditTypes.EDIT_INSERT, start);
-								} else if (edit.action === EditTypes.EDIT_DELETE) {
-									edit.action = EditTypes.EDIT_REPLACE;
-								}
-								// insert and replace edits are all relative to the original state
-								// of the document, so inserts should reset the current line/character
-								// position to the start.		
-								line = start.line;
-								character = start.character;
-								edit.text += diffs[i][1];
-								break;
-
-							case dmp.DIFF_EQUAL:
-								if (edit != null) {
-									edits.push(edit.apply());
-									edit = null;
-								}
-								break;
-						}
+						textEdits.push(edits[i].apply());
 					}
 
-					if (edit != null) {
-						edits.push(edit.apply());
-					}
-
-					return resolve(edits);
+					return resolve(textEdits);
 				} catch (e) {
 					reject(e);
 				}

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -42,7 +42,7 @@ export class Formatter {
 					let edits: Edit[] = GetEditsFromDiffs(diffs, 0);
 					let textEdits: vscode.TextEdit[] = [];
 
-					if (!edits){
+					if (!edits) {
 						return reject('Cannot format due to internal errors');
 					}
 

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -23,7 +23,8 @@ let tools: { [key: string]: string } = {
 	golint: 'github.com/golang/lint/golint',
 	'go-outline': 'github.com/lukehoban/go-outline',
 	'go-symbols': 'github.com/newhook/go-symbols',
-	guru: 'golang.org/x/tools/cmd/guru'
+	guru: 'golang.org/x/tools/cmd/guru',
+	godoctor: 'github.com/godoctor/godoctor'
 };
 
 export function installTool(tool: string) {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -59,7 +59,7 @@ export function setupGoPathAndOfferToInstallTools() {
 		});
 		return;
 	}
-
+	
 	let keys = Object.keys(tools);
 	Promise.all(keys.map(tool => new Promise<string>((resolve, reject) => {
 		let toolPath = getBinPath(tool);
@@ -77,9 +77,9 @@ export function setupGoPathAndOfferToInstallTools() {
 		}
 	});
 
-	function promptForInstall(missing: string[]) {
+	function promptForInstall(missing: string[]) {		
 		// set GO15VENDOREXPERIMENT=1 to support godoctor when using Go v1.5
-		cp.exec('set GO15VENDOREXPERIMENT=1', { env: process.env }, (err, stdout, stderr) => {});
+		process.env['GO15VENDOREXPERIMENT'] = 1;
 
 		let item = {
 			title: 'Install',

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -59,7 +59,7 @@ export function setupGoPathAndOfferToInstallTools() {
 		});
 		return;
 	}
-	
+
 	let keys = Object.keys(tools);
 	Promise.all(keys.map(tool => new Promise<string>((resolve, reject) => {
 		let toolPath = getBinPath(tool);
@@ -77,7 +77,7 @@ export function setupGoPathAndOfferToInstallTools() {
 		}
 	});
 
-	function promptForInstall(missing: string[]) {		
+	function promptForInstall(missing: string[]) {
 		// set GO15VENDOREXPERIMENT=1 to support godoctor when using Go v1.5
 		process.env['GO15VENDOREXPERIMENT'] = 1;
 

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -78,6 +78,9 @@ export function setupGoPathAndOfferToInstallTools() {
 	});
 
 	function promptForInstall(missing: string[]) {
+		// set GO15VENDOREXPERIMENT=1 to support godoctor when using Go v1.5
+		cp.exec('set GO15VENDOREXPERIMENT=1', { env: process.env }, (err, stdout, stderr) => {});
+
 		let item = {
 			title: 'Install',
 			command() {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -81,7 +81,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.method.extract', () => {
-		extractMethod();		
+		extractMethod();
 	}));
 
 	vscode.languages.setLanguageConfiguration(GO_MODE.language, {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -26,6 +26,7 @@ import { showHideStatus } from './goStatus';
 import { coverageCurrentPackage, getCodeCoverage, removeCodeCoverage } from './goCover';
 import { testAtCursor, testCurrentPackage, testCurrentFile } from './goTest';
 import { addImport } from './goImport';
+import { extractMethod } from './goExtractMethod';
 
 let diagnosticCollection: vscode.DiagnosticCollection;
 
@@ -77,6 +78,10 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.import.add', (arg: string) => {
 		return addImport(typeof arg === 'string' ? arg : null);
+	}));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.method.extract', () => {
+		extractMethod();		
 	}));
 
 	vscode.languages.setLanguageConfiguration(GO_MODE.language, {

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,6 +5,7 @@
 
 import { TextDocument, Position, TextEdit, Range } from 'vscode';
 import path = require('path');
+import dmp = require('diff-match-patch');
 
 export function byteOffsetAt(document: TextDocument, position: Position): number {
 	let offset = document.offsetAt(position);
@@ -49,7 +50,7 @@ export function parseFilePrelude(text: string): Prelude {
 }
 
 // Takes a Go function signature like:
-//     (foo, bar string, baz number) (string, string) 
+//     (foo, bar string, baz number) (string, string)
 // and returns an array of parameter strings:
 //     ["foo", "bar string", "baz string"]
 // Takes care of balancing parens so to not get confused by signatures like:
@@ -122,4 +123,67 @@ export class Edit {
 	}
 }
 
+/**
+ * Gets Edits from given diff array
+ *
+ * @param diffs The array of diffs which are translated to edits
+ * @param line The line number from where the edits are to be applied
+ * @returns Array of Edits that can be applied to the document
+ */
+export function GetEditsFromDiffs(diffs: dmp.Diff[], line: number): Edit[]{
+	let character = 0;
+	let edits: Edit[] = [];
+	let edit: Edit = null;
 
+	for (let i = 0; i < diffs.length; i++) {
+		let start = new Position(line, character);
+
+		// Compute the line/character after the diff is applied.
+		for (let curr = 0; curr < diffs[i][1].length; curr++) {
+			if (diffs[i][1][curr] !== '\n') {
+				character++;
+			} else {
+				character = 0;
+				line++;
+			}
+		}
+
+		switch (diffs[i][0]) {
+			case dmp.DIFF_DELETE:
+				if (edit == null) {
+					edit = new Edit(EditTypes.EDIT_DELETE, start);
+				} else if (edit.action !== EditTypes.EDIT_DELETE) {
+					return null;
+				}
+				edit.end = new Position(line, character);
+				break;
+
+			case dmp.DIFF_INSERT:
+				if (edit == null) {
+					edit = new Edit(EditTypes.EDIT_INSERT, start);
+				} else if (edit.action === EditTypes.EDIT_DELETE) {
+					edit.action = EditTypes.EDIT_REPLACE;
+				}
+				// insert and replace edits are all relative to the original state
+				// of the document, so inserts should reset the current line/character
+				// position to the start.
+				line = start.line;
+				character = start.character;
+				edit.text += diffs[i][1];
+				break;
+
+			case dmp.DIFF_EQUAL:
+				if (edit != null) {
+					edits.push(edit);
+					edit = null;
+				}
+				break;
+		}
+	}
+
+	if (edit != null) {
+		edits.push(edit);
+	}
+
+	return edits;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -84,8 +84,6 @@ export function parameters(signature: string): string[] {
 }
 
 export function canonicalizeGOPATHPrefix(filename: string): string {
-
-
 		let gopath: string = process.env['GOPATH'];
 		if (!gopath) return filename;
 		let workspaces = gopath.split(path.delimiter);
@@ -97,7 +95,6 @@ export function canonicalizeGOPATHPrefix(filename: string): string {
 		}
 		return filename;
 	}
-
 
 export enum EditTypes { EDIT_DELETE, EDIT_INSERT, EDIT_REPLACE};
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -130,7 +130,7 @@ export class Edit {
  * @param line The line number from where the edits are to be applied
  * @returns Array of Edits that can be applied to the document
  */
-export function GetEditsFromDiffs(diffs: dmp.Diff[], line: number): Edit[]{
+export function GetEditsFromDiffs(diffs: dmp.Diff[], line: number): Edit[] {
 	let character = 0;
 	let edits: Edit[] = [];
 	let edit: Edit = null;

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------*/
 
-import { TextDocument, Position } from 'vscode';
+import { TextDocument, Position, TextEdit, Range } from 'vscode';
 import path = require('path');
 
 export function byteOffsetAt(document: TextDocument, position: Position): number {
@@ -84,6 +84,8 @@ export function parameters(signature: string): string[] {
 }
 
 export function canonicalizeGOPATHPrefix(filename: string): string {
+
+
 		let gopath: string = process.env['GOPATH'];
 		if (!gopath) return filename;
 		let workspaces = gopath.split(path.delimiter);
@@ -95,3 +97,32 @@ export function canonicalizeGOPATHPrefix(filename: string): string {
 		}
 		return filename;
 	}
+
+
+export enum EditTypes { EDIT_DELETE, EDIT_INSERT, EDIT_REPLACE};
+
+export class Edit {
+	action: number;
+	start: Position;
+	end: Position;
+	text: string;
+
+	constructor(action: number, start: Position) {
+		this.action = action;
+		this.start = start;
+		this.text = '';
+	}
+
+	apply(): TextEdit {
+		switch (this.action) {
+			case EditTypes.EDIT_INSERT:
+				return TextEdit.insert(this.start, this.text);
+			case EditTypes.EDIT_DELETE:
+				return TextEdit.delete(new Range(this.start, this.end));
+			case EditTypes.EDIT_REPLACE:
+				return TextEdit.replace(new Range(this.start, this.end), this.text);
+		}
+	}
+}
+
+

--- a/test/fixtures/expectedAfterExtractMethod.go
+++ b/test/fixtures/expectedAfterExtractMethod.go
@@ -10,8 +10,11 @@ func print(txt string) {
 func main() {
 	print("Hello")
 
-	a:= 1
-	b:=2
-	c:= a+b
+	a := 1
+	b := 2
+	add(a, b)
+}
+func add(a int, b int) {
+	c := a + b
 	fmt.Println(c)
 }

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -11,7 +11,7 @@ import { GoHoverProvider } from '../src/goExtraInfo';
 import { GoCompletionItemProvider } from '../src/goSuggest';
 import { GoSignatureHelpProvider } from '../src/goSignature';
 import { check } from '../src/goCheck';
-import { extractMethodUsingGoDoctor } from '../src/goExtractMethod'; 
+import { extractMethodUsingGoDoctor } from '../src/goExtractMethod';
 
 suite('Go Extension Tests', () => {
 	let gopath = process.env['GOPATH'];
@@ -86,8 +86,8 @@ suite('Go Extension Tests', () => {
 			[new vscode.Position(7, 13), 'Println(a ...interface{}) (n int, err error)'],
 			[new vscode.Position(10, 7), 'print(txt string)']
 		];
-		let uri = vscode.Uri.file(path.join(fixturePath, 'test.go'));		
-		vscode.workspace.openTextDocument(uri).then((textDocument) => {						
+		let uri = vscode.Uri.file(path.join(fixturePath, 'test.go'));
+		vscode.workspace.openTextDocument(uri).then((textDocument) => {
 			let promises = testCases.map(([position, expected]) =>
 				provider.provideSignatureHelp(textDocument, position, null).then(sigHelp => {
 					assert.equal(sigHelp.signatures.length, 1, 'unexpected number of overloads');
@@ -120,42 +120,42 @@ suite('Go Extension Tests', () => {
 
 	test('Extract method fails due to invalid method name', (done) => {
 		let uri = vscode.Uri.file(path.join(fixtureSourcePath, 'test.go'));
-		let selection = new vscode.Selection(14, 0, 15, 14);	
+		let selection = new vscode.Selection(14, 0, 15, 14);
 
 		vscode.workspace.openTextDocument(uri).then((textDocument) => {
 			return vscode.window.showTextDocument(textDocument).then(editor => {
-				return extractMethodUsingGoDoctor('a dd', selection, editor).then((retValue) => {					
+				return extractMethodUsingGoDoctor('a dd', selection, editor).then((retValue) => {
 					assert.equal(retValue.indexOf('is not a valid Go identifier') > -1, true);
-				});		
+				});
 			});
-		}).then(() => done(), done);			
-	})
+		}).then(() => done(), done);
+	});
 
 	test('Extract method fails due to invalid selection', (done) => {
 		let uri = vscode.Uri.file(path.join(fixtureSourcePath, 'test.go'));
-		let selection = new vscode.Selection(2, 0, 5, 0);	
+		let selection = new vscode.Selection(2, 0, 5, 0);
 
 		vscode.workspace.openTextDocument(uri).then((textDocument) => {
 			return vscode.window.showTextDocument(textDocument).then(editor => {
-				return extractMethodUsingGoDoctor('add', selection, editor).then((retValue) => {					
+				return extractMethodUsingGoDoctor('add', selection, editor).then((retValue) => {
 					assert.equal(retValue.indexOf('invalid selection') > -1, true);
-				});				
+				});
 			});
-		}).then(() => done(), done);		
-	})
-	
+		}).then(() => done(), done);
+	});
+
 	test('Extract method successfully', (done) => {
 		let uri = vscode.Uri.file(path.join(fixtureSourcePath, 'test.go'));
 		let expectedOutput = fs.readFileSync(path.join(fixtureSourcePath, 'expectedAfterExtractMethod.go'), 'utf8');
-		let selection = new vscode.Selection(14, 0, 15, 14);		
-		
-		vscode.workspace.openTextDocument(uri).then((textDocument) => {			
+		let selection = new vscode.Selection(14, 0, 15, 14);
+
+		vscode.workspace.openTextDocument(uri).then((textDocument) => {
 			return vscode.window.showTextDocument(textDocument).then(editor => {
-				return extractMethodUsingGoDoctor('add', selection, editor).then((done) => {					
+				return extractMethodUsingGoDoctor('add', selection, editor).then((done) => {
 					assert.equal(editor.document.getText(), expectedOutput);
-				});				
+				});
 			});
-		}).then(() => done(), done);		
-	})
-	
+		}).then(() => done(), done);
+	});
+
 });

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -12,7 +12,6 @@ import { GoCompletionItemProvider } from '../src/goSuggest';
 import { GoSignatureHelpProvider } from '../src/goSignature';
 import { check } from '../src/goCheck';
 import { extractMethodUsingGoDoctor } from '../src/goExtractMethod'; 
-import dmp = require('diff-match-patch');
 
 suite('Go Extension Tests', () => {
 	let gopath = process.env['GOPATH'];
@@ -119,44 +118,41 @@ suite('Go Extension Tests', () => {
 		}).then(() => done(), done);
 	});
 
-	test('Extract method successfully', (done) => {
-		let uri = vscode.Uri.file(path.join(fixtureSourcePath, 'test.go'));
-		let expectedOutput = fs.readFileSync(path.join(fixtureSourcePath, 'expectedAfterExtractMethod.go'), 'utf8');
-		let selection = new vscode.Selection(14,0,15,14);		
-		
-		vscode.workspace.openTextDocument(uri).then((textDocument) => {
-			var editorPromise = vscode.window.showTextDocument(textDocument);			
-			editorPromise.then(editor => {
-				extractMethodUsingGoDoctor('add', selection, editor).then((done) => {					
-					assert.equal(editor.document.getText(), expectedOutput);
-				});				
-			});
-		}).then(() => done(), done);		
-	})
-
 	test('Extract method fails due to invalid method name', (done) => {
 		let uri = vscode.Uri.file(path.join(fixtureSourcePath, 'test.go'));
-		let selection = new vscode.Selection(14,0,15,14);	
+		let selection = new vscode.Selection(14, 0, 15, 14);	
 
 		vscode.workspace.openTextDocument(uri).then((textDocument) => {
-			var editorPromise = vscode.window.showTextDocument(textDocument);			
-			editorPromise.then(editor => {
-				extractMethodUsingGoDoctor('a dd', selection, editor).then((retValue) => {					
-					assert.equal(retValue.indexOf('Invalid name for method') > -1, true);
-				});				
+			return vscode.window.showTextDocument(textDocument).then(editor => {
+				return extractMethodUsingGoDoctor('a dd', selection, editor).then((retValue) => {					
+					assert.equal(retValue.indexOf('is not a valid Go identifier') > -1, true);
+				});		
 			});
 		}).then(() => done(), done);			
 	})
 
 	test('Extract method fails due to invalid selection', (done) => {
 		let uri = vscode.Uri.file(path.join(fixtureSourcePath, 'test.go'));
-		let selection = new vscode.Selection(2,0,5,0);	
+		let selection = new vscode.Selection(2, 0, 5, 0);	
 
 		vscode.workspace.openTextDocument(uri).then((textDocument) => {
-			var editorPromise = vscode.window.showTextDocument(textDocument);			
-			editorPromise.then(editor => {
-				extractMethodUsingGoDoctor('add', selection, editor).then((retValue) => {					
+			return vscode.window.showTextDocument(textDocument).then(editor => {
+				return extractMethodUsingGoDoctor('add', selection, editor).then((retValue) => {					
 					assert.equal(retValue.indexOf('invalid selection') > -1, true);
+				});				
+			});
+		}).then(() => done(), done);		
+	})
+	
+	test('Extract method successfully', (done) => {
+		let uri = vscode.Uri.file(path.join(fixtureSourcePath, 'test.go'));
+		let expectedOutput = fs.readFileSync(path.join(fixtureSourcePath, 'expectedAfterExtractMethod.go'), 'utf8');
+		let selection = new vscode.Selection(14, 0, 15, 14);		
+		
+		vscode.workspace.openTextDocument(uri).then((textDocument) => {			
+			return vscode.window.showTextDocument(textDocument).then(editor => {
+				return extractMethodUsingGoDoctor('add', selection, editor).then((done) => {					
+					assert.equal(editor.document.getText(), expectedOutput);
 				});				
 			});
 		}).then(() => done(), done);		


### PR DESCRIPTION
Related to a feature ask in #275 
This commit adds a command to the command palette that can be used to extract a method out of selected code and replace the selected code with a call to the extracted method using godoctor. Read more about godoctor at http://gorefactor.org/