### PR TITLE
Fix the executable name so ".exe" doesn't end up in the install warning

### DIFF
--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -59,7 +59,7 @@ export class Formatter {
 			cp.execFile(formatCommandBinPath, [...formatFlags, filename], {}, (err, stdout, stderr) => {
 				try {
 					if (err && (<any>err).code === 'ENOENT') {
-						promptForMissingTool(formatCommandBinPath);
+						promptForMissingTool(this.formatCommand);
 						return resolve(null);
 					}
 					if (err) return reject('Cannot format due to syntax errors.');


### PR DESCRIPTION
On windows, when the format tool doesn't exist, vscode-go will show ".exe" at the end of the command, breaking the installation.

![capture](https://cloud.githubusercontent.com/assets/312529/18139323/3ab108f8-6fb1-11e6-9eec-f4e00001539c.PNG)


This patch fixes it.