### PR TITLE
Dont allow import on vendored pkg from another project

### DIFF
--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -79,17 +79,18 @@ export function listPackages(excludeImportedPkgs: boolean = false): Thenable<str
 
 				// Check if current file and the vendor pkg belong to the same root project
 				// If yes, then vendor pkg can be replaced with its relative path to the "vendor" folder
+				// If not, then the vendor pkg should not be allowed to be imported.
 				if (vendorIndex > 0) {
 					let rootProjectForVendorPkg = path.join(currentWorkspace, pkg.substr(0, vendorIndex));
 					let relativePathForVendorPkg = pkg.substring(vendorIndex + magicVendorString.length);
 
 					if (relativePathForVendorPkg && currentFileDirPath.startsWith(rootProjectForVendorPkg)) {
 						pkgSet.add(relativePathForVendorPkg);
-						return;
 					}
+					return;
 				}
 
-				// pkg is not a vendor project or is a vendor project not belonging to current project
+				// pkg is not a vendor project
 				pkgSet.add(pkg);
 			});
 

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -491,4 +491,49 @@ encountered.
 			});
 		}).then(() => done(), done);
 	});
+
+	test('Vendor pkgs from other projects should not be allowed to import', (done) => {
+		// This test needs a go project that has vendor folder and vendor packages
+		// Since the Go extension takes a dependency on the godef tool at github.com/rogpeppe/godef
+		// which has vendor packages, we are using it here to test the "replace vendor packages with relative path" feature.
+		// If the extension ever stops depending on godef tool or if godef ever stops having vendor packages, then this test
+		// will fail and will have to be replaced with any other go project with vendor packages
+
+		let vendorSupportPromise = isVendorSupported();
+		let filePath = path.join(process.env['GOPATH'], 'src', 'github.com', 'lukehoban', 'go-outline', 'main.go');
+		let vendorPkgs = [
+			'github.com/rogpeppe/godef/vendor/9fans.net/go/acme',
+			'github.com/rogpeppe/godef/vendor/9fans.net/go/plan9',
+			'github.com/rogpeppe/godef/vendor/9fans.net/go/plan9/client'
+		];
+
+		vendorSupportPromise.then((vendorSupport: boolean) => {
+			let gopkgsPromise = new Promise<void>((resolve, reject) => {
+				cp.execFile(getBinPath('gopkgs'), [], (err, stdout, stderr) => {
+					let pkgs = stdout.split('\n').sort().slice(1);
+					if (vendorSupport) {
+						vendorPkgs.forEach(pkg => {
+							assert.equal(pkgs.indexOf(pkg) > -1, true, `Package not found by goPkgs: ${pkg}`);
+						});
+					}
+					return resolve();
+				});
+			});
+
+			let listPkgPromise: Thenable<void> = vscode.workspace.openTextDocument(vscode.Uri.file(filePath)).then(document => {
+				return vscode.window.showTextDocument(document).then(editor => {
+					return listPackages().then(pkgs => {
+						if (vendorSupport) {
+							vendorPkgs.forEach(pkg => {
+								assert.equal(pkgs.indexOf(pkg), -1, `Vendor package ${pkg} should not be shown by listPackages method`);
+							});
+						}
+						return Promise.resolve();
+					});
+				});
+			});
+
+			return Promise.all<void>([gopkgsPromise, listPkgPromise]);
+		}).then(() => done(), done);
+	});
 });


### PR DESCRIPTION
Fixes #598 

The functions `disallowVendor` and `disallowVendorVisibility` in https://golang.org/src/cmd/go/pkg.go make it clear that importing a vendor package from another project is not allowed in Go.