### PR TITLE
Extra info now checks doc

### DIFF
--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -74,7 +74,10 @@ export function definitionLocation(document: vscode.TextDocument, position: vsco
 							break;
 						}
 					}
-					definitionInformation.doc = doc;
+
+					if (doc != '') {
+						definitionInformation.doc = doc;
+					}
 					return resolve(definitionInformation);
 				});
 			} catch (e) {

--- a/src/goExtraInfo.ts
+++ b/src/goExtraInfo.ts
@@ -10,7 +10,7 @@ import { definitionLocation } from './goDeclaration';
 
 export class GoHoverProvider implements HoverProvider {
 	public provideHover(document: TextDocument, position: Position, token: CancellationToken): Thenable<Hover> {
-		return definitionLocation(document, position, false).then(definitionInfo => {
+		return definitionLocation(document, position, true).then(definitionInfo => {
 			if (definitionInfo == null) return null;
 			let lines = definitionInfo.lines;
 			lines = lines.map(line => {
@@ -28,7 +28,12 @@ export class GoHoverProvider implements HoverProvider {
 			} else {
 				text = lines[0];
 			}
-			let hover = new Hover({ language: 'go', value: text });
+			let hoverTexts = [];
+			if (definitionInfo.doc != null) {
+				hoverTexts.push({ language: null, value: definitionInfo.doc});
+			}
+			hoverTexts.push({ language: 'go', value: text});
+			let hover = new Hover(hoverTexts);
 			return hover;
 		});
 	}

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -32,19 +32,29 @@ suite('Go Extension Tests', () => {
 
 	test('Test Hover Provider', (done) => {
 		let provider = new GoHoverProvider();
-		let testCases: [vscode.Position, string][] = [
+		let printlnDoc = `Println formats using the default formats for its operands and writes to
+standard output. Spaces are always added between operands and a newline
+is appended. It returns the number of bytes written and any write error
+encountered.
+`
+		let testCases: [vscode.Position, string, string][] = [
 			// [new vscode.Position(3,3), '/usr/local/go/src/fmt'],
-			[new vscode.Position(9, 6), 'main func()'],
-			[new vscode.Position(7, 2), 'import (fmt "fmt")'],
-			[new vscode.Position(7, 6), 'Println func(a ...interface{}) (n int, err error)'],
-			[new vscode.Position(10, 3), 'print func(txt string)']
+			[new vscode.Position(9, 6), 'main func()', null],
+			[new vscode.Position(7, 2), 'import (fmt "fmt")', null],
+			[new vscode.Position(7, 6), 'Println func(a ...interface{}) (n int, err error)', printlnDoc],
+			[new vscode.Position(10, 3), 'print func(txt string)', null]
 		];
 		let uri = vscode.Uri.file(path.join(fixturePath, 'test.go'));
 		vscode.workspace.openTextDocument(uri).then((textDocument) => {
-			let promises = testCases.map(([position, expected]) =>
+			let promises = testCases.map(([position, expectedSignature, expectedDocumentation]) =>
 				provider.provideHover(textDocument, position, null).then(res => {
-					assert.equal(res.contents.length, 1);
-					assert.equal(expected, (<{ language: string; value: string }>res.contents[0]).value);
+					if (expectedDocumentation == null) {
+						assert.equal(res.contents.length, 1);
+					} else {
+						assert.equal(res.contents.length, 2);
+						assert.equal(expectedDocumentation, (<{ language: string; value: string }>res.contents[0]).value);
+					}
+					assert.equal(expectedSignature, (<{ language: string; value: string }>res.contents[res.contents.length-1]).value);
 				})
 			);
 			return Promise.all(promises);


### PR DESCRIPTION
This patch enables godoc provided documentation on function hover.

![capture](https://cloud.githubusercontent.com/assets/312529/17600652/c9781e94-6004-11e6-999f-d39fc2b2a387.PNG)


I have no idea why this was implemented but not enabled. Was there any reason?
This may not be desirable since it runs two programs on hover, and can be improved in a followup PR to use gogetdoc. That said, these processes are called everytime the developer writes a function call, which happens (at least for me) way less often than hovering a method.

It's also better than the documentation on parenthesis open, since it is not truncated.
Note that this does not enable the godoc in resolveCompletionItem, that may come in another PR :)

Fixes #87 