### PR TITLE
fix coverage display when editor changes to undefined

### DIFF
--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -60,6 +60,9 @@ export function coverageCurrentPackage() {
 }
 
 export function getCodeCoverage(editor: vscode.TextEditor) {
+	if (!editor) {
+		return;
+	}
 	for (let filename in coverageFiles) {
 		if (editor.document.uri.fsPath.endsWith(filename)) {
 			highlightCoverage(editor, coverageFiles[filename], false);


### PR DESCRIPTION
getCodeCoverage gets triggered when vscode.window.onDidChangeActiveTextEditor fires. onDidChangeActiveTextEditor also fires when the active editor changes to undefined.