### PR TITLE
Do not get definition info if not identifier

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -9,7 +9,7 @@ import vscode = require('vscode');
 import cp = require('child_process');
 import { dirname, basename } from 'path';
 import { getBinPath } from './goPath';
-import { parameters, parseFilePrelude } from './util';
+import { parameters, parseFilePrelude, isPositionInString } from './util';
 import { promptForMissingTool } from './goInstallTools';
 import { listPackages, getTextEditForAddImport } from './goImport';
 
@@ -61,11 +61,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 					return resolve([]);
 				}
 
-				// Count the number of double quotes in the line till current position. Ignore escaped double quotes
-				let doubleQuotesCnt = (lineTillCurrentPosition.match(/[^\\]\"/g) || []).length;
-				doubleQuotesCnt += lineTillCurrentPosition.startsWith('\"') ? 1 : 0;
-				let inString = (doubleQuotesCnt % 2 === 1);
-
+				let inString = isPositionInString(document, position);
 				if (!inString && lineTillCurrentPosition.endsWith('\"')) {
 					return resolve([]);
 				}

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,6 +13,34 @@ const extensionId: string = 'lukehoban.Go';
 const extensionVersion: string = vscode.extensions.getExtension(extensionId).packageJSON.version;
 const aiKey: string = 'AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217';
 
+export const goKeywords: string[] = [
+	'break',
+	'case',
+	'chan',
+	'const',
+	'continue',
+	'default',
+	'defer',
+	'else',
+	'fallthrough',
+	'for',
+	'func',
+	'go',
+	'goto',
+	'if',
+	'import',
+	'interface',
+	'map',
+	'package',
+	'range',
+	'return',
+	'select',
+	'struct',
+	'switch',
+	'type',
+	'var'
+];
+
 export interface SemVersion {
 	major: number;
 	minor: number;
@@ -205,4 +233,14 @@ export function sendTelemetryEvent(eventName: string, properties?: {
 
 			telemtryReporter = telemtryReporter ? telemtryReporter : new TelemetryReporter(extensionId, extensionVersion, aiKey);
 			telemtryReporter.sendTelemetryEvent(eventName, properties, measures);
+}
+
+export function isPositionInString(document: vscode.TextDocument, position: vscode.Position): boolean {
+	let lineText = document.lineAt(position.line).text;
+	let lineTillCurrentPosition = lineText.substr(0, position.character);
+
+	// Count the number of double quotes in the line till current position. Ignore escaped double quotes
+	let doubleQuotesCnt = (lineTillCurrentPosition.match(/[^\\]\"/g) || []).length;
+	doubleQuotesCnt += lineTillCurrentPosition.startsWith('\"') ? 1 : 0;
+	return doubleQuotesCnt % 2 === 1;
 }

--- a/test/fixtures/gogetdocTestData/test.go
+++ b/test/fixtures/gogetdocTestData/test.go
@@ -26,7 +26,7 @@ func main() {
 
 // Hello is a method on the struct ABC. Will signature help understand this correctly
 func (abcd *ABC) Hello(s string, exclaim bool) string {
-	net.CIDRMask(1, 2)
+	net.CIDRMask(10, 20)
 	if exclaim {
 		s = s + "!"
 	}

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -102,6 +102,10 @@ suite('Go Extension Tests', () => {
 					// 	assert.equal(res.contents.length, 2);
 					// 	assert.equal(expectedDocumentation, <string>(res.contents[0]));
 					// }
+					if (expectedSignature === null && expectedDocumentation === null) {
+						assert.equal(res, null);
+						return;
+					}
 					assert.equal(expectedSignature, (<{ language: string; value: string }>res.contents[0]).value);
 				})
 			);
@@ -165,6 +169,10 @@ encountered.
 `;
 		let testCases: [vscode.Position, string, string][] = [
 			// [new vscode.Position(3,3), '/usr/local/go/src/fmt'],
+			[new vscode.Position(0, 3), null, null], // keyword
+			[new vscode.Position(23, 14), null, null], // inside a string
+			[new vscode.Position(20, 0), null, null], // just a }
+			[new vscode.Position(28, 16), null, null], // inside a number
 			[new vscode.Position(22, 5), 'main func()', null],
 			[new vscode.Position(40, 23), 'import (math "math")', null],
 			[new vscode.Position(19, 6), 'Println func(a ...interface{}) (n int, err error)', printlnDoc],
@@ -179,6 +187,10 @@ Spaces are always added between operands and a newline is appended.
 It returns the number of bytes written and any write error encountered.
 `;
 		let testCases: [vscode.Position, string, string][] = [
+			[new vscode.Position(0, 3), null, null], // keyword
+			[new vscode.Position(23, 11), null, null], // inside a string
+			[new vscode.Position(20, 0), null, null], // just a }
+			[new vscode.Position(28, 16), null, null], // inside a number
 			[new vscode.Position(22, 5), 'func main()', ''],
 			[new vscode.Position(23, 4), 'func print(txt string)', 'This is an unexported function so couldnt get this comment on hover :(\nNot anymore!! gogetdoc to the rescue\n'],
 			[new vscode.Position(40, 23), 'package math', 'Package math provides basic constants and mathematical functions.\n'],


### PR DESCRIPTION
The Go extension spawns a new process to get definition information each time the hover provider is triggered. This sometimes results in massive number of processes to spin up and cause perf issues.

When we know beforehand that the text under the cursor is not an identifier, then we can skip creating new processes to get definition information. 

In this PR, we do this for the below cases:
- Not a word
- Is a keyword
- Is a number
- Is part of a string literal
- Is part of a single line comment