### PR TITLE
Expands ${workspaceRoot} in go.toolsGopath configuration

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -13,7 +13,7 @@ import cp = require('child_process');
 import { showGoStatus, hideGoStatus } from './goStatus';
 import { getGoRuntimePath } from './goPath';
 import { outputChannel } from './goStatus';
-import { getBinPath, getGoVersion, SemVersion, isVendorSupported } from './util';
+import { getBinPath, getToolsGopath, getGoVersion, SemVersion, isVendorSupported } from './util';
 
 let updatesDeclinedTools: string[] = [];
 
@@ -142,10 +142,10 @@ function installTools(goVersion: SemVersion, missing?: string[]) {
 
 	// If the go.toolsGopath is set, use
  	// its value as the GOPATH for the "go get" child process.
-	let goConfig = vscode.workspace.getConfiguration('go');
+	let toolsGopath = getToolsGopath();
 	let envWithSeparateGoPathForTools = null;
-	if (goConfig['toolsGopath']) {
-		envWithSeparateGoPathForTools = Object.assign({}, envForTools, {GOPATH: goConfig['toolsGopath']});
+	if (toolsGopath) {
+		envWithSeparateGoPathForTools = Object.assign({}, envForTools, {GOPATH: toolsGopath});
 	}
 
 	missing.reduce((res: Promise<string[]>, tool: string) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -249,7 +249,16 @@ export function isPositionInString(document: vscode.TextDocument, position: vsco
 	return doubleQuotesCnt % 2 === 1;
 }
 
-export function getBinPath(tool: string): string {
+export function getToolsGopath(): string {
 	let goConfig = vscode.workspace.getConfiguration('go');
-	return getBinPathWithPreferredGopath(tool, goConfig['toolsGopath']);
+	let toolsGopath = goConfig['toolsGopath'];
+	if (toolsGopath) {
+		toolsGopath = toolsGopath.replace(/\${workspaceRoot}/g, vscode.workspace.rootPath);
+	}
+	return toolsGopath;
 }
+
+export function getBinPath(tool: string): string {
+	return getBinPathWithPreferredGopath(tool, getToolsGopath());
+}
+


### PR DESCRIPTION
The same was done for go.gopath in https://github.com/Microsoft/vscode-go/commit/f83579f568055f8528234f56d32238f308f47ddb
Fixes #761