### PR TITLE
readme: more info about the linter features

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ This extension adds rich language support for the Go language to VS Code, includ
 
 ## Using
 
-First, you will need to install Visual Studio Code `0.10`. In the command palette (`cmd-shift-p`) select `Install Extension` and choose `Go`.  
+First, you will need to install Visual Studio Code. Then, in the command palette (`cmd-shift-p`) select `Install Extension` and choose `Go`.
 
 In a terminal window with the GOPATH environment variable set to the GOPATH you want to work on, launch `code`.  Open your GOPATH folder or any subfolder you want to work on, then open a `.go` file to start editing.  You should see `Analysis Tools Missing` in the bottom right, clicking this will offer to install all of the Go tooling needed for the extension to support its full feature set.  See the [Tools](#tools) section below for more details.
 
-_Note_: Users may want to consider turning `Auto Save` on in Visual Studio Code (`"files.autoSave": "afterDelay"`) when using this extension.  Many of the Go tools work only on saved files, and error reporting will be more interactive with `Auto Save` turned on. If you do turn `Auto Save` on, you may also want to turn format-on-save off (`"go.formatOnSave": "false"`), so that it is not triggered while typing. 
+_Note_: Users may want to consider turning `Auto Save` on in Visual Studio Code (`"files.autoSave": "afterDelay"`) when using this extension.  Many of the Go tools work only on saved files, and error reporting will be more interactive with `Auto Save` turned on. If you do turn `Auto Save` on, you may also want to turn format-on-save off (`"go.formatOnSave": "false"`), so that it is not triggered while typing.
 
 _Note 2_:  This extension uses `gocode` to provide completion lists as you type. To provide fresh results, including against not-yet-built dependencies, the extension uses `gocode`'s `autobuild=true` setting. If you experience any performance issues with autocomplete, you should try setting `"go.gocodeAutoBuild": false` in your VS Code settings.
 
@@ -45,6 +45,7 @@ The following Visual Studio Code settings are available for the Go extension.  T
 	"go.vetOnSave": true,
 	"go.buildTags": "",
 	"go.buildFlags": [],
+	"go.lintTool": "golint",
 	"go.lintFlags": [],
 	"go.vetFlags": [],
 	"go.coverOnSave": false,
@@ -57,6 +58,35 @@ The following Visual Studio Code settings are available for the Go extension.  T
 }
 ```
 
+### Linter
+
+A linter is a tool giving coding style feedback and suggestions.
+By default this extension uses the official [golint](https://github.com/golang/lint) as a linter.
+
+You can change the default linter and use the more advanced [Go Meta Linter](https://github.com/alecthomas/gometalinter).
+Note that you need to install the package manually: `go get -u github.com/alecthomas/gometalinter`
+and edit your configuration (set the `go.lintTool` value to "gometalinter").
+
+Go meta linter uses a collection of various linters and those linters also need to be installed manually.
+If one of the tool is available, it will be used by default (`golint` for instance is still run by default).
+
+Some of the very useful linter tools:
+* [errcheck](https://github.com/kisielk/errcheck) checks for unchecked errors in your code.
+* [varcheck](https://github.com/opennota/check) finds unused global variables and constants.
+* [deadcode](https://github.com/tsenart/deadcode) finds unused code.
+
+If you wish to install all the supported linter tools, gometalinter provides you with an installer:
+`gometalinter --install`
+
+If you want to run only specific linters (some linters are slow), you can modify your configuration to specify them:
+
+```javascript
+  "go.lintFlags": ["--disable-all", "--enable=errcheck"],
+```
+
+Finally, the result of those linters will show right in the code (locations with suggestions will be underlined),
+as well as in the output pane.
+
 ### Commands
 
 In addition to integrated editing features, the extension also provides several commands in the Command Palette for working with Go files:
@@ -64,7 +94,7 @@ In addition to integrated editing features, the extension also provides several 
 * `Go: Add Import` to add an import from the list of packages in your Go context
 * `Go: Current GOPATH` to see your currently configured GOPATH
 * `Go: Run test at cursor` to run a test at the current cursor position in the active document
-* `Go: Run tests in current package` to run all tests in the package containing the active document 
+* `Go: Run tests in current package` to run all tests in the package containing the active document
 * `Go: Run tests in current file` to run all tests in the current active document
 
 ### _Optional_: Debugging
@@ -124,8 +154,8 @@ Then, create a remote debug configuration in VS Code `launch.json`.
 }
 ```
 
-When you launch the debugger with this new `Remote` target selected, VS Code will send debugging 
-commands to the `dlv` server you started previously instead of launching it's own `dlv` instance against your app. 
+When you launch the debugger with this new `Remote` target selected, VS Code will send debugging
+commands to the `dlv` server you started previously instead of launching it's own `dlv` instance against your app.
 
 The above example runs both the headless `dlv` server and the VS Code debugger locally on the same machine.  For an
 example of running these on different hosts, see the example of debugging a process running in a docker host at https://github.com/lukehoban/webapp-go/tree/debugging.
@@ -142,12 +172,12 @@ cd ~
 git clone https://github.com/Microsoft/vscode-go
 cd vscode-go
 npm install
-code . 
+code .
 ```
 
 You can now go to the Debug viewlet and select `Launch Extension` then hit run (`F5`).
 
-In the `[Extension Development Host]` instance, open your GOPATH folder.  
+In the `[Extension Development Host]` instance, open your GOPATH folder.
 
 You can now hit breakpoints and step through the extension.
 
@@ -157,7 +187,7 @@ To debug the debugger, see [the debugAdapter readme](src/debugAdapter/Readme.md)
 
 ## Tools
 
-The extension uses the following tools, installed in the current GOPATH.  If any tools are missing, you will see an "Analysis Tools Missing" warning in the bottom right corner of the editor.  Clicking it will offer to install the missing tools for you. 
+The extension uses the following tools, installed in the current GOPATH.  If any tools are missing, you will see an "Analysis Tools Missing" warning in the bottom right corner of the editor.  Clicking it will offer to install the missing tools for you.
 
 - gocode: `go get -u -v github.com/nsf/gocode`
 - godef: `go get -u -v github.com/rogpeppe/godef`


### PR DESCRIPTION
I didn't realize that a lot of the great go tools were already supported thanks to gometalinter. I was particularly interested in running `errcheck` on save (it verifies that all errors are being handled).  The linter change wasn't really documented and I didn't even realize that by switching linter I would get access to all these amazing tools.

This PR is a simple README update that explains what is a linter, how to change it and how to setup/customize gometalinter.

cc @egamma 