### PR TITLE
Add showLog to initialConfigurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
             "host": "127.0.0.1",
             "program": "${workspaceRoot}",
             "env": {},
-            "args": []
+            "args": [],
+            "showLog": true
           }
         ],
         "configurationAttributes": {


### PR DESCRIPTION
Related to [delve debugger non-functional in VSCode 1.3.1](https://github.com/Microsoft/vscode-go/issues/410)

`showLog` was added as a new option in 0.6.40.  When set to false (the default), the debugger appears not to work.  Adding `"showLog": true` to the initialConfigurations allows the debugger to work with the auto generated launch.json.