### PR TITLE
Add logging using vscode-debug-logger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,17 @@
 			"args": [ "--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out",
+			"outFiles": ["${workspaceRoot}/out/**/*.js"],
 			"preLaunchTask": "npm"
+		},
+		{
+			"name": "Launch as server",
+			"type": "node2",
+			"request": "launch",
+			"program": "${workspaceRoot}/out/src/debugAdapter/goDebug.js",
+			"args": [ "--server=4712" ],
+			"sourceMaps": true,
+			"outFiles": ["${workspaceRoot}/out/**/*.js"]
 		},
 		{
 			"name": "Launch Tests",
@@ -22,7 +31,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test", "env.GOPATH" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out",
+			"outFiles": ["${workspaceRoot}/out/**/*.js"],
 			"preLaunchTask": "npm"
 		}
 	]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,5 @@
 		"**/bower_components": true,
 		"out/": true
 	},
-	"editor.insertSpaces": false,
-	"typescript.tsdk": "./node_modules/typescript/lib"
+	"editor.insertSpaces": false
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^6.0.50",
     "fs-extra": "^1.0.0",
     "tslint": "^4.0.2",
-    "typescript": "^2.0.10",
+    "typescript": "^2.1.5",
     "vscode": "^1.0.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -244,9 +244,10 @@
                 "default": "127.0.0.1"
               },
               "trace": {
-                "type": "boolean",
+                "type": ["boolean", "string"],
+                "enum": ["verbose", true],
                 "default": true,
-                "description": "When 'true', the extension will log diagnostic info to the console and to a file."
+                "description": "When 'true', the extension will log diagnostic info to a file. When 'verbose', it will also show logs in the console."
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "console-stamp": "^0.2.2",
     "diff": "~3.0.0",
     "json-rpc2": "^1.0.2",
-    "vscode-debug-logger": "^0.0.3",
+    "vscode-debug-logger": "^0.0.4",
     "vscode-debugadapter": "^1.11.0",
     "vscode-debugprotocol": "^1.11.0",
     "vscode-extension-telemetry": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "console-stamp": "^0.2.2",
     "diff": "~3.0.0",
     "json-rpc2": "^1.0.2",
-    "vscode-debug-logger": "0.0.2",
+    "vscode-debug-logger": "^0.0.3",
     "vscode-debugadapter": "^1.11.0",
     "vscode-debugprotocol": "^1.11.0",
     "vscode-extension-telemetry": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -242,6 +242,11 @@
                 "type": "string",
                 "description": "The host name of the machine the delve debugger will be listening on.",
                 "default": "127.0.0.1"
+              },
+              "trace": {
+                "type": "boolean",
+                "default": true,
+                "description": "When 'true', the extension will log diagnostic info to the console and to a file."
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "console-stamp": "^0.2.2",
     "diff": "~3.0.0",
     "json-rpc2": "^1.0.2",
+    "vscode-debug-logger": "0.0.2",
     "vscode-debugadapter": "^1.11.0",
     "vscode-debugprotocol": "^1.11.0",
     "vscode-extension-telemetry": "0.0.5",
@@ -244,8 +245,14 @@
                 "default": "127.0.0.1"
               },
               "trace": {
-                "type": ["boolean", "string"],
-                "enum": ["verbose", true],
+                "type": [
+                  "boolean",
+                  "string"
+                ],
+                "enum": [
+                  "verbose",
+                  true
+                ],
                 "default": true,
                 "description": "When 'true', the extension will log diagnostic info to a file. When 'verbose', it will also show logs in the console."
               }

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -139,18 +139,20 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	trace?: string|boolean;
 }
 
