### PR TITLE
fix offsets for files with multibyte characters

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -53,12 +53,7 @@ let telemtryReporter: TelemetryReporter;
 export function byteOffsetAt(document: vscode.TextDocument, position: vscode.Position): number {
 	let offset = document.offsetAt(position);
 	let text = document.getText();
-	let byteOffset = 0;
-	for (let i = 0; i < offset; i++) {
-		let clen = Buffer.byteLength(text[i]);
-		byteOffset += clen;
-	}
-	return byteOffset;
+	return Buffer.byteLength(text.substr(0, offset));
 }
 
 export interface Prelude {


### PR DESCRIPTION
When using multibyte characters like 🚨 in comments, actions like hover and go-to-def were using wrong offsets after that character.