### PR TITLE
Ignore import statements in Go to Symbol in File feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -425,7 +425,7 @@
           "default": false,
           "description": "Experimental: Not available in Windows. Use Go language server from Sourcegraph for Hover, Definition, Find All References, Signature Help, File Outline and Workspace Symbol features"
         },
-        "go.gotoSymbolIncludeImports": {
+        "go.gotoSymbol.includeImports": {
           "type": "boolean",
           "default": false,
           "description": "If false, the import statements will be excluded while using the Go to Symbol in File feature"

--- a/package.json
+++ b/package.json
@@ -276,6 +276,11 @@
           "default": [],
           "description": "Flags to `go build`/`go test` used during build-on-save or running tests. (e.g. ['-ldflags=\"-s\"'])"
         },
+        "go.buildTags": {
+          "type": "string",
+          "default": "",
+          "description": "The Go build tags to use for all commands that support a `-tags '...'` argument"
+        },
         "go.lintOnSave": {
           "type": "boolean",
           "default": true,
@@ -311,6 +316,11 @@
           "default": [],
           "description": "Flags to pass to `go tool vet` (e.g. ['-all', '-shadow'])"
         },
+        "go.formatOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Runs formatting tool on save."
+        },
         "go.formatTool": {
           "type": "string",
           "default": "goreturns",
@@ -334,11 +344,6 @@
           "default": true,
           "description": "Run the formatting tools with the -d flag"
         },
-        "go.useCodeSnippetsOnFunctionSuggest": {
-          "type": "boolean",
-          "default": false,
-          "description": "Complete functions with their parameter signature"
-        },
         "go.inferGopath": {
           "type": "boolean",
           "default": false,
@@ -352,6 +357,11 @@
           "default": null,
           "description": "Specifies the GOPATH to use when no environment variable is set. The inferred GOPATH from workspace root overrides this, if go.inferGopath is set to true."
         },
+         "go.toolsGopath": {
+          "type": "string",
+          "default": "",
+          "description": "Location to install the Go tools that the extension depends on if you don't want them in your GOPATH."
+        },
         "go.goroot": {
           "type": [
             "string",
@@ -359,11 +369,6 @@
           ],
           "default": null,
           "description": "Specifies the GOROOT to use when no environment variable is set."
-        },
-        "go.formatOnSave": {
-          "type": "boolean",
-          "default": true,
-          "description": "Runs formatting tool on save."
         },
         "go.coverOnSave": {
           "type": "boolean",
@@ -375,20 +380,31 @@
           "default": "30s",
           "description": "Specifies the timeout for go test in ParseDuration format."
         },
+        "go.testEnvVars": {
+          "type": "object",
+          "default": {},
+          "description": "Environment variables that will passed to the process that runs the Go tests"
+        },
+        "go.testFlags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "default": null,
+          "description": "Flags to pass to `go test`. If null, then buildFlags will be used."
+        },
         "go.gocodeAutoBuild": {
           "type": "boolean",
           "default": true,
           "description": "Enable gocode's autobuild feature"
         },
-        "go.buildTags": {
-          "type": "string",
-          "default": "",
-          "description": "The Go build tags to use for all commands that support a `-tags '...'` argument"
-        },
-        "go.testEnvVars": {
-          "type": "object",
-          "default": {},
-          "description": "Environment variables that will passed to the process that runs the Go tests"
+         "go.useCodeSnippetsOnFunctionSuggest": {
+          "type": "boolean",
+          "default": false,
+          "description": "Complete functions with their parameter signature"
         },
         "go.autocompleteUnimportedPackages": {
           "type": "boolean",
@@ -404,26 +420,15 @@
             "gogetdoc"
           ]
         },
-        "go.toolsGopath": {
-          "type": "string",
-          "default": "",
-          "description": "Location to install the Go tools that the extension depends on if you don't want them in your GOPATH."
-        },
-        "go.testFlags": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "default": null,
-          "description": "Flags to pass to `go test`. If null, then buildFlags will be used."
-        },
         "go.useLanguageServer": {
           "type": "boolean",
           "default": false,
           "description": "Experimental: Not available in Windows. Use Go language server from Sourcegraph for Hover, Definition, Find All References, Signature Help, File Outline and Workspace Symbol features"
+        },
+        "go.gotoSymbolIncludeImports": {
+          "type": "boolean",
+          "default": false,
+          "description": "If false, the import statements will be excluded while using the Go to Symbol in File feature"
         }
       }
     }

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -76,7 +76,8 @@ export class GoDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 	};
 
 	private convertToCodeSymbols(document: vscode.TextDocument, decls: GoOutlineDeclaration[], symbols: vscode.SymbolInformation[], containerName: string): void {
-		let includeImports = vscode.workspace.getConfiguration('go')['gotoSymbolIncludeImports'];
+		let gotoSymbolConfig = vscode.workspace.getConfiguration('go')['gotoSymbol'];
+		let includeImports = gotoSymbolConfig ? gotoSymbolConfig['includeImports'] : false;
 		sendTelemetryEvent('file-symbols', { includeImports });
 		decls.forEach(decl => {
 			if (!includeImports && decl.type === 'import') return;

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -8,7 +8,7 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import path = require('path');
-import { getBinPath } from './util';
+import { getBinPath, sendTelemetryEvent } from './util';
 import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
 
 // Keep in sync with https://github.com/lukehoban/go-outline
@@ -76,7 +76,10 @@ export class GoDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 	};
 
 	private convertToCodeSymbols(document: vscode.TextDocument, decls: GoOutlineDeclaration[], symbols: vscode.SymbolInformation[], containerName: string): void {
+		let includeImports = vscode.workspace.getConfiguration('go')['gotoSymbolIncludeImports'];
+		sendTelemetryEvent('file-symbols', { includeImports });
 		decls.forEach(decl => {
+			if (!includeImports && decl.type === 'import') return;
 			let label = decl.label;
 			if (decl.receiverType) {
 				label = '(' + decl.receiverType + ').' + label;


### PR DESCRIPTION
The Go To Symbols in File feature currently lists all the import statements as symbols as well.
This becomes noisy for a file with a lot of imports and hinders symbol search as well.

See https://github.com/Microsoft/vscode-go/issues/680#issuecomment-267515076

This PR ignores the import statements in the Go to Symbol File feature.
Will keep a setting to include them. 
Based on the telemetry, we can see how many users turn it back on to include imports, and then take the call to remove the setting if needed.