### PR TITLE
Don't use vscode config directly in tests

### DIFF
--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -129,8 +129,9 @@ encountered.
 	});
 
 	test('Gometalinter error checking', (done) => {
-		let config = vscode.workspace.getConfiguration('go');
-		config['lintTool'] = 'gometalinter';
+		let config = Object.create(vscode.workspace.getConfiguration('go'), {
+			'lintTool': { value: 'gometalinter' }
+		});
 		let expected = [
 			{ line: 7, severity: 'warning', msg: 'Print2 is unused (deadcode)' },
 			{ line: 11, severity: 'warning', msg: 'error return value not checked (undeclared name: prin) (errcheck)' },


### PR DESCRIPTION
Fixes #479.  A little bit of a hack - but really something that should be solved in VSCode itself.