### PR TITLE
Clear cache for tools when toolspath changes

### DIFF
--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -92,3 +92,7 @@ function fileExists(filePath: string): boolean {
 		return false;
 	}
 }
+
+export function clearCacheForTools() {
+	binPathCache = {};
+}


### PR DESCRIPTION
When `go.toolsGopath` changes, we need to clear the cache (for tools path), so that the extensions starts looking at the new `go.toolsGopath` without needing a VS Code window reload