### PR TITLE
Added go format flags to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following Visual Studio Code settings are available for the Go extension.  T
 	"go.useCodeSnippetsOnFunctionSuggest": false,
 	"go.formatOnSave": true,
 	"go.formatTool": "goreturns",
+	"go.formatFlags": [],
 	"go.goroot": "/usr/local/go",
 	"go.gopath": "/Users/lukeh/go",
 	"go.gocodeAutoBuild": false


### PR DESCRIPTION
Quick change to the README to include the go format options, as found in:
https://github.com/Microsoft/vscode-go/blob/dca9bef794ba1a40f42a1dff63ab5fe9658e4652/package.json#L270