### PR TITLE
Fixes #310 - install Missing Analysis Tool. Better feedback would be nice

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -26,15 +26,41 @@ let tools: { [key: string]: string } = {
 	guru: 'golang.org/x/tools/cmd/guru'
 };
 
-export function installTool(tool: string) {
-	outputChannel.clear();
+export function installTools(missing: string[]) {
 	outputChannel.show();
-	cp.exec('go get -u -v ' + tools[tool], { env: process.env }, (err, stdout, stderr) => {
-		outputChannel.append(stdout.toString());
-		outputChannel.append(stderr.toString());
-		if (err) {
-			outputChannel.append('exec error: ' + err);
+	outputChannel.clear();
+	outputChannel.appendLine('Installing ' + missing.length + ' missing tools');
+	missing.forEach((missingTool, index, missing) => {
+		outputChannel.appendLine('  ' + missingTool);
+	});
+
+	outputChannel.appendLine(''); // Blank line for spacing.
+
+	Promise.all(missing.map(tool => new Promise<string>((resolve, reject) => {
+		cp.exec('go get -u -v ' + tools[tool], { env: process.env }, (err, stdout, stderr) => {
+			if (err) {
+				outputChannel.appendLine('Installing ' + tool + ' FAILED');
+				let failureReason = tool + ';;' + err + stdout.toString() + stderr.toString();
+				resolve(failureReason);
+			} else {
+				outputChannel.appendLine('Installing ' + tool + ' SUCCEEDED');
+				resolve();
+			}
+		});
+	}))).then(res => {
+		outputChannel.appendLine(''); // Blank line for spacing
+		let failures = res.filter(x => x != null);
+		if (failures.length == 0) {
+			outputChannel.appendLine('All tools successfully installed. You\'re ready to Go :).');
+			return;
 		}
+
+		outputChannel.appendLine(failures.length + ' tools failed to install.\n');
+		failures.forEach((failure, index, failures) => {
+			let reason = failure.split(';;')
+			outputChannel.appendLine(reason[0] + ':');
+			outputChannel.appendLine(reason[1]);
+		});
 	});
 }
 
@@ -67,6 +93,7 @@ export function setupGoPathAndOfferToInstallTools() {
 		});
 	}))).then(res => {
 		let missing = res.filter(x => x != null);
+		console.log(missing);
 		if (missing.length > 0) {
 			showGoStatus('Analysis Tools Missing', 'go.promptforinstall', 'Not all Go tools are available on the GOPATH');
 			vscode.commands.registerCommand('go.promptforinstall', () => {
@@ -80,7 +107,7 @@ export function setupGoPathAndOfferToInstallTools() {
 		let item = {
 			title: 'Install',
 			command() {
-				missing.forEach(installTool);
+				installTools(missing);
 			}
 		};
 		vscode.window.showInformationMessage('Some Go analysis tools are missing from your GOPATH.  Would you like to install them?', item).then(selection => {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -93,7 +93,6 @@ export function setupGoPathAndOfferToInstallTools() {
 		});
 	}))).then(res => {
 		let missing = res.filter(x => x != null);
-		console.log(missing);
 		if (missing.length > 0) {
 			showGoStatus('Analysis Tools Missing', 'go.promptforinstall', 'Not all Go tools are available on the GOPATH');
 			vscode.commands.registerCommand('go.promptforinstall', () => {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -50,14 +50,14 @@ export function installTools(missing: string[]) {
 	}))).then(res => {
 		outputChannel.appendLine(''); // Blank line for spacing
 		let failures = res.filter(x => x != null);
-		if (failures.length == 0) {
+		if (failures.length === 0) {
 			outputChannel.appendLine('All tools successfully installed. You\'re ready to Go :).');
 			return;
 		}
 
 		outputChannel.appendLine(failures.length + ' tools failed to install.\n');
 		failures.forEach((failure, index, failures) => {
-			let reason = failure.split(';;')
+			let reason = failure.split(';;');
 			outputChannel.appendLine(reason[0] + ':');
 			outputChannel.appendLine(reason[1]);
 		});

--- a/src/goReferences.ts
+++ b/src/goReferences.ts
@@ -10,7 +10,7 @@ import cp = require('child_process');
 import path = require('path');
 import { getBinPath } from './goPath';
 import { byteOffsetAt, canonicalizeGOPATHPrefix } from './util';
-import { installTool } from './goInstallTools';
+import { installTools } from './goInstallTools';
 
 export class GoReferenceProvider implements vscode.ReferenceProvider {
 
@@ -40,7 +40,7 @@ export class GoReferenceProvider implements vscode.ReferenceProvider {
 				try {
 					if (err && (<any>err).code === 'ENOENT') {
 						vscode.window.showInformationMessage('The "guru" command is not available.  Use "go get -v golang.org/x/tools/cmd/guru" to install.', 'Install').then(selected => {
-							installTool('guru');
+							installTools(['guru']);
 						});
 						return resolve(null);
 					}

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -38,6 +38,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 	private gocodeConfigurationComplete = false;
 
 	public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.CompletionItem[]> {
+		console.log("My dude");
 		return this.ensureGoCodeConfigured().then(() => {
 			return new Promise<vscode.CompletionItem[]>((resolve, reject) => {
 				let filename = document.fileName;
@@ -59,6 +60,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 					let word = document.getText(wordAtPosition);
 					currentWord = word.substr(0, position.character - wordAtPosition.start.character);
 				}
+
 
 				if (currentWord.match(/^\d+$/)) {
 					return resolve([]);
@@ -138,6 +140,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 
 	// TODO: Shouldn't lib-path also be set?
 	private ensureGoCodeConfigured(): Thenable<void> {
+		console.log("configured");
 		return new Promise<void>((resolve, reject) => {
 			// TODO: Since the gocode daemon is shared amongst clients, shouldn't settings be
 			// adjusted per-invocation to avoid conflicts from other gocode-using programs?

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -38,7 +38,6 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 	private gocodeConfigurationComplete = false;
 
 	public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.CompletionItem[]> {
-		console.log("My dude");
 		return this.ensureGoCodeConfigured().then(() => {
 			return new Promise<vscode.CompletionItem[]>((resolve, reject) => {
 				let filename = document.fileName;
@@ -140,7 +139,6 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 
 	// TODO: Shouldn't lib-path also be set?
 	private ensureGoCodeConfigured(): Thenable<void> {
-		console.log("configured");
 		return new Promise<void>((resolve, reject) => {
 			// TODO: Since the gocode daemon is shared amongst clients, shouldn't settings be
 			// adjusted per-invocation to avoid conflicts from other gocode-using programs?


### PR DESCRIPTION
This commit causes goInstallTools to log very differently than present.

Presently, goInstallTools just writes the output of stdout and stderr to the Go outputChannel.

This commit proposes logging _much_ less in the case of success, and only logging the cause of errors.

Let me know what you think @lukehoban.

(A total success)
```
Installing 9 missing tools
  gorename
  gopkgs
  gocode
  goreturns
  godef
  golint
  go-outline
  go-symbols
  guru

Installing gopkgs SUCCEEDED
Installing go-outline SUCCEEDED
Installing go-symbols SUCCEEDED
Installing godef SUCCEEDED
Installing gorename SUCCEEDED
Installing golint SUCCEEDED
Installing goreturns SUCCEEDED
Installing gocode SUCCEEDED
Installing guru SUCCEEDED

All tools successfully installed. You're ready to Go :).
```

(A failure)
```
Installing 9 missing tools
  gorename
  gopkgs
  gocode
  goreturns
  godef
  golint
  go-outline
  go-symbols
  guru

Installing go-outline FAILED
Installing gorename FAILED
Installing gopkgs FAILED
Installing go-symbols FAILED
Installing golint FAILED
Installing goreturns FAILED
Installing gocode FAILED
Installing godef FAILED
Installing guru FAILED

9 tools failed to install.

gorename:
Error: Command failed: go get -u -v golang.org/x/tools/cmd/gorename
Fetching https://golang.org/x/tools/cmd/gorename?go-get=1
https fetch failed: Get https://golang.org/x/tools/cmd/gorename?go-get=1: dial tcp: lookup golang.org: no such host
golang.org/x/tools (download)
# cd /Users/ben/Documents/gowork/src/golang.org/x/tools; git pull --ff-only
fatal: unable to access 'https://go.googlesource.com/tools/': Could not resolve host: go.googlesource.com
package golang.org/x/tools/cmd/gorename: exit status 1
Fetching https://golang.org/x/tools/cmd/gorename?go-get=1
https fetch failed: Get https://golang.org/x/tools/cmd/gorename?go-get=1: dial tcp: lookup golang.org: no such host
golang.org/x/tools (download)
# cd /Users/ben/Documents/gowork/src/golang.org/x/tools; git pull --ff-only
fatal: unable to access 'https://go.googlesource.com/tools/': Could not resolve host: go.googlesource.com
package golang.org/x/tools/cmd/gorename: exit status 1
```

NOTE: Didn't include every failure's output as they're all the same (no internet connection).