### PR TITLE
Use -imports-only option from go-outline

### DIFF
--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -104,8 +104,9 @@ export function listPackages(excludeImportedPkgs: boolean = false): Thenable<str
  * @param fileName File system path of the file whose imports need to be returned
  * @returns Array of imported package paths wrapped in a promise
  */
-export function getImports(fileName: string): Promise<string[]> {
-	return documentSymbols(fileName).then(symbols => {
+function getImports(fileName: string): Promise<string[]> {
+	let options = { fileName: fileName, importsOnly: true };
+	return documentSymbols(options).then(symbols => {
 		if (!symbols || !symbols[0] || !symbols[0].children) {
 			return [];
 		}

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -21,6 +21,7 @@ interface SemVersion {
 
 let goVersion: SemVersion = null;
 let vendorSupport: boolean = null;
+let updatesDeclinedTools: string[] = [];
 
 function getTools(): { [key: string]: string }  {
 	let goConfig = vscode.workspace.getConfiguration('go');
@@ -76,7 +77,20 @@ export function promptForMissingTool(tool: string) {
 			}
 		});
 	});
+}
 
+export function promptForUpdatingTool(tool: string) {
+	// If user has declined to update, then don't prompt
+	if (updatesDeclinedTools.indexOf(tool) > -1) {
+		return;
+	}
+	vscode.window.showInformationMessage(`The Go extension is better with the latest version of "${tool}". Use "go get -u -v ${getTools()[tool]}" to update`, 'Update').then(selected => {
+		if (selected === 'Update') {
+			installTools([tool]);
+		} else {
+			updatesDeclinedTools.push(tool);
+		}
+	});
 }
 
 /**

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -189,7 +189,7 @@ encountered.
 
 	test('Test Generate unit tests squeleton for file', (done) => {
 		getGoVersion().then(version => {
-			if (version.major === 1 && version.minor === 5) {
+			if (version.major === 1 && version.minor < 6) {
 				// gotests is not supported in Go 1.5, so skip the test
 				return Promise.resolve();
 			}
@@ -211,7 +211,7 @@ encountered.
 
 	test('Test Generate unit tests squeleton for package', (done) => {
 		getGoVersion().then(version => {
-			if (version.major === 1 && version.minor === 5) {
+			if (version.major === 1 && version.minor < 6) {
 				// gotests is not supported in Go 1.5, so skip the test
 				return Promise.resolve();
 			}


### PR DESCRIPTION
We use `go-outline` tool to get list of imported packages in the current file. `go-outline` internally parses the file to return all symbols. But since we need only imports, the whole file need not be parsed. https://github.com/lukehoban/go-outline/pull/4 added the option to parse only the initial part of the file that contains the imports.
This PR uses this option.