### PR TITLE
Select a random port to debug on

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -10,6 +10,7 @@ import { basename, dirname } from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { Client, RPCConnection } from 'json-rpc2';
 import { getBinPath } from '../goPath';
+import {random} from './../util';
 
 require('console-stamp')(console);
 
@@ -214,7 +215,7 @@ class Delve {
 
 			function connectClient(port: number, host: string) {
 				// Add a slight delay to avoid issues on Linux with
-				// Delve failing calls made shortly after connection. 
+				// Delve failing calls made shortly after connection.
 				setTimeout(() => {
 					let client = Client.$create(port, host);
 					client.connectSocket((err, conn) => {
@@ -320,7 +321,7 @@ class GoDebugSession extends DebugSession {
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
 		// Launch the Delve debugger on the program
 		let remotePath = args.remotePath || '';
-		let port = args.port || 2345;
+		let port = args.port || random(2000, 50000);
 		let host = args.host || '127.0.0.1';
 
 		if (remotePath.length > 0) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -97,5 +97,5 @@ export function canonicalizeGOPATHPrefix(filename: string): string {
 }
 
 export function random(low: number, high: number): number {
-    return Math.floor(Math.random() * (high - low) + low);
+	return Math.floor(Math.random() * (high - low) + low);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -49,7 +49,7 @@ export function parseFilePrelude(text: string): Prelude {
 }
 
 // Takes a Go function signature like:
-//     (foo, bar string, baz number) (string, string) 
+//     (foo, bar string, baz number) (string, string)
 // and returns an array of parameter strings:
 //     ["foo", "bar string", "baz string"]
 // Takes care of balancing parens so to not get confused by signatures like:
@@ -94,4 +94,8 @@ export function canonicalizeGOPATHPrefix(filename: string): string {
 		}
 	}
 	return filename;
+}
+
+export function random(low: number, high: number): number {
+    return Math.floor(Math.random() * (high - low) + low);
 }


### PR DESCRIPTION
Fix #552.

This is copied from node-debug/node-debug2. It doesn't check whether a port is already in use, but... there are lots of ports out there. Without this, debugging two Go processes with a 'composite' launch config won't work out of the box without specifying ports manually.