### PR TITLE
Add Formatters to category list

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "Languages",
     "Snippets",
     "Linters",
-    "Debuggers"
+    "Debuggers",
+    "Formatters"
   ],
   "galleryBanner": {
     "color": "#CFB69A",


### PR DESCRIPTION
The Marketplace has introduce a new category called formatters for extensions that add formatting.