### PR TITLE
Do not cache bin path for tools when they are not found. Fixes #456

### DIFF
--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -50,7 +50,6 @@ export function getBinPath(binname: string) {
 	}
 
 	// Else return the binary name directly (this will likely always fail downstream) 
-	binPathCache[binname] = binname;
 	return binname;
 }
 


### PR DESCRIPTION
When the bin path for tools are not found, the tool name is cached as bin path. Therefore, even after the tools get installed, the right path to the tools are never used.