### PR TITLE
if buildOnSave is on: build using -i

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -63,7 +63,7 @@ export function byteOffsetAt(document: vscode.TextDocument, position: vscode.Pos
 
 export interface Prelude {
 	imports: Array<{ kind: string; start: number; end: number; }>;
-	pkg: { start: number; end: number; };
+	pkg: { start: number; end: number; name: string };
 }
 
 export function parseFilePrelude(text: string): Prelude {
@@ -71,8 +71,9 @@ export function parseFilePrelude(text: string): Prelude {
 	let ret: Prelude = { imports: [], pkg: null };
 	for (let i = 0; i < lines.length; i++) {
 		let line = lines[i];
-		if (line.match(/^(\s)*package(\s)+/)) {
-			ret.pkg = { start: i, end: i };
+		let pkgMatch = line.match(/^(\s)*package(\s)+(\w+)/);
+		if (pkgMatch) {
+			ret.pkg = { start: i, end: i, name: pkgMatch[3] };
 		}
 		if (line.match(/^(\s)*import(\s)+\(/)) {
 			ret.imports.push({ kind: 'multi', start: i, end: -1 });

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -288,12 +288,15 @@ It returns the number of bytes written and any write error encountered.
 			}
 			return check(path.join(fixturePath, 'errorsTest', 'errors.go'), config).then(diagnostics => {
 				let sortedDiagnostics = diagnostics.sort((a, b) => a.line - b.line);
+				assert.equal(sortedDiagnostics.length, expected.length, `too many errors ${JSON.stringify(sortedDiagnostics)}`);
 				for (let i in expected) {
-					assert.equal(sortedDiagnostics[i].line, expected[i].line);
+					if (expected[i].line) {
+						assert(sortedDiagnostics[i]);
+						assert.equal(sortedDiagnostics[i].line, expected[i].line);
+					};
 					assert.equal(sortedDiagnostics[i].severity, expected[i].severity);
 					assert.equal(sortedDiagnostics[i].msg, expected[i].msg);
 				}
-				assert.equal(sortedDiagnostics.length, expected.length, `too many errors ${JSON.stringify(sortedDiagnostics)}`);
 			});
 		}).then(() => done(), done);
 	});


### PR DESCRIPTION
This PR addresses the compilation performance optimization discussed in #673.

Installing the built packages improves following compilations since packages are only rebuilt if they changed.
If the current package is a main package, the installation is skipped to avoid installing executable binaries.

I had to tweak a util method that was scanning text files to find the package and the imports. Unfortunately this util wasn't tracking the name of the package. I needed the package name to check if the `-i` flag should be used or not.