### PR TITLE
Fix signature / hover provider (e.g. for struct fields)

### DIFF
--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -73,16 +73,17 @@ function addLinesToDefinition(defInfo: GoDefinitionInformtation, lines: string[]
 	if (line.startsWith('func') || !line.match('\{\s*$')) {
 		line = line.replace(/\s*\{\s*$/, '');
 		defInfo.lines = [line];
-		return
-	}
-	// Handle definitions with multiple lines
-	defInfo.lines = [];
-	for (let i = defInfo.line; i < lines.length; i++) {
-		defInfo.lines.push(lines[i]);
-		if (lines[i].trim() == '}') {
-			break;
+	} else {
+		// Handle definitions with multiple lines
+		defInfo.lines = [];
+		for (let i = defInfo.line; i < lines.length; i++) {
+			defInfo.lines.push(lines[i]);
+			if (lines[i].trim() == '}') {
+				break;
+			}
 		}
 	}
+	defInfo.lines = unindent(defInfo.lines);
 }
 
 function addDocToDefinition(defInfo: GoDefinitionInformtation, lines: string[]) {
@@ -108,6 +109,24 @@ function addDocToDefinition(defInfo: GoDefinitionInformtation, lines: string[]) 
 	// trim leading '// ' or '//' per line
 	doc = doc.replace(/^\/\//gm, '');
 	defInfo.doc = doc
+}
+
+// Uniformly trims leadings tabs.
+function unindent(lines: string[]): string[] {
+	// find the minimum amount of leading tabs
+	let minWhitespace = 999;
+	for (let i = 0; i < lines.length; i++) {
+		let l = /^\t*/.exec(lines[i])[0].length;
+		if (l < minWhitespace) {
+			minWhitespace = l;
+		}
+	}
+	// trim the minimum amount from all lines
+	let out = [];
+	for (let i = 0; i < lines.length; i++) {
+		out.push(lines[i].substr(minWhitespace));
+	}
+	return out;
 }
 
 export class GoDefinitionProvider implements vscode.DefinitionProvider {

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -27,29 +27,29 @@ export function definitionLocation(document: vscode.TextDocument, position: vsco
 		let wordAtPosition = document.getWordRangeAtPosition(position);
 		let offset = byteOffsetAt(document, position);
 
-		let godef = getBinPath('godef');
+		let guru = getBinPath('guru');
 
-		// Spawn `godef` process
-		let p = cp.execFile(godef, ['-t', '-i', '-f', document.fileName, '-o', offset.toString()], {}, (err, stdout, stderr) => {
+		// Spawn `guru` process
+		let p = cp.execFile(guru, ['definition', document.fileName + ':#' + offset.toString()], {}, (err, stdout, stderr) => {
 			try {
 				if (err && (<any>err).code === 'ENOENT') {
-					promptForMissingTool('godef');
+					promptForMissingTool('guru');
 				}
 				if (err) return resolve(null);
 				let result = stdout.toString();
 				let lines = result.split('\n');
-				let match = /(.*):(\d+):(\d+)/.exec(lines[0]);
+				let match = /(.*):(\d+):(\d+): defined here as (.*)$/.exec(lines[0]);
 				if (!match) {
 					// TODO: Gotodef on pkg name:
 					// /usr/local/go/src/html/template\n
 					return resolve(null);
 				}
-				let [_, file, line, col] = match;
+				let [_, file, line, col, sig] = match;
 				let definitionInformation: GoDefinitionInformtation = {
 					file: file,
 					line: +line - 1,
 					col: + col - 1,
-					lines,
+					lines: [sig],
 					doc: undefined
 				};
 				if (includeDocs) {

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -53,7 +53,9 @@ export function definitionLocation(document: vscode.TextDocument, position: vsco
 					doc: undefined
 				};
 				if (includeDocs) {
-					addDocToDefinition(definitionInformation);
+					let source = fs.readFileSync(definitionInformation.file, 'utf8');
+					let lines = source.split('\n');
+					addDocToDefinition(definitionInformation, lines);
 				}
 				return resolve(definitionInformation);
 			} catch (e) {
@@ -64,9 +66,7 @@ export function definitionLocation(document: vscode.TextDocument, position: vsco
 	});
 }
 
-function addDocToDefinition(defInfo: GoDefinitionInformtation) {
-	let source = fs.readFileSync(defInfo.file, 'utf8');
-	let lines = source.split('\n');
+function addDocToDefinition(defInfo: GoDefinitionInformtation, lines: string[]) {
 	let doc = '';
 	// gather comments above the definition
 	for (let i = defInfo.line - 1; i >= 0; i--) {

--- a/src/goExtraInfo.ts
+++ b/src/goExtraInfo.ts
@@ -22,12 +22,8 @@ export class GoHoverProvider implements HoverProvider {
 			lines = lines.filter(line => line.length !== 0);
 			if (lines.length > 10) lines[9] = '...';
 			let text;
-			if (lines.length > 1) {
-				text = lines.slice(1, 10).join('\n');
-				text = text.replace(/\n+$/, '');
-			} else {
-				text = lines[0];
-			}
+			text = lines.slice(0, 10).join('\n');
+			text = text.replace(/\n+$/, '');
 			let hoverTexts: MarkedString[] = [];
 			if (definitionInfo.doc != null) {
 				hoverTexts.push(definitionInfo.doc);

--- a/src/goExtraInfo.ts
+++ b/src/goExtraInfo.ts
@@ -13,12 +13,6 @@ export class GoHoverProvider implements HoverProvider {
 		return definitionLocation(document, position, true).then(definitionInfo => {
 			if (definitionInfo == null) return null;
 			let lines = definitionInfo.lines;
-			lines = lines.map(line => {
-				if (line.indexOf('\t') === 0) {
-					line = line.slice(1);
-				}
-				return line.replace(/\t/g, '  ');
-			});
 			lines = lines.filter(line => line.length !== 0);
 			if (lines.length > 10) lines[9] = '...';
 			let text;


### PR DESCRIPTION
This fixes #440.

`guru` is used to find the position of any definition instead of `godef` as it's more reliable.
The definition lines are read straight from source.

Also `godoc` is no longer used to fetch the documentation, because querying it did not work in all cases.

This is my first time working with TypeScript, so feel free to nitpick. I've tested all I could think of and it consistently provides useful hover information to me.
