### PR TITLE
remove black space after auto completed brackets

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -178,7 +178,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 										paramSnippets.push('{{' + param + '}}');
 									}
 								}
-								item.insertText = suggest.name + '(' + paramSnippets.join(', ') + ') {{}}';
+								item.insertText = suggest.name + '(' + paramSnippets.join(', ') + '){{}}';
 							}
 							// Add same sortText to all suggestions from gocode so that they appear before the unimported packages
 							item.sortText = 'a';


### PR DESCRIPTION
when `"go.useCodeSnippetsOnFunctionSuggest": true`，if a function auto completed brackets，there are a black space will insert after it. This's pull request will fix it.