### PR TITLE
Fix #760 - straighten out debug init flow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,5 +34,11 @@
 			"outFiles": ["${workspaceRoot}/out/**/*.js"],
 			"preLaunchTask": "npm"
 		}
+	],
+	"compounds": [
+		{
+			"name": "Extension + Debug server",
+			"configurations": ["Launch Extension", "Launch as server"]
+		}
 	]
 }

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -312,10 +312,10 @@ class GoDebugSession extends DebugSession {
 	private threads: Set<number>;
 	private debugState: DebuggerState;
 	private delve: Delve;
-	private initialBreakpointsSetPromise: Promise<void>;
-	private signalInitialBreakpointsSet: () => void;
 	private localPathSeparator: string;
 	private remotePathSeparator: string;
+
+	private launchArgs: LaunchRequestArguments;
 
 	public constructor(debuggerLinesStartAt1: boolean, isServer: boolean = false) {
 		super(debuggerLinesStartAt1, isServer);
@@ -324,7 +324,6 @@ class GoDebugSession extends DebugSession {
 		this.debugState = null;
 		this.delve = null;
 		this.breakpoints = new Map<string, DebugBreakpoint[]>();
-		this.initialBreakpointsSetPromise = new Promise<void>((resolve, reject) => this.signalInitialBreakpointsSet = resolve);
 
 		const logPath = path.join(os.tmpdir(), 'vscode-go-debug.txt');
 		logger.init(e => this.sendEvent(e), logPath, isServer);
@@ -336,11 +335,10 @@ class GoDebugSession extends DebugSession {
 		response.body.supportsConfigurationDoneRequest = true;
 		this.sendResponse(response);
 		verbose('InitializeResponse');
-		this.sendEvent(new InitializedEvent());
-		verbose('InitializeEvent');
 	}
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
+		this.launchArgs = args;
 		const logLevel = args.trace === 'verbose' ?
 			logger.LogLevel.Verbose :
 			args.trace ? logger.LogLevel.Log :
@@ -368,16 +366,9 @@ class GoDebugSession extends DebugSession {
 			this.sendEvent(new OutputEvent(str, 'stderr'));
 		};
 
-		this.delve.connection.then(() =>
-			this.initialBreakpointsSetPromise
-		).then(() => {
-			if (args.stopOnEntry) {
-				this.sendEvent(new StoppedEvent('breakpoint', 0));
-				verbose('StoppedEvent("breakpoint")');
-				this.sendResponse(response);
-			} else {
-				this.continueRequest(<DebugProtocol.ContinueResponse>response);
-			}
+		this.delve.connection.then(() => {
+			this.sendEvent(new InitializedEvent());
+			verbose('InitializeEvent');
 		}, err => {
 			this.sendErrorResponse(response, 3000, 'Failed to continue: "{e}"', { e: err.toString() });
 			verbose('ContinueResponse');
@@ -393,9 +384,16 @@ class GoDebugSession extends DebugSession {
 
 	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
 		verbose('ConfigurationDoneRequest');
-		this.signalInitialBreakpointsSet();
 		this.sendResponse(response);
 		verbose('ConfigurationDoneRequest');
+
+		if (this.launchArgs.stopOnEntry) {
+			this.sendEvent(new StoppedEvent('breakpoint', 0));
+			verbose('StoppedEvent("breakpoint")');
+			this.sendResponse(response);
+		} else {
+			this.continueRequest(<DebugProtocol.ContinueResponse>response);
+		}
 	}
 
 	protected toDebuggerPath(path: string): string {

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -461,7 +461,7 @@ class GoDebugSession extends DebugSession {
 				// If the program exits very quickly, the initial threadsRequest will complete after it has exited.
 				// A TerminatedEvent has already been sent. Ignore the err returned in this case.
 				response.body = { threads: [] };
-				this.sendResponse(response);
+				return this.sendResponse(response);
 			}
 
 			if (err) {

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -369,6 +369,7 @@ class GoDebugSession extends DebugSession {
 		this.delve.connection.then(() => {
 			this.sendEvent(new InitializedEvent());
 			verbose('InitializeEvent');
+			this.sendResponse(response);
 		}, err => {
 			this.sendErrorResponse(response, 3000, 'Failed to continue: "{e}"', { e: err.toString() });
 			verbose('ContinueResponse');
@@ -383,8 +384,6 @@ class GoDebugSession extends DebugSession {
 	}
 
 	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
-		verbose('ConfigurationDoneRequest');
-		this.sendResponse(response);
 		verbose('ConfigurationDoneRequest');
 
 		if (this.launchArgs.stopOnEntry) {


### PR DESCRIPTION
Now this will do things in the same order as other debug adapters.