### PR TITLE
clean up import paths

### DIFF
--- a/src/diffUtils.ts
+++ b/src/diffUtils.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------*/
 
 import { TextDocument, Position, Range, TextEdit, Uri, WorkspaceEdit, TextEditorEdit } from 'vscode';
-import { getBinPathFromEnvVar } from '../src/goPath';
+import { getBinPathFromEnvVar } from './goPath';
 import jsDiff = require('diff');
 
 let diffToolAvailable: boolean = null;

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -8,7 +8,7 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import path = require('path');
-import { isDiffToolAvailable, getEdits, getEditsFromUnifiedDiffStr } from '../src/diffUtils';
+import { isDiffToolAvailable, getEdits, getEditsFromUnifiedDiffStr } from './diffUtils';
 import { promptForMissingTool } from './goInstallTools';
 import { sendTelemetryEvent, getBinPath } from './util';
 

--- a/src/goRename.ts
+++ b/src/goRename.ts
@@ -8,7 +8,7 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import { getBinPath, byteOffsetAt, canonicalizeGOPATHPrefix } from './util';
-import { getEditsFromUnifiedDiffStr, isDiffToolAvailable, FilePatch, Edit } from '../src/diffUtils';
+import { getEditsFromUnifiedDiffStr, isDiffToolAvailable, FilePatch, Edit } from './diffUtils';
 import { promptForMissingTool } from './goInstallTools';
 
 export class GoRenameProvider implements vscode.RenameProvider {


### PR DESCRIPTION
These paths caused me problems when I was trying to pursue method 1 in https://github.com/Microsoft/vscode/issues/20623

When running `./scripts/code.sh` in vscode I saw:
```
[85253:0214/175725:INFO:CONSOLE(84)] "Activating extension `lukehoban.vscode-go` failed: Cannot find module '../src/diffUtils'.", source: file:////Users/nick/code/vscode/out/vs/workbench/services/message/browser/messageService.js (84)
```

Seems like these paths are otherwise equivalent so I hope this doesn't cause a problem elsewhere.