### PR TITLE
added go.inferGopath. Similar to GoSublime's use_gs_gopath

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following Visual Studio Code settings are available for the Go extension.  T
 	"go.formatFlags": [],
 	"go.goroot": "/usr/local/go",
 	"go.gopath": "/Users/lukeh/go",
+	"go.inferGopath": false,
 	"go.gocodeAutoBuild": false
 }
 ```

--- a/package.json
+++ b/package.json
@@ -337,6 +337,11 @@
           "default": false,
           "description": "Complete functions with their parameter signature"
         },
+        "go.inferGopath": {
+          "type": "boolean",
+          "default": false,
+          "description": "use workspace root to find appropriate GOPATH"
+        },
         "go.gopath": {
           "type": [
             "string",

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -212,12 +212,12 @@ export function updateGoPathGoRootFromConfig() {
 
 	let inferGoPath = vscode.workspace.getConfiguration('go')['inferGopath'];
 	if (inferGoPath) {
-		let dirs = vscode.workspace.rootPath.toLowerCase().split(path.sep)
+		let dirs = vscode.workspace.rootPath.toLowerCase().split(path.sep);
 		// find src directory closest to workspace root
-		let srcIdx = dirs.lastIndexOf("src")
+		let srcIdx = dirs.lastIndexOf('src');
 
 		if (srcIdx > 0) {
-			process.env['GOPATH'] = vscode.workspace.rootPath.substr(0, dirs.slice(0, srcIdx).join(path.sep).length)
+			process.env['GOPATH'] = vscode.workspace.rootPath.substr(0, dirs.slice(0, srcIdx).join(path.sep).length);
 		}
 	}
 }

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -209,6 +209,17 @@ export function updateGoPathGoRootFromConfig() {
 	if (gopath) {
 		process.env['GOPATH'] = gopath.replace(/\${workspaceRoot}/g, vscode.workspace.rootPath);
 	}
+
+	let inferGoPath = vscode.workspace.getConfiguration('go')['inferGopath'];
+	if (inferGoPath) {
+		let dirs = vscode.workspace.rootPath.toLowerCase().split(path.sep)
+		// find src directory closest to workspace root
+		let srcIdx = dirs.lastIndexOf("src")
+
+		if (srcIdx > 0) {
+			process.env['GOPATH'] = vscode.workspace.rootPath.substr(0, dirs.slice(0, srcIdx).join(path.sep).length)
+		}
+	}
 }
 
 export function setupGoPathAndOfferToInstallTools() {


### PR DESCRIPTION
I would like to propose this implementation for the feature request raised in #757 