### PR TITLE
Due to issue #599, use gogetdoc instead of godef

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - npm install
   - npm run vscode:prepublish
   - go get -u -v github.com/nsf/gocode
-  - go get -u -v github.com/rogpeppe/godef
+  - go get -u -v github.com/zmb3/gogetdoc
   - if [[ "$(go version)" =~ "go version go1.5" ]]; then echo cannot get golint; else go get -u -v github.com/golang/lint/golint; fi
   - go get -u -v github.com/lukehoban/go-outline
   - go get -u -v sourcegraph.com/sqs/goreturns
@@ -32,8 +32,8 @@ install:
   - go get -u -v golang.org/x/tools/cmd/guru
   - go get -u -v github.com/alecthomas/gometalinter
   - go get -u -v github.com/cweill/gotests/...
-  - GO15VENDOREXPERIMENT=1 
-  - if [[ "$(go version)" =~ "go version go1.5" ]]; then echo skipping gometalinter; else gometalinter --install; fi 
+  - GO15VENDOREXPERIMENT=1
+  - if [[ "$(go version)" =~ "go version go1.5" ]]; then echo skipping gometalinter; else gometalinter --install; fi
 
 script:
   - npm run lint

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This extension adds rich language support for the Go language to VS Code, includ
 - Completion Lists (using `gocode`)
 - Signature Help (using `godoc`)
 - Snippets
-- Quick Info (using `godef`)
-- Goto Definition (using `godef`)
+- Quick Info (using `gogetdoc`)
+- Goto Definition (using `gogetdoc`)
 - Find References (using `guru`)
 - File outline (using `go-outline`)
 - Workspace symbol search (using `go-symbols`)
@@ -198,7 +198,7 @@ To debug the debugger, see [the debugAdapter readme](src/debugAdapter/Readme.md)
 The extension uses the following tools, installed in the current GOPATH.  If any tools are missing, you will see an "Analysis Tools Missing" warning in the bottom right corner of the editor.  Clicking it will offer to install the missing tools for you.
 
 - gocode: `go get -u -v github.com/nsf/gocode`
-- godef: `go get -u -v github.com/rogpeppe/godef`
+- gogetdoc: `go get -u -v github.com/zmb3/gogetdoc`
 - golint: `go get -u -v github.com/golang/lint/golint`
 - go-outline: `go get -u -v github.com/lukehoban/go-outline`
 - goreturns: `go get -u -v sourcegraph.com/sqs/goreturns`
