### PR TITLE
Preserve focus when running tests

### DIFF
--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -119,7 +119,7 @@ export function testCurrentFile(timeout: string) {
 function goTest(config: TestConfig): Thenable<boolean> {
 	return new Promise<boolean>((resolve, reject) => {
 		outputChannel.clear();
-		outputChannel.show(2);
+		outputChannel.show(2, true);
 		let buildFlags: string[] = vscode.workspace.getConfiguration('go')['buildFlags'];
 		let buildTags: string = vscode.workspace.getConfiguration('go')['buildTags'];
 		let args = ['test', '-v', '-timeout', config.timeout, '-tags', buildTags, ...buildFlags];


### PR DESCRIPTION
Use the preserveFocus[1] argument on OutputChannel.Show() to ensure that the editor does not lose focus when running tests.

This is, for instance, useful when you have a setup such as this keybinding that runs tests in the current package whenever cmd+t is pressed:

[
   {
       "key":"cmd+t",
       "command":"go.test.package",
       "when":"editorTextFocus && editorLangId=='go'"
   }
]


[1] https://github.com/Microsoft/vscode/commit/1da94d28ee74302bc30747403a314c49129519be