### PR TITLE
Fix for when Go is used from source without release tag

### DIFF
--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -8,9 +8,9 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import { getBinPath } from './goPath';
-import { parseFilePrelude } from './util';
+import { parseFilePrelude, isVendorSupported } from './util';
 import { documentSymbols } from './goOutline';
-import { promptForMissingTool, isVendorSupported } from './goInstallTools';
+import { promptForMissingTool } from './goInstallTools';
 import path = require('path');
 
 export function listPackages(excludeImportedPkgs: boolean = false): Thenable<string[]> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,8 +3,18 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------*/
 
-import { TextDocument, Position } from 'vscode';
+import { TextDocument, Position, window } from 'vscode';
 import path = require('path');
+import { getGoRuntimePath } from './goPath';
+import cp = require('child_process');
+
+export interface SemVersion {
+	major: number;
+	minor: number;
+}
+
+let goVersion: SemVersion = null;
+let vendorSupport: boolean = null;
 
 export function byteOffsetAt(document: TextDocument, position: Position): number {
 	let offset = document.offsetAt(position);
@@ -94,4 +104,60 @@ export function canonicalizeGOPATHPrefix(filename: string): string {
 		}
 	}
 	return filename;
+}
+
+/**
+ * Gets version of Go based on the output of the command `go version`. 
+ * Returns null if go is being used from source/tip in which case `go version` will not return release tag like go1.6.3
+ */
+export function getGoVersion(): Promise<SemVersion> {
+	let goRuntimePath = getGoRuntimePath();
+
+	if (!goRuntimePath) {
+		window.showInformationMessage('Cannot find "go" binary. Update PATH or GOROOT appropriately');
+		return Promise.resolve(null);
+	}
+
+	if (goVersion) {
+		return Promise.resolve(goVersion);
+	}
+	return new Promise<SemVersion>((resolve, reject) => {
+		cp.execFile(goRuntimePath, ['version'], {}, (err, stdout, stderr) => {
+			let matches = /go version go(\d).(\d).*/.exec(stdout);
+			if (matches) {
+				goVersion = {
+					major: parseInt(matches[1]),
+					minor: parseInt(matches[2])
+				};
+			}
+			return resolve(goVersion);
+		});
+	});
+}
+
+/**
+ * Returns boolean denoting if current version of Go supports vendoring
+ */
+export function isVendorSupported(): Promise<boolean> {
+	if (vendorSupport != null) {
+		return Promise.resolve(vendorSupport);
+	}
+	return getGoVersion().then(version => {
+		if (!version) {
+			return true;
+		}
+
+		switch (version.major) {
+			case 0:
+				vendorSupport = false;
+				break;
+			case 1:
+				vendorSupport = (version.minor > 5 || (version.minor  === 5 && process.env['GO15VENDOREXPERIMENT'] === '1')) ? true : false;
+				break;
+			default:
+				vendorSupport = true;
+				break;
+		}
+		return vendorSupport;
+	});
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -144,7 +144,7 @@ export function isVendorSupported(): Promise<boolean> {
 	}
 	return getGoVersion().then(version => {
 		if (!version) {
-			return true;
+			return process.env['GO15VENDOREXPERIMENT'] === '0' ? false : true;
 		}
 
 		switch (version.major) {
@@ -152,7 +152,7 @@ export function isVendorSupported(): Promise<boolean> {
 				vendorSupport = false;
 				break;
 			case 1:
-				vendorSupport = (version.minor > 5 || (version.minor  === 5 && process.env['GO15VENDOREXPERIMENT'] === '1')) ? true : false;
+				vendorSupport = (version.minor > 6 || ((version.minor === 5 || version.minor === 6) && process.env['GO15VENDOREXPERIMENT'] === '1')) ? true : false;
 				break;
 			default:
 				vendorSupport = true;

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -15,12 +15,11 @@ import cp = require('child_process');
 import { getEditsFromUnifiedDiffStr, getEdits } from '../src/diffUtils';
 import jsDiff = require('diff');
 import { testCurrentFile } from '../src/goTest';
-import { getGoVersion } from '../src/goInstallTools';
+import { getGoVersion, isVendorSupported } from '../src/util';
 import { documentSymbols } from '../src/goOutline';
 import { listPackages } from '../src/goImport';
 import { generateTestCurrentFile, generateTestCurrentPackage } from '../src/goGenerateTests';
 import { getBinPath } from '../src/goPath';
-import { isVendorSupported } from '../src/goInstallTools';
 
 suite('Go Extension Tests', () => {
 	let gopath = process.env['GOPATH'];


### PR DESCRIPTION
Fixes #545 
- Moved `getGoVersion`, `SemVersion` and `isVendorSupported` from `goInstallTools.ts` to `util.ts`
- check for GO15VENDOREXPERIMENT env var is added for Go 1.6 because

> Go 1.5 introduced experimental support for vendoring, enabled by setting the GO15VENDOREXPERIMENT environment variable to 1. Go 1.6 keeps the vendoring support, no longer considered experimental, and enables it by default. It can be disabled explicitly by setting the GO15VENDOREXPERIMENT environment variable to 0. Go 1.7 will remove support for the environment variable.

- If no release tag is found and GO15VENDOREXPERIMENT is explicitly set to 0, `isVendorSupported` will return false. 
- If no release tag is found and GO15VENDOREXPERIMENT is not explicitly set to 0, `isVendorSupported` will return true. 
- If release tag is not found, `golint` and `gotests` would be installed assuming that the Go version supports them. If not, then error messages from running these tools will bubble up to the user