@@ -211,7 +211,7 @@ The extension uses the following tools, installed in the current GOPATH.  If any
 To install them just paste and run:
 ```bash
 go get -u -v github.com/nsf/gocode
-go get -u -v github.com/rogpeppe/godef
+go get -u -v github.com/zmb3/gogetdoc
 go get -u -v github.com/golang/lint/golint
 go get -u -v github.com/lukehoban/go-outline
 go get -u -v sourcegraph.com/sqs/goreturns

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -7,7 +7,6 @@
 
 import vscode = require('vscode');
 import cp = require('child_process');
-import path = require('path');
 import { getBinPath } from './goPath';
 import { byteOffsetAt } from './util';
 import { promptForMissingTool } from './goInstallTools';
@@ -15,87 +14,65 @@ import { promptForMissingTool } from './goInstallTools';
 export interface GoDefinitionInformtation {
 	file: string;
 	line: number;
-	col: number;
-	lines: string[];
-	doc: string;
+	column: number;
+	docInfo: GoDocInfomation;
 }
 
 export function definitionLocation(document: vscode.TextDocument, position: vscode.Position, includeDocs = true): Promise<GoDefinitionInformtation> {
 	return new Promise<GoDefinitionInformtation>((resolve, reject) => {
-
 		let wordAtPosition = document.getWordRangeAtPosition(position);
 		let offset = byteOffsetAt(document, position);
-
-		let godef = getBinPath('godef');
-
-		// Spawn `godef` process
-		let p = cp.execFile(godef, ['-t', '-i', '-f', document.fileName, '-o', offset.toString()], {}, (err, stdout, stderr) => {
+		let gogetdoc = getBinPath('gogetdoc');
+		let p = cp.execFile(gogetdoc, ['-u', '-json', '-modified', '-pos', document.fileName + ':#' + offset.toString()], {}, (err, stdout, stderr) => {
 			try {
 				if (err && (<any>err).code === 'ENOENT') {
-					promptForMissingTool('godef');
+					promptForMissingTool('gogetdoc');
 				}
 				if (err) return resolve(null);
-				let result = stdout.toString();
-				let lines = result.split('\n');
-				let match = /(.*):(\d+):(\d+)/.exec(lines[0]);
+				let goDocInfomation = <GoDocInfomation>JSON.parse(stdout.toString());
+				let match = /(.*):(\d+):(\d+)/.exec(goDocInfomation.pos);
 				if (!match) {
-					// TODO: Gotodef on pkg name:
-					// /usr/local/go/src/html/template\n
-					return resolve(null);
+					return resolve({
+						file: null,
+						line: 0,
+						column: 0,
+						docInfo: goDocInfomation
+					});
 				}
 				let [_, file, line, col] = match;
-				let signature = lines[1];
-				let godoc = getBinPath('godoc');
-				let pkgPath = path.dirname(file);
-				let definitionInformation: GoDefinitionInformtation = {
+				return resolve({
 					file: file,
 					line: +line - 1,
-					col: + col - 1,
-					lines,
-					doc: undefined
-				};
-				if (!includeDocs) {
-					return resolve(definitionInformation);
-				}
-				cp.execFile(godoc, [pkgPath], {}, (err, stdout, stderr) => {
-					if (err && (<any>err).code === 'ENOENT') {
-						vscode.window.showInformationMessage('The "godoc" command is not available.');
-					}
-					let godocLines = stdout.toString().split('\n');
-					let doc = '';
-					let sigName = signature.substring(0, signature.indexOf(' '));
-					let sigParams = signature.substring(signature.indexOf(' func') + 5);
-					let searchSignature = 'func ' + sigName + sigParams;
-					for (let i = 0; i < godocLines.length; i++) {
-						if (godocLines[i] === searchSignature) {
-							while (godocLines[++i].startsWith('    ')) {
-								doc += godocLines[i].substring(4) + '\n';
-							}
-							break;
-						}
-					}
-					if (doc !== '') {
-						definitionInformation.doc = doc;
-					}
-					return resolve(definitionInformation);
+					column: +col - 1,
+					docInfo: goDocInfomation
 				});
 			} catch (e) {
 				reject(e);
 			}
 		});
-		p.stdin.end(document.getText());
+		let documentText = document.getText();
+		let documentArchive = document.fileName + '\n';
+		documentArchive = documentArchive + Buffer.byteLength(documentText) + '\n';
+		documentArchive = documentArchive + documentText;
+		p.stdin.end(documentArchive);
 	});
 }
 
 export class GoDefinitionProvider implements vscode.DefinitionProvider {
-
 	public provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Location> {
 		return definitionLocation(document, position, false).then(definitionInfo => {
-			if (definitionInfo == null) return null;
+			if (definitionInfo == null || definitionInfo.file == null) return null;
 			let definitionResource = vscode.Uri.file(definitionInfo.file);
-			let pos = new vscode.Position(definitionInfo.line, definitionInfo.col);
+			let pos = new vscode.Position(definitionInfo.line, definitionInfo.column);
 			return new vscode.Location(definitionResource, pos);
 		});
 	}
+}
 
+interface GoDocInfomation {
+	name: string;
+	imp: string;
+	decl: string;
+	doc: string;
+	pos: string;
 }

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -71,7 +71,7 @@ export class GoDefinitionProvider implements vscode.DefinitionProvider {
 
 interface GoDocInfomation {
 	name: string;
-	imp: string;
+	import: string;
 	decl: string;
 	doc: string;
 	pos: string;

--- a/src/goExtraInfo.ts
+++ b/src/goExtraInfo.ts
@@ -13,11 +13,9 @@ export class GoHoverProvider implements HoverProvider {
 		return definitionLocation(document, position, true).then(definitionInfo => {
 			console.log(definitionInfo);
 			if (definitionInfo == null) return null;
-			let lines = definitionInfo.docInfo.decl.split('\n');
-			lines = lines.filter(val => !val.startsWith('\t//')).map(line => {
-				return line.replace(/\t/g, '    ');
-			});
-			lines = lines.filter(line => line.length !== 0);
+			let lines = definitionInfo.docInfo.decl.split('\n')
+				.filter(line => !line.startsWith('\t//') && line !== '')
+				.map(line => line.replace(/\t/g, '    '));
 			let text;
 			if (lines.length > 1) {
 				text = lines.join('\n').replace(/\n+$/, '');

--- a/src/goExtraInfo.ts
+++ b/src/goExtraInfo.ts
@@ -11,7 +11,6 @@ import { definitionLocation } from './goDeclaration';
 export class GoHoverProvider implements HoverProvider {
 	public provideHover(document: TextDocument, position: Position, token: CancellationToken): Thenable<Hover> {
 		return definitionLocation(document, position, true).then(definitionInfo => {
-			console.log(definitionInfo);
 			if (definitionInfo == null) return null;
 			let lines = definitionInfo.docInfo.decl.split('\n')
 				.filter(line => !line.startsWith('\t//') && line !== '')

--- a/src/goExtraInfo.ts
+++ b/src/goExtraInfo.ts
@@ -11,28 +11,24 @@ import { definitionLocation } from './goDeclaration';
 export class GoHoverProvider implements HoverProvider {
 	public provideHover(document: TextDocument, position: Position, token: CancellationToken): Thenable<Hover> {
 		return definitionLocation(document, position, true).then(definitionInfo => {
+			console.log(definitionInfo);
 			if (definitionInfo == null) return null;
-			let lines = definitionInfo.lines;
-			lines = lines.map(line => {
-				if (line.indexOf('\t') === 0) {
-					line = line.slice(1);
-				}
-				return line.replace(/\t/g, '  ');
+			let lines = definitionInfo.docInfo.decl.split('\n');
+			lines = lines.filter(val => !val.startsWith('\t//')).map(line => {
+				return line.replace(/\t/g, '    ');
 			});
 			lines = lines.filter(line => line.length !== 0);
-			if (lines.length > 10) lines[9] = '...';
 			let text;
 			if (lines.length > 1) {
-				text = lines.slice(1, 10).join('\n');
-				text = text.replace(/\n+$/, '');
+				text = lines.join('\n').replace(/\n+$/, '');
 			} else {
 				text = lines[0];
 			}
 			let hoverTexts: MarkedString[] = [];
-			if (definitionInfo.doc != null) {
-				hoverTexts.push(definitionInfo.doc);
+			hoverTexts.push({ language: 'go', value: text });
+			if (definitionInfo.docInfo.doc != null) {
+				hoverTexts.push(definitionInfo.docInfo.doc);
 			}
-			hoverTexts.push({ language: 'go', value: text});
 			let hover = new Hover(hoverTexts);
 			return hover;
 		});

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -22,7 +22,7 @@ function getTools(goVersion: SemVersion): { [key: string]: string } {
 	let tools: { [key: string]: string } = {
 		'gocode': 'github.com/nsf/gocode',
 		'gopkgs': 'github.com/tpng/gopkgs',
-		'godef': 'github.com/rogpeppe/godef',
+		'gogetdoc': 'github.com/zmb3/gogetdoc',
 		'go-outline': 'github.com/lukehoban/go-outline',
 		'go-symbols': 'github.com/newhook/go-symbols',
 		'guru': 'golang.org/x/tools/cmd/guru',

--- a/src/goSignature.ts
+++ b/src/goSignature.ts
@@ -30,12 +30,12 @@ export class GoSignatureHelpProvider implements SignatureHelpProvider {
 				return null;
 			}
 			let result = new SignatureHelp();
-			let text = res.lines[1];
+			let text = res.docInfo.decl.split('\n')[1];
 			let nameEnd = text.indexOf(' ');
 			let sigStart = nameEnd + 5; // ' func'
 			let funcName = text.substring(0, nameEnd);
 			let sig = text.substring(sigStart);
-			let si = new SignatureInformation(funcName + sig, res.doc);
+			let si = new SignatureInformation(funcName + sig, res.docInfo.doc);
 			si.parameters = parameters(sig).map(paramText =>
 				new ParameterInformation(paramText)
 			);

--- a/src/goSignature.ts
+++ b/src/goSignature.ts
@@ -6,8 +6,6 @@
 'use strict';
 
 import cp = require('child_process');
-import path = require('path');
-import { getBinPath } from './goPath';
 import { languages, window, commands, SignatureHelpProvider, SignatureHelp, SignatureInformation, ParameterInformation, TextDocument, Position, Range, CancellationToken } from 'vscode';
 import { definitionLocation } from './goDeclaration';
 import { parameters } from './util';
@@ -30,13 +28,10 @@ export class GoSignatureHelpProvider implements SignatureHelpProvider {
 				return null;
 			}
 			let result = new SignatureHelp();
-			let text = res.docInfo.decl.split('\n')[1];
-			let nameEnd = text.indexOf(' ');
-			let sigStart = nameEnd + 5; // ' func'
-			let funcName = text.substring(0, nameEnd);
-			let sig = text.substring(sigStart);
-			let si = new SignatureInformation(funcName + sig, res.docInfo.doc);
-			si.parameters = parameters(sig).map(paramText =>
+			let text = res.docInfo.decl.substring(5);
+			let si = new SignatureInformation(text, res.docInfo.doc);
+			let braceStart = text.indexOf('(');
+			si.parameters = parameters(text.substring(braceStart)).map(paramText =>
 				new ParameterInformation(paramText)
 			);
 			result.signatures = [si];

--- a/test/fixtures/vendorTest/vd.go
+++ b/test/fixtures/vendorTest/vd.go
@@ -1,0 +1,11 @@
+package abc
+
+const ABC = 123
+
+func unExported() int {
+	return 1
+}
+
+func Exported() string {
+	return "Hello,world"
+}

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -23,17 +23,21 @@ import { getBinPath } from '../src/goPath';
 
 suite('Go Extension Tests', () => {
 	let gopath = process.env['GOPATH'];
-	let repoPath = path.join(gopath, 'src', '___testrepo');
-	let fixturePath = path.join(repoPath, 'test', 'testfixture');
+	let repoPath = path.join(gopath, 'src', 'test');
+	let fixturePath = path.join(repoPath, 'testfixture');
 	let fixtureSourcePath = path.join(__dirname, '..', '..', 'test', 'fixtures');
 
 	suiteSetup(() => {
 		assert.ok(gopath !== null, 'GOPATH is not defined');
 		fs.removeSync(repoPath);
-		fs.mkdirsSync(fixturePath);
+		fs.mkdirsSync(path.join(fixturePath, 'vendor', 'abc', 'internal'));
 		fs.copySync(path.join(fixtureSourcePath, 'test.go'), path.join(fixturePath, 'test.go'));
 		fs.copySync(path.join(fixtureSourcePath, 'errorsTest', 'errors.go'), path.join(fixturePath, 'errorsTest', 'errors.go'));
 		fs.copySync(path.join(fixtureSourcePath, 'sample_test.go'), path.join(fixturePath, 'sample_test.go'));
+		fs.copySync(path.join(fixtureSourcePath, 'vendorTest', 'vd.go'), path.join(fixturePath, 'vendor', 'abc', 'vd.go'));
+		fs.copySync(path.join(fixtureSourcePath, 'vendorTest', 'vd.go'), path.join(fixturePath, 'vendor', 'abc', 'internal', 'vd.go'));
+		cp.execSync('go install test/testfixture/vendor/abc');
+		cp.execSync('go install test/testfixture/vendor/abc/internal');
 	});
 
 	suiteTeardown(() => {
@@ -435,16 +439,14 @@ encountered.
 		// will fail and will have to be replaced with any other go project with vendor packages
 
 		let vendorSupportPromise = isVendorSupported();
-		let filePath = path.join(process.env['GOPATH'], 'src', 'github.com', 'rogpeppe', 'godef', 'go', 'ast', 'ast.go');
+		let filePath = path.join(fixturePath, 'vendor', 'abc', 'vd.go');
 		let vendorPkgsFullPath = [
-			'github.com/rogpeppe/godef/vendor/9fans.net/go/acme',
-			'github.com/rogpeppe/godef/vendor/9fans.net/go/plan9',
-			'github.com/rogpeppe/godef/vendor/9fans.net/go/plan9/client'
+			'test/testfixture/vendor/abc',
+			'test/testfixture/vendor/abc/internal'
 		];
 		let vendorPkgsRelativePath = [
-			'9fans.net/go/acme',
-			'9fans.net/go/plan9',
-			'9fans.net/go/plan9/client'
+			'abc',
+			'abc/internal'
 		];
 
 		vendorSupportPromise.then((vendorSupport: boolean) => {

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -49,10 +49,10 @@ encountered.
 `;
 		let testCases: [vscode.Position, string, string][] = [
 			// [new vscode.Position(3,3), '/usr/local/go/src/fmt'],
-			[new vscode.Position(9, 6), 'main func()', null],
-			[new vscode.Position(7, 2), 'import (fmt "fmt")', null],
-			[new vscode.Position(7, 6), 'Println func(a ...interface{}) (n int, err error)', printlnDoc],
-			[new vscode.Position(10, 3), 'print func(txt string)', null]
+			[new vscode.Position(9, 6), 'func main()', null],
+			[new vscode.Position(7, 2), 'package fmt', null],
+			[new vscode.Position(7, 6), 'func Println(a ...interface{}) (n int, err error)', printlnDoc],
+			[new vscode.Position(10, 3), 'func print(txt string)', null]
 		];
 		let uri = vscode.Uri.file(path.join(fixturePath, 'test.go'));
 		vscode.workspace.openTextDocument(uri).then((textDocument) => {
@@ -65,7 +65,7 @@ encountered.
 					// 	assert.equal(res.contents.length, 2);
 					// 	assert.equal(expectedDocumentation, <string>(res.contents[0]));
 					// }
-					assert.equal(expectedSignature, (<{ language: string; value: string }>res.contents[res.contents.length - 1]).value);
+					assert.equal(expectedSignature, (<{ language: string; value: string }>res.contents[0]).value);
 				})
 			);
 			return Promise.all(promises);


### PR DESCRIPTION
Changes:
1 use gogetdoc instead of godef and godoc. Now can use only gogetdoc tool and only one step get both definition info and doc.
2 hover info, old one is doc before signature, now is signature before doc. Since other language or extension dose.
3 support `builtin` package that no definition info in gogetdoc properties.( PS:but can't jump to source.)