### PR TITLE
Move away from deprecated language configuration settings

### DIFF
--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -86,35 +86,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 			// ^.*\{[^}'']*$
 			increaseIndentPattern: /^.*\{[^}'']*$/
 		},
-		wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
-		comments: {
-			lineComment: '//',
-			blockComment: ['/*', '*/']
-		},
-		brackets: [
-			['{', '}'],
-			['[', ']'],
-			['(', ')'],
-		],
-
-		__electricCharacterSupport: {
-			brackets: [
-				{ tokenType: 'delimiter.curly.ts', open: '{', close: '}', isElectric: true },
-				{ tokenType: 'delimiter.square.ts', open: '[', close: ']', isElectric: true },
-				{ tokenType: 'delimiter.paren.ts', open: '(', close: ')', isElectric: true }
-			]
-		},
-
-		__characterPairSupport: {
-			autoClosingPairs: [
-				{ open: '{', close: '}' },
-				{ open: '[', close: ']' },
-				{ open: '(', close: ')' },
-				{ open: '`', close: '`', notIn: ['string'] },
-				{ open: '"', close: '"', notIn: ['string'] },
-				{ open: '\'', close: '\'', notIn: ['string', 'comment'] }
-			]
-		}
+		wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g
 	});
 
 	if (vscode.window.activeTextEditor) {


### PR DESCRIPTION
In the July release of VSCode we added new properties to the language configuration files so that the deprecated __characterPairSupport and __electricCharacterSupport APIs in vscode.d.ts are no longer necessary.
See Microsoft/vscode#9281.

I've already added the comment, brackets and bracket pairs to the go language definition in the built-in go extension. See Microsoft/vscode@8020da609fefa8a96e8b538ecba0e6da1e2de2e3 

You can keep your current state a while if you want to be backward compatible to pre-July versions.