-// Note: Only turn this on when debugging the debugAdapter.
-// See https://github.com/Microsoft/vscode-go/issues/206#issuecomment-194571950
-const DEBUG = false;
-function log(msg?: any, ...args) {
-	if (DEBUG) {
-		console.warn(msg, ...args);
+function log(msg: any) {
+	if (typeof msg !== 'string') {
+		msg = JSON.stringify(msg);
 	}
+
+	logger.log(msg);
 }
+
 function logError(msg?: any, ...args) {
-	if (DEBUG) {
-		console.error(msg, ...args);
+	if (typeof msg !== 'string') {
+		msg = JSON.stringify(msg);
 	}
+
+	logger.error(msg);
 }
 
 class Delve {
@@ -174,7 +176,7 @@ class Delve {
 			}
 			let dlv = getBinPathWithPreferredGopath('dlv', env['GOPATH']);
 
-			log('Using dlv at: ', dlv);
+			log('Using dlv at: ' + dlv);
 			if (!existsSync(dlv)) {
 				return reject(`Cannot find Delve debugger at ${dlv}. Ensure it is in your "GOPATH/bin" or "PATH".`);
 			}

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -139,6 +139,12 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	trace?: string|boolean;
 }
 
+process.on('uncaughtException', (err: any) => {
+	const errMessage = err && (err.stack || err.message);
+	logger.error(`Unhandled error in debug adapter: ${errMessage}`);
+	throw err;
+});
+
 function log(...args: any[]) {
 	const msg = args.map(arg => {
 		return typeof arg === 'string' ?

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -139,18 +139,22 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	trace?: string|boolean;
 }
 
-function log(msg: any) {
-	if (typeof msg !== 'string') {
-		msg = JSON.stringify(msg);
-	}
+function log(...args: any[]) {
+	const msg = args.map(arg => {
+		return typeof arg === 'string' ?
+			arg :
+			JSON.stringify(arg);
+	}).join(' ');
 
 	logger.log(msg);
 }
 
-function logError(msg?: any, ...args) {
-	if (typeof msg !== 'string') {
-		msg = JSON.stringify(msg);
-	}
+function logError(...args: any[]) {
+	const msg = args.map(arg => {
+		return typeof arg === 'string' ?
+			arg :
+			JSON.stringify(arg);
+	}).join(' ');
 
 	logger.error(msg);
 }
@@ -457,7 +461,7 @@ class GoDebugSession extends DebugSession {
 				logError('Failed to get threads.');
 				return this.sendErrorResponse(response, 2003, 'Unable to display threads: "{e}"', { e: err.toString() });
 			}
-			log(goroutines);
+			log('goroutines', goroutines);
 			let threads = goroutines.map(goroutine =>
 				new Thread(
 					goroutine.id,
@@ -466,8 +470,7 @@ class GoDebugSession extends DebugSession {
 			);
 			response.body = { threads };
 			this.sendResponse(response);
-			log('ThreadsResponse');
-			log(threads);
+			log('ThreadsResponse', threads);
 		});
 	}
 
@@ -478,7 +481,7 @@ class GoDebugSession extends DebugSession {
 				logError('Failed to produce stack trace!');
 				return this.sendErrorResponse(response, 2004, 'Unable to produce stack trace: "{e}"', { e: err.toString() });
 			}
-			log(locations);
+			log('locations', locations);
 			let stackFrames = locations.map((location, i) =>
 				new StackFrame(
 					i,
@@ -504,13 +507,13 @@ class GoDebugSession extends DebugSession {
 				logError('Failed to list local variables.');
 				return this.sendErrorResponse(response, 2005, 'Unable to list locals: "{e}"', { e: err.toString() });
 			}
-			log(locals);
+			log('locals', locals);
 			this.delve.call<DebugVariable[]>('ListFunctionArgs', [{ goroutineID: this.debugState.currentGoroutine.id, frame: args.frameId }], (err, args) => {
 				if (err) {
 					logError('Failed to list function args.');
 					return this.sendErrorResponse(response, 2006, 'Unable to list args: "{e}"', { e: err.toString() });
 				}
-				log(args);
+				log('functionArgs', args);
 				let vars = args.concat(locals);
 
 				let scopes = new Array<Scope>();
@@ -607,10 +610,9 @@ class GoDebugSession extends DebugSession {
 				};
 			});
 		}
-		log(JSON.stringify(variables, null, ' '));
 		response.body = { variables };
 		this.sendResponse(response);
-		log('VariablesResponse');
+		log('VariablesResponse', JSON.stringify(variables, null, ' '));
 	}
 
 	private handleReenterDebug(reason: string): void {
@@ -655,7 +657,7 @@ class GoDebugSession extends DebugSession {
 			if (err) {
 				logError('Failed to continue.');
 			}
-			log(state);
+			log('state', state);
 			this.debugState = state;
 			this.handleReenterDebug('breakpoint');
 		});
@@ -669,7 +671,7 @@ class GoDebugSession extends DebugSession {
 			if (err) {
 				logError('Failed to next.');
 			}
-			log(state);
+			log('state', state);
 			this.debugState = state;
 			this.handleReenterDebug('step');
 		});
@@ -683,7 +685,7 @@ class GoDebugSession extends DebugSession {
 			if (err) {
 				logError('Failed to step.');
 			}
-			log(state);
+			log('state', state);
 			this.debugState = state;
 			this.handleReenterDebug('step');
 		});
@@ -697,7 +699,7 @@ class GoDebugSession extends DebugSession {
 			if (err) {
 				logError('Failed to stepout.');
 			}
-			log(state);
+			log('state', state);
 			this.debugState = state;
 			this.handleReenterDebug('step');
 		});
@@ -712,7 +714,7 @@ class GoDebugSession extends DebugSession {
 				logError('Failed to halt.');
 				return this.sendErrorResponse(response, 2010, 'Unable to halt execution: "{e}"', { e: err.toString() });
 			}
-			log(state);
+			log('state', state);
 			this.sendResponse(response);
 			log('PauseResponse');
 		});

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -136,7 +136,7 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	host?: string;
 	buildFlags?: string;
 	init?: string;
-	trace?: string|boolean;
+	trace?: boolean;
 }
 
 process.on('uncaughtException', (err: any) => {
@@ -341,13 +341,7 @@ class GoDebugSession extends DebugSession {
 	}
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
-		const logLevel =
-			args.trace === 'verbose' ?
-				logger.LogLevel.Verbose :
-				args.trace === true ?
-					logger.LogLevel.Log :
-					logger.LogLevel.Error;
-
+		const logLevel = args.trace ? logger.LogLevel.Verbose : logger.LogLevel.Error;
 		logger.setMinLogLevel(logLevel);
 
 		// Launch the Delve debugger on the program

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -136,7 +136,7 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	host?: string;
 	buildFlags?: string;
 	init?: string;
-	trace?: boolean|"verbose";
+	trace?: boolean|'verbose';
 }
 
 process.on('uncaughtException', (err: any) => {


### PR DESCRIPTION
Spun out my debug adapter logging in node2/chrome into a new node module: https://github.com/roblourens/vscode-debug-logger.

This adds a new launch config property, 'trace'. When it isn't set, there is no change, except that the calls to `logError` will be shown as errors in the console.

When it's set to `true`, all log messages will be written to a file, and the path to the file will be printed at the top of the console.

When it's set to `"verbose"`, all log messages will be written to the file, and printed in the console.

There's quite a lot of info printed, it should be enough to trace what happens when someone reports an error.  