### PR TITLE
Enable testflags via settings and keyboard bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,6 +393,17 @@
           "default": "",
           "description": "Location to install the Go tools that the extension depends on if you don't want them in your GOPATH."
         },
+        "go.testFlags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "default": null,
+          "description": "Flags to pass to `go test`. If null, then buildFlags will be used."
+        },
         "go.useLanguageServer": {
           "type": "boolean",
           "default": false,

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -84,19 +84,19 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		vscode.window.showInformationMessage('Current GOPATH:' + gopath);
 	}));
 
-	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.cursor', () => {
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.cursor', (args) => {
 		let goConfig = vscode.workspace.getConfiguration('go');
-		testAtCursor(goConfig);
+		testAtCursor(goConfig, args);
 	}));
 
-	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.package', () => {
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.package', (args) => {
 		let goConfig = vscode.workspace.getConfiguration('go');
-		testCurrentPackage(goConfig);
+		testCurrentPackage(goConfig, args);
 	}));
 
-	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.file', () => {
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.file', (args) => {
 		let goConfig = vscode.workspace.getConfiguration('go');
-		testCurrentFile(goConfig);
+		testCurrentFile(goConfig, args);
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.previous', () => {


### PR DESCRIPTION
(Updated on 21/1/2017)

Fixes #401 and #683

Added a new setting `go.testFlags`
    - If null, then all the test commands will continue to use the `go.buildFlags` and '-v' while running `go test` as always.
    - Else, the provided flags will be used by the test commands  instead of `go.buildFlags`  while running `go test`

The usage of `go.testTimeout` and `go.buildTags` will continue to remain as is.

Users can also customize the flags and have keyboard shortcuts for the same.

```json
{
        "key": "ctrl+shift+t",
        "command": "go.test.file",
        "args": {
            "flags": ["-short"]
        },
        "when": "editorTextFocus"
}
```


