### PR TITLE
pkg suggestions to appear after gocode suggestions

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -184,6 +184,8 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 								}
 								item.insertText = suggest.name + '(' + paramSnippets.join(', ') + ') {{}}';
 							}
+							// Add same sortText to all suggestions from gocode so that they appear before the unimported packages
+							item.sortText = 'a';
 							suggestions.push(item);
 						};
 					}
@@ -240,6 +242,8 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				command: 'go.import.add',
 				arguments: [pkgInfo.path]
 			};
+			// Add same sortText to the unimported packages so that they appear after the suggestions from gocode
+			item.sortText = 'z';
 			return item;
 		});
 		return completionItems;


### PR DESCRIPTION
Ever since we introduced importable packages as suggestions in the auto-complete, people have found it annoying that these package suggestions are interspersed among variables/function names etc.

Excerpt from Gitter:

> After last plugin update in autocompletion list I got list of all available packages, it's pretty cool but little annoying because variables with corresponding names appears in the end of a list. It would be nice to sort this list and show variables on top

This PR is to group all the package suggestions and make them appear AFTER the usual/normal suggestions from `gocode`.

