### PR TITLE
Send test output to a distinct output channel

### DIFF
--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -11,7 +11,8 @@ import vscode = require('vscode');
 import util = require('util');
 import { getGoRuntimePath } from './goPath';
 import { GoDocumentSymbolProvider } from './goOutline';
-import { outputChannel } from './goStatus';
+
+let outputChannel = vscode.window.createOutputChannel('Go Tests');
 
 /**
  * Input to goTest.


### PR DESCRIPTION
Send Go test output to a dedicated output channel. Re-using the "Go"
channel from the status component causes a lot of confusing
interspersed unrelated output, and the test command often clears the
"Go" channel, obliterating things users might want to see.