### PR TITLE
Add a command to execute the previous test

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "onCommand:go.test.cursor",
     "onCommand:go.test.package",
     "onCommand:go.test.file",
+    "onCommand:go.test.previous",
     "onCommand:go.test.coverage"
   ],
   "main": "./out/src/goMain",
@@ -95,6 +96,11 @@
         "command": "go.test.file",
         "title": "Go: Test (file)",
         "description": "Runs all unit tests in the current file."
+      },
+      {
+        "command": "go.test.previous",
+        "title": "Go: Test Previous",
+        "description": "Re-runs the last executed test."
       },
       {
         "command": "go.test.coverage",

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -24,7 +24,7 @@ import { updateGoPathGoRootFromConfig, setupGoPathAndOfferToInstallTools } from 
 import { GO_MODE } from './goMode';
 import { showHideStatus } from './goStatus';
 import { coverageCurrentPackage, getCodeCoverage, removeCodeCoverage } from './goCover';
-import { testAtCursor, testCurrentPackage, testCurrentFile } from './goTest';
+import { testAtCursor, testCurrentPackage, testCurrentFile, testPrevious } from './goTest';
 import { addImport } from './goImport';
 import { installAllTools } from './goInstallTools';
 
@@ -70,6 +70,10 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.file', () => {
 		let goConfig = vscode.workspace.getConfiguration('go');
 		testCurrentFile(goConfig['testTimeout']);
+	}));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.previous', () => {
+		testPrevious();
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.coverage', () => {

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -31,6 +31,10 @@ interface TestConfig {
 	functions?: string[];
 }
 
+// lastTestConfig holds a reference to the last executed TestConfig which allows
+// the last test to be easily re-executed.
+let lastTestConfig: TestConfig;
+
 /**
 * Executes the unit test at the primary cursor using `go test`. Output
 * is sent to the 'Go' channel.
@@ -112,12 +116,28 @@ export function testCurrentFile(timeout: string) {
 }
 
 /**
+ * Runs the previously executed test.
+ */
+export function testPrevious() {
+	let editor = vscode.window.activeTextEditor;
+	if (!lastTestConfig) {
+		vscode.window.showInformationMessage('No test has been recently executed.');
+		return;
+	}
+	goTest(lastTestConfig).then(null, err => {
+		console.error(err);
+	});
+}
+
+/**
  * Runs go test and presents the output in the 'Go' channel.
  *
  * @param config the test execution configuration.
  */
 function goTest(config: TestConfig): Thenable<boolean> {
 	return new Promise<boolean>((resolve, reject) => {
+		// Remember this config as the last executed test.
+		lastTestConfig = config;
 		outputChannel.clear();
 		outputChannel.show(2);
 		let buildFlags: string[] = vscode.workspace.getConfiguration('go')['buildFlags'];


### PR DESCRIPTION
Add a `go.test.previous` command which runs the last test which was
executed.