### PR TITLE
Preserve focus while running tests

### DIFF
--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -141,7 +141,7 @@ function goTest(testconfig: TestConfig): Thenable<boolean> {
 		// Remember this config as the last executed test.
 		lastTestConfig = testconfig;
 		outputChannel.clear();
-		outputChannel.show(2);
+		outputChannel.show(2, true);
 
 		let buildFlags: string[] = testconfig.goConfig['buildFlags'];
 		let buildTags: string = testconfig.goConfig['buildTags'];


### PR DESCRIPTION
Implementing the same that was attempted in #388 which at the time failed because the Go extension was using a very old vscode.d.ts
