### PR TITLE
Option to Ignore folders while workspace symbol search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
   - go get -u -v sourcegraph.com/sqs/goreturns
   - go get -u -v golang.org/x/tools/cmd/gorename
   - go get -u -v github.com/tpng/gopkgs
-  - go get -u -v github.com/newhook/go-symbols
+  - go get -u -v github.com/acroca/go-symbols
   - go get -u -v github.com/alecthomas/gometalinter
   - go get -u -v github.com/cweill/gotests/...
   - GO15VENDOREXPERIMENT=1

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The extension uses the following tools, installed in the current GOPATH.  If any
 - goreturns: `go get -u -v sourcegraph.com/sqs/goreturns`
 - gorename: `go get -u -v golang.org/x/tools/cmd/gorename`
 - gopkgs: `go get -u -v github.com/tpng/gopkgs`
-- go-symbols: `go get -u -v github.com/newhook/go-symbols`
+- go-symbols: `go get -u -v github.com/acroca/go-symbols`
 - guru: `go get -u -v golang.org/x/tools/cmd/guru`
 - gotests: `go get -u -v github.com/cweill/gotests/...`
 
@@ -165,7 +165,7 @@ go get -u -v github.com/lukehoban/go-outline
 go get -u -v sourcegraph.com/sqs/goreturns
 go get -u -v golang.org/x/tools/cmd/gorename
 go get -u -v github.com/tpng/gopkgs
-go get -u -v github.com/newhook/go-symbols
+go get -u -v github.com/acroca/go-symbols
 go get -u -v golang.org/x/tools/cmd/guru
 go get -u -v github.com/cweill/gotests/...
 ```

--- a/package.json
+++ b/package.json
@@ -429,6 +429,14 @@
           "type": "boolean",
           "default": false,
           "description": "If false, the import statements will be excluded while using the Go to Symbol in File feature"
+        },
+        "go.gotoSymbol.ignoreFolders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Folder names (not paths) to ignore while using Go to Symbol in Workspace feature"
         }
       }
     }

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -23,7 +23,7 @@ function getTools(goVersion: SemVersion): { [key: string]: string } {
 		'gocode': 'github.com/nsf/gocode',
 		'gopkgs': 'github.com/tpng/gopkgs',
 		'go-outline': 'github.com/lukehoban/go-outline',
-		'go-symbols': 'github.com/newhook/go-symbols',
+		'go-symbols': 'github.com/acroca/go-symbols',
 		'guru': 'golang.org/x/tools/cmd/guru',
 		'gorename': 'golang.org/x/tools/cmd/gorename'
 	};

--- a/src/goSymbol.ts
+++ b/src/goSymbol.ts
@@ -72,7 +72,7 @@ export function getWorkspaceSymbols(workspacePath: string, query: string, goConf
 					if (err && (<any>err).code === 'ENOENT') {
 						promptForMissingTool('go-symbols');
 					}
-					if (err && stderr && stderr.startsWith('flag provided but not defined: -ignoreFoldersString')) {
+					if (err && stderr && stderr.startsWith('flag provided but not defined: -ignore')) {
 						promptForUpdatingTool('go-symbols');
 						return getWorkspaceSymbols(workspacePath, query, goConfig, false).then(results => {
 							return resolve(results);

--- a/src/goSymbol.ts
+++ b/src/goSymbol.ts
@@ -7,9 +7,9 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import { getBinPath } from './util';
-import { promptForMissingTool } from './goInstallTools';
+import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
 
-// Keep in sync with github.com/newhook/go-symbols'
+// Keep in sync with github.com/acroca/go-symbols'
 interface GoSymbolDeclaration {
 	name: string;
 	kind: string;
@@ -47,11 +47,24 @@ export class GoWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider
 				symbols.push(symbolInfo);
 			});
 		};
-		let symArgs = vscode.workspace.getConfiguration('go')['symbols'];
-		let args = [vscode.workspace.rootPath, query];
-		if (symArgs !== undefined && symArgs !== '') {
-			args.unshift(symArgs);
+
+		return getWorkspaceSymbols(vscode.workspace.rootPath, query).then(results => {
+			let symbols: vscode.SymbolInformation[] = [];
+			convertToCodeSymbols(results, symbols);
+			return symbols;
+		});
+	}
+}
+
+export function getWorkspaceSymbols(workspacePath: string, query: string, goConfig?: vscode.WorkspaceConfiguration, ignoreFolderFeatureOn: boolean = true): Thenable<GoSymbolDeclaration[]> {
+		if (!goConfig) {
+			goConfig = vscode.workspace.getConfiguration('go');
 		}
+		let gotoSymbolConfig = goConfig['gotoSymbol'];
+		let ignoreFolders: string[] = gotoSymbolConfig ? gotoSymbolConfig['ignoreFolders'] : [];
+		let args = (ignoreFolderFeatureOn && ignoreFolders && ignoreFolders.length > 0) ? ['-ignore', ignoreFolders.join(',')] : [];
+		args.push(workspacePath);
+		args.push(query);
 		let gosyms = getBinPath('go-symbols');
 		return new Promise((resolve, reject) => {
 			let p = cp.execFile(gosyms, args, { maxBuffer: 1024 * 1024 }, (err, stdout, stderr) => {
@@ -59,16 +72,19 @@ export class GoWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider
 					if (err && (<any>err).code === 'ENOENT') {
 						promptForMissingTool('go-symbols');
 					}
+					if (err && stderr && stderr.startsWith('flag provided but not defined: -ignoreFoldersString')) {
+						promptForUpdatingTool('go-symbols');
+						return getWorkspaceSymbols(workspacePath, query, goConfig, false).then(results => {
+							return resolve(results);
+						});
+					}
 					if (err) return resolve(null);
 					let result = stdout.toString();
 					let decls = <GoSymbolDeclaration[]>JSON.parse(result);
-					let symbols: vscode.SymbolInformation[] = [];
-					convertToCodeSymbols(decls, symbols);
-					return resolve(symbols);
+					return resolve(decls);
 				} catch (e) {
 					reject(e);
 				}
 			});
 		});
 	}
-}


### PR DESCRIPTION
This uses https://github.com/acroca/go-symbols/ which is a fork of https://github.com/newhook/go-symbols. Didnt get a response to merge the former to the latter, therefore using the fork.

Fixes #700 
