### PR TITLE
Removing common parts from program and remotePath

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -339,7 +339,8 @@ class GoDebugSession extends DebugSession {
 
 			let llist = localPath.split(/\/|\\(?! )/).reverse();
 			let rlist = remotePath.split(/\/|\\(?! )/).reverse();
-			for(var i = 0; i < llist.length; i++) if (llist[i] !== rlist[i]) break;
+			let i = 0;
+			for(; i < llist.length; i++) if (llist[i] !== rlist[i]) break;
 
 			if (i) {
 				localPath = llist.reverse().slice(0, -i).join(this.localPathSeparator);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -340,7 +340,7 @@ class GoDebugSession extends DebugSession {
 			let llist = localPath.split(/\/|\\(?! )/).reverse();
 			let rlist = remotePath.split(/\/|\\(?! )/).reverse();
 			let i = 0;
-			for(; i < llist.length; i++) if (llist[i] !== rlist[i]) break;
+			for (; i < llist.length; i++) if (llist[i] !== rlist[i]) break;
 
 			if (i) {
 				localPath = llist.reverse().slice(0, -i).join(this.localPathSeparator);


### PR DESCRIPTION
also returning '\\' as a separator on Windows paths with mixed separators.

PR as requested in #689.

