### PR TITLE
No more reload when choice of tool is changed

### DIFF
--- a/src/diffUtils.ts
+++ b/src/diffUtils.ts
@@ -137,11 +137,11 @@ function parseUniDiffs(diffOutput: jsDiff.IUniDiff[]): FilePatch[] {
 
 /**
  * Returns a FilePatch object by generating diffs between given oldStr and newStr using the diff module
- * 
+ *
  * @param fileName string: Name of the file to which edits should be applied
  * @param oldStr string
  * @param newStr string
- * 
+ *
  * @returns A single FilePatch object
  */
 export function getEdits(fileName: string, oldStr: string, newStr: string): FilePatch {
@@ -156,13 +156,13 @@ export function getEdits(fileName: string, oldStr: string, newStr: string): File
 
 /**
  * Uses diff module to parse given diff string and returns edits for files
- * 
+ *
  * @param diffStr : Diff string in unified format. http://www.gnu.org/software/diffutils/manual/diffutils.html#Unified-Format
- * 
+ *
  * @returns Array of FilePatch objects, one for each file
  */
 export function getEditsFromUnifiedDiffStr(diffstr: string): FilePatch[] {
-	// Workaround for the bug https://github.com/kpdecker/jsdiff/issues/135 
+	// Workaround for the bug https://github.com/kpdecker/jsdiff/issues/135
 	if (diffstr.startsWith('---')) {
 		diffstr = diffstr.split('---').join('Index\n---');
 	}

--- a/src/goCodeAction.ts
+++ b/src/goCodeAction.ts
@@ -13,7 +13,7 @@ export class GoCodeActionProvider implements vscode.CodeActionProvider {
 	public provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): Thenable<vscode.Command[]> {
 
 		let promises = context.diagnostics.map(diag => {
-			// When a name is not found but could refer to a package, offer to add import 
+			// When a name is not found but could refer to a package, offer to add import
 			if (diag.message.indexOf('undefined: ') === 0) {
 				let [_, name] = /^undefined: (\S*)/.exec(diag.message);
 				return listPackages().then(packages => {

--- a/src/goExtraInfo.ts
+++ b/src/goExtraInfo.ts
@@ -5,18 +5,18 @@
 
 'use strict';
 
-import { HoverProvider, Hover, MarkedString, TextDocument, Position, CancellationToken } from 'vscode';
+import { HoverProvider, Hover, MarkedString, TextDocument, Position, CancellationToken, WorkspaceConfiguration, workspace } from 'vscode';
 import { definitionLocation } from './goDeclaration';
 
 export class GoHoverProvider implements HoverProvider {
-	private toolForDocs = 'godoc';
+	private goConfig = null;
 
-	constructor(toolForDocs: string) {
-		this.toolForDocs = toolForDocs;
+	constructor(goConfig?: WorkspaceConfiguration) {
+		this.goConfig = goConfig;
 	}
 
 	public provideHover(document: TextDocument, position: Position, token: CancellationToken): Thenable<Hover> {
-		return definitionLocation(document, position, this.toolForDocs, true).then(definitionInfo => {
+		return definitionLocation(document, position, this.goConfig, true).then(definitionInfo => {
 			if (definitionInfo == null) return null;
 			let lines = definitionInfo.declarationlines
 				.filter(line => !line.startsWith('\t//') && line !== '')

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -136,7 +136,7 @@ function installTools(goVersion: SemVersion, missing?: string[]) {
 		});
 	}
 
-	// If the go.toolsGopath is set, use 
+	// If the go.toolsGopath is set, use
  	// its value as the GOPATH for the "go get" child process.
 	let goConfig = vscode.workspace.getConfiguration('go');
 	let envWithSeparateGoPathForTools = null;

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -34,15 +34,15 @@ let diagnosticCollection: vscode.DiagnosticCollection;
 
 export function activate(ctx: vscode.ExtensionContext): void {
 
-	ctx.subscriptions.push(vscode.languages.registerHoverProvider(GO_MODE, new GoHoverProvider(vscode.workspace.getConfiguration('go')['docsTool'])));
+	ctx.subscriptions.push(vscode.languages.registerHoverProvider(GO_MODE, new GoHoverProvider()));
 	ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(GO_MODE, new GoCompletionItemProvider(), '.', '\"'));
-	ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(GO_MODE, new GoDefinitionProvider(vscode.workspace.getConfiguration('go')['docsTool'])));
+	ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(GO_MODE, new GoDefinitionProvider()));
 	ctx.subscriptions.push(vscode.languages.registerReferenceProvider(GO_MODE, new GoReferenceProvider()));
 	ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(GO_MODE, new GoDocumentFormattingEditProvider()));
 	ctx.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(GO_MODE, new GoDocumentSymbolProvider()));
 	ctx.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new GoWorkspaceSymbolProvider()));
 	ctx.subscriptions.push(vscode.languages.registerRenameProvider(GO_MODE, new GoRenameProvider()));
-	ctx.subscriptions.push(vscode.languages.registerSignatureHelpProvider(GO_MODE, new GoSignatureHelpProvider(vscode.workspace.getConfiguration('go')['docsTool']), '(', ','));
+	ctx.subscriptions.push(vscode.languages.registerSignatureHelpProvider(GO_MODE, new GoSignatureHelpProvider(), '(', ','));
 	ctx.subscriptions.push(vscode.languages.registerCodeActionsProvider(GO_MODE, new GoCodeActionProvider()));
 
 	diagnosticCollection = vscode.languages.createDiagnosticCollection('go');

--- a/src/goSignature.ts
+++ b/src/goSignature.ts
@@ -6,15 +6,15 @@
 'use strict';
 
 import cp = require('child_process');
-import { languages, window, commands, SignatureHelpProvider, SignatureHelp, SignatureInformation, ParameterInformation, TextDocument, Position, Range, CancellationToken } from 'vscode';
+import { languages, window, commands, SignatureHelpProvider, SignatureHelp, SignatureInformation, ParameterInformation, TextDocument, Position, Range, CancellationToken, WorkspaceConfiguration, workspace } from 'vscode';
 import { definitionLocation } from './goDeclaration';
 import { parameters } from './util';
 
 export class GoSignatureHelpProvider implements SignatureHelpProvider {
-	private toolForDocs = 'godoc';
+	private goConfig = null;
 
-	constructor(toolForDocs: string) {
-		this.toolForDocs = toolForDocs;
+	constructor(goConfig?: WorkspaceConfiguration) {
+		this.goConfig = goConfig;
 	}
 
 	public provideSignatureHelp(document: TextDocument, position: Position, token: CancellationToken): Promise<SignatureHelp> {
@@ -23,7 +23,7 @@ export class GoSignatureHelpProvider implements SignatureHelpProvider {
 			return Promise.resolve(null);
 		}
 		let callerPos = this.previousTokenPosition(document, theCall.openParen);
-		return definitionLocation(document, callerPos, this.toolForDocs).then(res => {
+		return definitionLocation(document, callerPos, this.goConfig).then(res => {
 			if (!res) {
 				// The definition was not found
 				return null;

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -50,8 +50,8 @@ suite('Go Extension Tests', () => {
 		fs.removeSync(repoPath);
 	});
 
-	function testDefinitionProvider(tool: string): Thenable<any> {
-		let provider = new GoDefinitionProvider(tool);
+	function testDefinitionProvider(goConfig: vscode.WorkspaceConfiguration): Thenable<any> {
+		let provider = new GoDefinitionProvider(goConfig);
 		let uri = vscode.Uri.file(path.join(fixturePath, 'test.go'));
 		let position = new vscode.Position(10, 3);
 		return vscode.workspace.openTextDocument(uri).then((textDocument) => {
@@ -66,8 +66,8 @@ suite('Go Extension Tests', () => {
 		});
 	}
 
-	function testSignatureHelpProvider(tool: string, testCases: [vscode.Position, string, string, string[]][]): Thenable<any> {
-		let provider = new GoSignatureHelpProvider(tool);
+	function testSignatureHelpProvider(goConfig: vscode.WorkspaceConfiguration, testCases: [vscode.Position, string, string, string[]][]): Thenable<any> {
+		let provider = new GoSignatureHelpProvider(goConfig);
 		let uri = vscode.Uri.file(path.join(fixturePath, 'gogetdocTestData', 'test.go'));
 		return vscode.workspace.openTextDocument(uri).then((textDocument) => {
 			let promises = testCases.map(([position, expected, expectedDoc, expectedParams]) =>
@@ -88,8 +88,8 @@ suite('Go Extension Tests', () => {
 		});
 	}
 
-	function testHoverProvider(tool: string, testCases: [vscode.Position, string, string][]): Thenable<any> {
-		let provider = new GoHoverProvider(tool);
+	function testHoverProvider(goConfig: vscode.WorkspaceConfiguration, testCases: [vscode.Position, string, string][]): Thenable<any> {
+		let provider = new GoHoverProvider(goConfig);
 		let uri = vscode.Uri.file(path.join(fixturePath, 'gogetdocTestData', 'test.go'));
 		return vscode.workspace.openTextDocument(uri).then((textDocument) => {
 			let promises = testCases.map(([position, expectedSignature, expectedDocumentation]) =>
@@ -116,13 +116,19 @@ suite('Go Extension Tests', () => {
 	}
 
 	test('Test Definition Provider using godoc', (done) => {
-		testDefinitionProvider('godoc').then(() => done(), done);
+		let config = Object.create(vscode.workspace.getConfiguration('go'), {
+			'docsTool': { value: 'godoc' }
+		});
+		testDefinitionProvider(config).then(() => done(), done);
 	});
 
 	test('Test Definition Provider using gogetdoc', (done) => {
+		let config = Object.create(vscode.workspace.getConfiguration('go'), {
+			'docsTool': { value: 'gogetdoc' }
+		});
 		getGoVersion().then(version => {
 			if (version.major > 1 || (version.major === 1 && version.minor > 5)) {
-				return testDefinitionProvider('gogetdoc');
+				return testDefinitionProvider(config);
 			}
 			return Promise.resolve();
 		}).then(() => done(), done);
@@ -139,7 +145,10 @@ encountered.
 			[new vscode.Position(23, 7), 'print(txt string)', null, ['txt string']],
 			[new vscode.Position(41, 19), 'Hello(s string, exclaim bool) string', null, ['s string', 'exclaim bool']]
 		];
-		testSignatureHelpProvider('godoc', testCases).then(() => done(), done);
+		let config = Object.create(vscode.workspace.getConfiguration('go'), {
+			'docsTool': { value: 'godoc' }
+		});
+		testSignatureHelpProvider(config, testCases).then(() => done(), done);
 	});
 
 	test('Test SignatureHelp Provider using gogetdoc', (done) => {
@@ -152,9 +161,12 @@ It returns the number of bytes written and any write error encountered.
 			[new vscode.Position(23, 7), 'print(txt string)', 'This is an unexported function so couldnt get this comment on hover :(\nNot anymore!! gogetdoc to the rescue\n', ['txt string']],
 			[new vscode.Position(41, 19), 'Hello(s string, exclaim bool) string', 'Hello is a method on the struct ABC. Will signature help understand this correctly\n', ['s string', 'exclaim bool']]
 		];
+		let config = Object.create(vscode.workspace.getConfiguration('go'), {
+			'docsTool': { value: 'gogetdoc' }
+		});
 		getGoVersion().then(version => {
 			if (version.major > 1 || (version.major === 1 && version.minor > 5)) {
-				return testSignatureHelpProvider('gogetdoc', testCases);
+				return testSignatureHelpProvider(config, testCases);
 			}
 			return Promise.resolve();
 		}).then(() => done(), done);
@@ -177,7 +189,10 @@ encountered.
 			[new vscode.Position(19, 6), 'Println func(a ...interface{}) (n int, err error)', printlnDoc],
 			[new vscode.Position(23, 4), 'print func(txt string)', null]
 		];
-		testHoverProvider('godoc', testCases).then(() => done(), done);
+		let config = Object.create(vscode.workspace.getConfiguration('go'), {
+			'docsTool': { value: 'godoc' }
+		});
+		testHoverProvider(config, testCases).then(() => done(), done);
 	});
 
 	test('Test Hover Provider using gogetdoc', (done) => {
@@ -197,9 +212,12 @@ It returns the number of bytes written and any write error encountered.
 			[new vscode.Position(27, 14), 'type ABC struct {\n    a int\n    b int\n    c int\n}', 'ABC is a struct, you coudnt use Goto Definition or Hover info on this before\nNow you can due to gogetdoc\n'],
 			[new vscode.Position(28, 6), 'func CIDRMask(ones, bits int) IPMask', 'CIDRMask returns an IPMask consisting of `ones\' 1 bits\nfollowed by 0s up to a total length of `bits\' bits.\nFor a mask of this form, CIDRMask is the inverse of IPMask.Size.\n']
 		];
+		let config = Object.create(vscode.workspace.getConfiguration('go'), {
+			'docsTool': { value: 'gogetdoc' }
+		});
 		getGoVersion().then(version => {
 			if (version.major > 1 || (version.major === 1 && version.minor > 5)) {
-				return testHoverProvider('gogetdoc', testCases);
+				return testHoverProvider(config, testCases);
 			}
 			return Promise.resolve();
 		}).then(() => done(), done);


### PR DESCRIPTION
Today, when you change your choice of formatting or docs tool, you need to reload VS Code for that to change to take effect.
With this PR, no more reload needed in such cases.