### PR TITLE
Use settings for separate location for installing Go tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -388,6 +388,11 @@
             "godoc",
             "gogetdoc"
           ]
+        },
+        "go.toolsGopath": {
+          "type": "string",
+          "default": "",
+          "description": "Location to install the Go tools that the extension depends on if you don't want them in your GOPATH."
         }
       }
     }

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -9,7 +9,7 @@ import { readFileSync, existsSync, lstatSync } from 'fs';
 import { basename, dirname } from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { Client, RPCConnection } from 'json-rpc2';
-import { getBinPath } from '../goPath';
+import { getBinPathWithPreferredGopath } from '../goPath';
 
 require('console-stamp')(console);
 
@@ -168,12 +168,7 @@ class Delve {
 				connectClient(port, host);
 				return;
 			}
-			let dlv = getBinPath('dlv');
-
-			// If dlv not found, try using the GOPATH that was set in env in launch.json
-			if (!existsSync(dlv) && env['GOPATH']) {
-				dlv = getBinPath('dlv', env['GOPATH']);
-			}
+			let dlv = getBinPathWithPreferredGopath('dlv', env['GOPATH']);
 
 			log('Using dlv at: ', dlv);
 			if (!existsSync(dlv)) {

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -10,11 +10,11 @@ import cp = require('child_process');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
-import { getBinPath, getGoRuntimePath } from './goPath';
+import { getGoRuntimePath } from './goPath';
 import { getCoverage } from './goCover';
 import { outputChannel } from './goStatus';
 import { promptForMissingTool } from './goInstallTools';
-import { parseFilePrelude } from './util';
+import { getBinPath, parseFilePrelude } from './util';
 
 export interface ICheckResult {
 	file: string;

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -9,7 +9,8 @@ import cp = require('child_process');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
-import { getBinPath, getGoRuntimePath } from './goPath';
+import { getGoRuntimePath } from './goPath';
+import { getBinPath } from './util';
 import rl = require('readline');
 import { outputChannel } from './goStatus';
 

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -8,8 +8,7 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import path = require('path');
-import { getBinPath } from './goPath';
-import { byteOffsetAt } from './util';
+import { byteOffsetAt, getBinPath } from './util';
 import { promptForMissingTool } from './goInstallTools';
 import { getGoVersion, SemVersion, goKeywords, isPositionInString } from './util';
 

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -9,9 +9,8 @@ import vscode = require('vscode');
 import cp = require('child_process');
 import path = require('path');
 import { isDiffToolAvailable, getEdits, getEditsFromUnifiedDiffStr } from '../src/diffUtils';
-import { getBinPath } from './goPath';
 import { promptForMissingTool } from './goInstallTools';
-import { sendTelemetryEvent } from './util';
+import { sendTelemetryEvent, getBinPath } from './util';
 
 export class Formatter {
 	private formatCommand = 'goreturns';

--- a/src/goGenerateTests.ts
+++ b/src/goGenerateTests.ts
@@ -10,7 +10,7 @@ import path = require('path');
 import vscode = require('vscode');
 import util = require('util');
 
-import { getBinPath } from './goPath';
+import { getBinPath } from './util';
 import { promptForMissingTool } from './goInstallTools';
 import { GoDocumentSymbolProvider } from './goOutline';
 

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -7,8 +7,7 @@
 
 import vscode = require('vscode');
 import cp = require('child_process');
-import { getBinPath } from './goPath';
-import { parseFilePrelude, isVendorSupported } from './util';
+import { parseFilePrelude, isVendorSupported, getBinPath } from './util';
 import { documentSymbols } from './goOutline';
 import { promptForMissingTool } from './goInstallTools';
 import path = require('path');

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -11,9 +11,9 @@ import path = require('path');
 import os = require('os');
 import cp = require('child_process');
 import { showGoStatus, hideGoStatus } from './goStatus';
-import { getBinPath, getGoRuntimePath } from './goPath';
+import { getGoRuntimePath } from './goPath';
 import { outputChannel } from './goStatus';
-import { getGoVersion, SemVersion, isVendorSupported } from './util';
+import { getBinPath, getGoVersion, SemVersion, isVendorSupported } from './util';
 
 let updatesDeclinedTools: string[] = [];
 
@@ -136,11 +136,12 @@ function installTools(goVersion: SemVersion, missing?: string[]) {
 		});
 	}
 
-	// If the VSCODE_GOTOOLS environment variable is set, use
- 	// its value as the GOPATH for the "go get" child precess.
+	// If the go.toolsGopath is set, use 
+ 	// its value as the GOPATH for the "go get" child process.
+	let goConfig = vscode.workspace.getConfiguration('go');
 	let envWithSeparateGoPathForTools = null;
-	if (process.env['VSCODE_GOTOOLS']) {
-		envWithSeparateGoPathForTools = Object.assign({}, envForTools, {GOPATH: process.env['VSCODE_GOTOOLS']});
+	if (goConfig['toolsGopath']) {
+		envWithSeparateGoPathForTools = Object.assign({}, envForTools, {GOPATH: goConfig['toolsGopath']});
 	}
 
 	missing.reduce((res: Promise<string[]>, tool: string) => {

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -8,7 +8,7 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import path = require('path');
-import { getBinPath } from './goPath';
+import { getBinPath } from './util';
 import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
 
 // Keep in sync with https://github.com/lukehoban/go-outline

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -30,17 +30,17 @@ export function getBinPathFromEnvVar(toolName: string, envVarValue: string, appe
 	return null;
 }
 
-export function getBinPath(binname: string, goPath: string = null) {
+export function getBinPathWithPreferredGopath(binname: string, preferredGopath: string = null) {
 	if (binPathCache[correctBinname(binname)]) return binPathCache[correctBinname(binname)];
 
-	// First search VSCODE_GOTOOLS' bin folder
-	let pathFromToolsGoPath = getBinPathFromEnvVar(binname, process.env['VSCODE_GOTOOLS'], true);
-	if (pathFromToolsGoPath) {
-		return pathFromToolsGoPath;
+	// Search in the preferred GOPATH workspace's bin folder
+	let pathFrompreferredGoPath = getBinPathFromEnvVar(binname, preferredGopath, true);
+	if (pathFrompreferredGoPath) {
+		return pathFrompreferredGoPath;
 	}
 
-	// Then search each GOPATH workspace's bin folder
-	let pathFromGoPath = getBinPathFromEnvVar(binname, goPath ? goPath : process.env['GOPATH'], true);
+	// Then search user's GOPATH workspace's bin folder
+	let pathFromGoPath = getBinPathFromEnvVar(binname, process.env['GOPATH'], true);
 	if (pathFromGoPath) {
 		return pathFromGoPath;
 	}

--- a/src/goReferences.ts
+++ b/src/goReferences.ts
@@ -8,8 +8,7 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import path = require('path');
-import { getBinPath } from './goPath';
-import { byteOffsetAt, canonicalizeGOPATHPrefix } from './util';
+import { getBinPath, byteOffsetAt, canonicalizeGOPATHPrefix } from './util';
 import { promptForMissingTool } from './goInstallTools';
 
 export class GoReferenceProvider implements vscode.ReferenceProvider {

--- a/src/goRename.ts
+++ b/src/goRename.ts
@@ -7,8 +7,7 @@
 
 import vscode = require('vscode');
 import cp = require('child_process');
-import { getBinPath } from './goPath';
-import { byteOffsetAt, canonicalizeGOPATHPrefix } from './util';
+import { getBinPath, byteOffsetAt, canonicalizeGOPATHPrefix } from './util';
 import { getEditsFromUnifiedDiffStr, isDiffToolAvailable, FilePatch, Edit } from '../src/diffUtils';
 import { promptForMissingTool } from './goInstallTools';
 

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -8,8 +8,7 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import { dirname, basename } from 'path';
-import { getBinPath } from './goPath';
-import { parameters, parseFilePrelude, isPositionInString } from './util';
+import { getBinPath, parameters, parseFilePrelude, isPositionInString } from './util';
 import { promptForMissingTool } from './goInstallTools';
 import { listPackages, getTextEditForAddImport } from './goImport';
 

--- a/src/goSymbol.ts
+++ b/src/goSymbol.ts
@@ -6,7 +6,7 @@
 
 import vscode = require('vscode');
 import cp = require('child_process');
-import { getBinPath } from './goPath';
+import { getBinPath } from './util';
 import { promptForMissingTool } from './goInstallTools';
 
 // Keep in sync with github.com/newhook/go-symbols'

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,7 +5,7 @@
 
 import vscode = require('vscode');
 import path = require('path');
-import { getGoRuntimePath } from './goPath';
+import { getGoRuntimePath, getBinPathWithPreferredGopath} from './goPath';
 import cp = require('child_process');
 import TelemetryReporter from 'vscode-extension-telemetry';
 
@@ -244,4 +244,9 @@ export function isPositionInString(document: vscode.TextDocument, position: vsco
 	let doubleQuotesCnt = (lineTillCurrentPosition.match(/[^\\]\"/g) || []).length;
 	doubleQuotesCnt += lineTillCurrentPosition.startsWith('\"') ? 1 : 0;
 	return doubleQuotesCnt % 2 === 1;
+}
+
+export function getBinPath(tool: string): string {
+	let goConfig = vscode.workspace.getConfiguration('go');
+	return getBinPathWithPreferredGopath(tool, goConfig['toolsGopath']);
 }

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -16,11 +16,10 @@ import cp = require('child_process');
 import { getEditsFromUnifiedDiffStr, getEdits } from '../src/diffUtils';
 import jsDiff = require('diff');
 import { testCurrentFile } from '../src/goTest';
-import { getGoVersion, isVendorSupported } from '../src/util';
+import { getBinPath, getGoVersion, isVendorSupported } from '../src/util';
 import { documentSymbols } from '../src/goOutline';
 import { listPackages } from '../src/goImport';
 import { generateTestCurrentFile, generateTestCurrentPackage, generateTestCurrentFunction } from '../src/goGenerateTests';
-import { getBinPath } from '../src/goPath';
 
 suite('Go Extension Tests', () => {
 	let gopath = process.env['GOPATH'];


### PR DESCRIPTION
See #5 for the discussion on the need for a separate location to install Go tools instead of the user's GOPATH.

See #351 for the implementation using env vars and further talk of how a VS Code setting is better instead of env var

This PR is to use VS Code setting where user can provide a location for installing the Go tools.
`gometalinter` is an exception to this rule and will get installed in the user's GOPATH always.
This is because `gometalinter` expects all the linters it uses to be in the user's GOPATH.

Users need to install `dlv` manually as always and is out of this disucssion

cc @roblourens 