### PR TITLE
export GoOutlineRange, GoOutlineDeclaration, GoOutlineOptions

### DIFF
--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -12,12 +12,12 @@ import { getBinPath, sendTelemetryEvent } from './util';
 import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
 
 // Keep in sync with https://github.com/lukehoban/go-outline
-interface GoOutlineRange {
+export interface GoOutlineRange {
 	start: number;
 	end: number;
 }
 
-interface GoOutlineDeclaration {
+export interface GoOutlineDeclaration {
 	label: string;
 	type: string;
 	receiverType?: string;
@@ -29,7 +29,7 @@ interface GoOutlineDeclaration {
 	comment?: GoOutlineRange;
 }
 
-interface GoOutlineOptions {
+export interface GoOutlineOptions {
 	fileName: string;
 	importsOnly?: boolean;
 }


### PR DESCRIPTION
because they are used in an exported function.

These paths caused me problems when I was trying to pursue method 1 in https://github.com/Microsoft/vscode/issues/20623

```
[17:13:16] Starting 'watch-client'...
[17:14:20] Error: /Users/nick/code/vscode/extensions/vscode-go/src/goOutline.ts(37,42): Parameter 'options' of exported function has or is using private name 'GoOutlineOptions'.
[17:14:20] Error: /Users/nick/code/vscode/extensions/vscode-go/src/goOutline.ts(37,69): Return type of exported function has or is using private name 'GoOutlineDeclaration'.
```