### PR TITLE
provide a command to install/update the go dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
         "command": "go.import.add",
         "title": "Go: Add Import",
         "description": "Add an import declaration"
+      },
+      {
+        "command": "go.tools.install",
+        "title": "Go: Install Tools",
+        "description": "install/update the required go packages"
       }
     ],
     "debuggers": [

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -26,6 +26,10 @@ let tools: { [key: string]: string } = {
 	'gorename': 'golang.org/x/tools/cmd/gorename'
 };
 
+export function installAllTools() {
+	installTools(Object.keys(tools));
+}
+
 export function promptForMissingTool(tool: string) {
 	vscode.window.showInformationMessage(`The "${tool}" command is not available.  Use "go get -v ${tools[tool]}" to install.`, 'Install All', 'Install').then(selected => {
 		if (selected === 'Install') {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -26,6 +26,7 @@ import { showHideStatus } from './goStatus';
 import { coverageCurrentPackage, getCodeCoverage, removeCodeCoverage } from './goCover';
 import { testAtCursor, testCurrentPackage, testCurrentFile } from './goTest';
 import { addImport } from './goImport';
+import { installAllTools } from './goInstallTools';
 
 let diagnosticCollection: vscode.DiagnosticCollection;
 
@@ -77,6 +78,10 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.import.add', (arg: string) => {
 		return addImport(typeof arg === 'string' ? arg : null);
+	}));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.tools.install', () => {
+		installAllTools();
 	}));
 
 	vscode.languages.setLanguageConfiguration(GO_MODE.language, {
@@ -178,7 +183,7 @@ function startBuildOnSaveWatcher(subscriptions: vscode.Disposable[]) {
 
 	// TODO: This is really ugly.  I'm not sure we can do better until
 	// Code supports a pre-save event where we can do the formatting before
-	// the file is written to disk.	
+	// the file is written to disk.
 	let ignoreNextSave = new WeakSet<vscode.TextDocument>();
 
 	vscode.workspace.onDidSaveTextDocument(document => {
@@ -200,7 +205,7 @@ function startBuildOnSaveWatcher(subscriptions: vscode.Disposable[]) {
 			}).then(() => {
 				ignoreNextSave.delete(document);
 			}, () => {
-				// Catch any errors and ignore so that we still trigger 
+				// Catch any errors and ignore so that we still trigger
 				// the file save.
 			});
 		}


### PR DESCRIPTION
Once the dependencies have been found once, users cannot trigger a reinstall or update of the go pkgs used by vscode. This PR provides a command to installer or update all tools at once.