### PR TITLE
Fix #438

### DIFF
--- a/scripts/terminateProcess.sh
+++ b/scripts/terminateProcess.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+terminateTree() {
+	for cpid in $(/usr/bin/pgrep -P $1); do
+		terminateTree $cpid
+	done
+	kill -9 $1 > /dev/null 2>&1
+}
+
+for pid in $*; do
+	terminateTree $pid
+done

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -758,23 +758,23 @@ function random(low: number, high: number): number {
 }
 
 function killTree(processId: number): void {
-    if (process.platform === 'win32') {
-        const TASK_KILL = 'C:\\Windows\\System32\\taskkill.exe';
+	if (process.platform === 'win32') {
+		const TASK_KILL = 'C:\\Windows\\System32\\taskkill.exe';
 
-        // when killing a process in Windows its child processes are *not* killed but become root processes.
-        // Therefore we use TASKKILL.EXE
-        try {
-            execSync(`${TASK_KILL} /F /T /PID ${processId}`);
-        } catch (err) {
-        }
-    } else {
-        // on linux and OS X we kill all direct and indirect child processes as well
-        try {
-            const cmd = path.join(__dirname, '../../../scripts/terminateProcess.sh');
-            spawnSync(cmd, [ processId.toString() ]);
-        } catch (err) {
-        }
-    }
+		// when killing a process in Windows its child processes are *not* killed but become root processes.
+		// Therefore we use TASKKILL.EXE
+		try {
+			execSync(`${TASK_KILL} /F /T /PID ${processId}`);
+		} catch (err) {
+		}
+	} else {
+		// on linux and OS X we kill all direct and indirect child processes as well
+		try {
+			const cmd = path.join(__dirname, '../../../scripts/terminateProcess.sh');
+			spawnSync(cmd, [ processId.toString() ]);
+		} catch (err) {
+		}
+	}
 }
 
 DebugSession.run(GoDebugSession);


### PR DESCRIPTION
This is using the same code we have in the node debuggers to kill the whole process tree, not just the delve process. 