### PR TITLE
Add setting to control use of -d flag by the formatting tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,6 +296,11 @@
           "default": [],
           "description": "Flags to pass to format tool (e.g. ['-s'])"
         },
+        "go.useDiffForFormatting": {
+          "type": "boolean",
+          "default": true,
+          "description": "Run the formatting tools with the -d flag"
+        },
         "go.useCodeSnippetsOnFunctionSuggest": {
           "type": "boolean",
           "default": false,

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -28,7 +28,7 @@ export class Formatter {
 
 			let formatCommandBinPath = getBinPath(this.formatCommand);
 			let formatFlags = vscode.workspace.getConfiguration('go')['formatFlags'] || [];
-			let canFormatToolUseDiff = isDiffToolAvailable();
+			let canFormatToolUseDiff = vscode.workspace.getConfiguration('go')['useDiffForFormatting'] && isDiffToolAvailable();
 			if (canFormatToolUseDiff) {
 				formatFlags.push('-d');
 			}


### PR DESCRIPTION
For some users using `-d` while formatting is not giving any results.
This PR adds a setting that can be used to disable the use of `-d` while formatting to unblock such users, until we find the problem with the formatting tool