### PR TITLE
Fixed wrong workspace when one gopath is the substring of another.

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -98,12 +98,17 @@ export function canonicalizeGOPATHPrefix(filename: string): string {
 	if (!gopath) return filename;
 	let workspaces = gopath.split(path.delimiter);
 	let filenameLowercase = filename.toLowerCase();
+
+	let currentWorkspace : string = null
 	for (let workspace of workspaces) {
-		if (filenameLowercase.substring(0, workspace.length) === workspace.toLowerCase()) {
-			return workspace + filename.slice(workspace.length);
+		if (filenameLowercase.substring(0, workspace.length) === workspace.toLowerCase() 
+			&& (!currentWorkspace || workspace.length > currentWorkspace.length)) {
+			currentWorkspace = workspace;
 		}
 	}
-	return filename;
+	
+	if(!currentWorkspace) return  filename;
+	return currentWorkspace + filename.slice(currentWorkspace.length);	
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -99,16 +99,21 @@ export function canonicalizeGOPATHPrefix(filename: string): string {
 	let workspaces = gopath.split(path.delimiter);
 	let filenameLowercase = filename.toLowerCase();
 
-	let currentWorkspace : string = null
+	// In case of multiple workspaces, find current workspace by checking if current file is
+	// under any of the workspaces in $GOPATH
+	let currentWorkspace: string = null;
 	for (let workspace of workspaces) {
-		if (filenameLowercase.substring(0, workspace.length) === workspace.toLowerCase() 
+		// In case of nested workspaces, (example: both /Users/me and /Users/me/a/b/c are in $GOPATH)
+		// both parent & child workspace in the nested workspaces pair can make it inside the above if block
+		// Therefore, the below check will take longer (more specific to current file) of the two
+		if (filenameLowercase.substring(0, workspace.length) === workspace.toLowerCase()
 			&& (!currentWorkspace || workspace.length > currentWorkspace.length)) {
 			currentWorkspace = workspace;
 		}
 	}
-	
-	if(!currentWorkspace) return  filename;
-	return currentWorkspace + filename.slice(currentWorkspace.length);	
+
+	if (!currentWorkspace) return filename;
+	return currentWorkspace + filename.slice(currentWorkspace.length);
 }
 
 /**


### PR DESCRIPTION
Fixed wrong workspace when one gopath is the substring of another in “canonicalizeGOPATHPrefix” of “util.ts”.