### PR TITLE
minor fix hover doc unexcept line wrapping!

### DIFF
--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -49,7 +49,7 @@ export function definitionLocation(document: vscode.TextDocument, position: vsco
 				let pkgPath = path.dirname(file);
 				let definitionInformation: GoDefinitionInformtation = {
 					file: file,
-					line: +line - 1,
+					line: + line - 1,
 					col: + col - 1,
 					lines,
 					doc: undefined
@@ -74,6 +74,7 @@ export function definitionLocation(document: vscode.TextDocument, position: vsco
 							break;
 						}
 					}
+					doc = doc.replace('\n', ' ');
 					if (doc !== '') {
 						definitionInformation.doc = doc;
 					}

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -21,7 +21,7 @@ interface SemVersion {
 
 let goVersion: SemVersion = null;
 
-function getTools(): { [key: string]: string }  {
+function getTools(): { [key: string]: string } {
 	let goConfig = vscode.workspace.getConfiguration('go');
 	let tools: { [key: string]: string } = {
 		'gocode': 'github.com/nsf/gocode',


### PR DESCRIPTION
Due to go source doc have some newline. It's may be conflict with the auto wrap in vscode hover action. So replace `\n` with ` ` to fix this.
If source doc is 
```
This code is a balblabla value. And
other
```
Before:
```
This code is a balblabla
value. And 
other
```
After:
```
This code is a balblabla
value. And other
```
