### PR TITLE
Add go.testOnSave option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following Visual Studio Code settings are available for the Go extension.  T
 	"go.lintTool": "golint",
 	"go.lintFlags": [],
 	"go.vetFlags": [],
+	"go.testOnSave": false,
 	"go.coverOnSave": false,
 	"go.useCodeSnippetsOnFunctionSuggest": false,
 	"go.formatOnSave": true, 

--- a/package.json
+++ b/package.json
@@ -420,6 +420,11 @@
           "default": null,
           "description": "Specifies the GOROOT to use when no environment variable is set."
         },
+        "go.testOnSave": {
+          "type": "boolean",
+          "default": false,
+          "description": "Run 'go test' on save."
+        },
         "go.coverOnSave": {
           "type": "boolean",
           "default": false,

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -14,7 +14,42 @@ import { getGoRuntimePath } from './goPath';
 import { getCoverage } from './goCover';
 import { outputChannel } from './goStatus';
 import { promptForMissingTool } from './goInstallTools';
+import { goTest } from './goTest';
 import { getBinPath, parseFilePrelude } from './util';
+
+let statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+statusBarItem.command = 'go.test.showOutput';
+
+export function removeTestStatus(e: vscode.TextDocumentChangeEvent) {
+	if (e.document.isUntitled || e.document.languageId !== 'go') {
+		return;
+	}
+	statusBarItem.hide();
+	statusBarItem.text = '';
+}
+
+export function showHideTestStatus() {
+	if (!vscode.window.activeTextEditor) {
+		statusBarItem.hide();
+		return;
+	}
+
+	let goConfig = vscode.workspace.getConfiguration('go');
+	if (!goConfig['testOnSave']) {
+		statusBarItem.hide();
+		return;
+	}
+
+	let editor = vscode.window.activeTextEditor;
+	if (editor.document.languageId !== 'go') {
+		statusBarItem.hide();
+		return;
+	}
+
+	if (statusBarItem.text !== '') {
+		statusBarItem.show();
+	}
+}
 
 export interface ICheckResult {
 	file: string;
@@ -27,7 +62,7 @@ export interface ICheckResult {
  * Runs given Go tool and returns errors/warnings that can be fed to the Problems Matcher
  * @param args Arguments to be passed while running given tool
  * @param cwd cwd that will passed in the env object while running given tool
- * @param serverity error or warning
+ * @param severity error or warning
  * @param useStdErr If true, the stderr of the output of the given tool will be used, else stdout will be used
  * @param toolName The name of the Go tool to run. If none is provided, the go runtime itself is used
  * @param printUnexpectedOutput If true, then output that doesnt match expected format is printed to the output channel
@@ -103,6 +138,30 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 		return Promise.resolve([]);
 	}
 
+	let testPromise: Thenable<boolean>;
+	let tmpCoverPath;
+	let runTest = () => {
+		if (testPromise) {
+			return testPromise;
+		}
+
+		let buildFlags = goConfig['testFlags'] || goConfig['buildFlags'] || [];
+
+		let args = buildFlags;
+		if (goConfig['coverOnSave']) {
+			tmpCoverPath = path.normalize(path.join(os.tmpdir(), 'go-code-cover'));
+			args = ['-coverprofile=' + tmpCoverPath, ...buildFlags];
+		}
+
+		testPromise = goTest({
+			goConfig: goConfig,
+			dir: cwd,
+			flags: args,
+			background: true
+		});
+		return testPromise;
+	};
+
 	if (!!goConfig['buildOnSave']) {
 		// we need to parse the file to check the package name
 		// if the package is a main pkg, we won't be doing a go build -i
@@ -140,6 +199,22 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 		});
 		runningToolsPromises.push(buildPromise);
 	}
+
+	if (!!goConfig['testOnSave']) {
+		statusBarItem.show();
+		statusBarItem.text = 'testing';
+		runTest().then(success => {
+			if (statusBarItem.text === '') {
+				return;
+			}
+			if (success) {
+				statusBarItem.text = 'OK :-)';
+			} else {
+				statusBarItem.text = 'FAIL :-(';
+			}
+		});
+	}
+
 	if (!!goConfig['lintOnSave']) {
 		let lintTool = goConfig['lintTool'] || 'golint';
 		let lintFlags: string[] = goConfig['lintFlags'] || [];
@@ -171,7 +246,14 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 	}
 
 	if (!!goConfig['coverOnSave']) {
-		runningToolsPromises.push(getCoverage(filename));
+		let coverPromise = runTest().then(success => {
+			if (!success) {
+				return [];
+			}
+			// FIXME: it's not obvious that tmpCoverPath comes from runTest()
+			return getCoverage(tmpCoverPath);
+		});
+		runningToolsPromises.push(coverPromise);
 	}
 
 	return Promise.all(runningToolsPromises).then(resultSets => [].concat.apply([], resultSets));

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -19,12 +19,12 @@ import { GoDocumentSymbolProvider } from './goOutline';
 import { GoSignatureHelpProvider } from './goSignature';
 import { GoWorkspaceSymbolProvider } from './goSymbol';
 import { GoCodeActionProvider } from './goCodeAction';
-import { check, ICheckResult } from './goCheck';
+import { check, ICheckResult, removeTestStatus, showHideTestStatus } from './goCheck';
 import { updateGoPathGoRootFromConfig, setupGoPathAndOfferToInstallTools } from './goInstallTools';
 import { GO_MODE } from './goMode';
 import { showHideStatus } from './goStatus';
 import { coverageCurrentPackage, getCodeCoverage, removeCodeCoverage } from './goCover';
-import { testAtCursor, testCurrentPackage, testCurrentFile, testPrevious } from './goTest';
+import { testAtCursor, testCurrentPackage, testCurrentFile, testPrevious, showTestOutput } from './goTest';
 import * as goGenerateTests from './goGenerateTests';
 import { addImport } from './goImport';
 import { installAllTools, checkLanguageServer } from './goInstallTools';
@@ -74,8 +74,10 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	diagnosticCollection = vscode.languages.createDiagnosticCollection('go');
 	ctx.subscriptions.push(diagnosticCollection);
 	vscode.workspace.onDidChangeTextDocument(removeCodeCoverage, null, ctx.subscriptions);
+	vscode.workspace.onDidChangeTextDocument(removeTestStatus, null, ctx.subscriptions);
 	vscode.window.onDidChangeActiveTextEditor(showHideStatus, null, ctx.subscriptions);
 	vscode.window.onDidChangeActiveTextEditor(getCodeCoverage, null, ctx.subscriptions);
+	vscode.window.onDidChangeActiveTextEditor(showHideTestStatus, null, ctx.subscriptions);
 
 	setupGoPathAndOfferToInstallTools();
 	startBuildOnSaveWatcher(ctx.subscriptions);
@@ -113,6 +115,10 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.coverage', () => {
 		coverageCurrentPackage();
+	}));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.showOutput', () => {
+		showTestOutput();
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.import.add', (arg: string) => {

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -9,6 +9,7 @@ import cp = require('child_process');
 import path = require('path');
 import vscode = require('vscode');
 import util = require('util');
+import os = require('os');
 import { getGoRuntimePath } from './goPath';
 import { GoDocumentSymbolProvider } from './goOutline';
 
@@ -34,6 +35,10 @@ interface TestConfig {
 	 * Specific function names to test.
 	 */
 	functions?: string[];
+	/**
+	 * Test was not requested explicitly. The output should not appear in the UI.
+	 */
+	background?: boolean;
 }
 
 // lastTestConfig holds a reference to the last executed TestConfig which allows
@@ -89,7 +94,7 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, args: any)
  *
  * @param goConfig Configuration for the Go extension.
  */
-export function testCurrentPackage(goConfig: vscode.WorkspaceConfiguration, args: string[]) {
+export function testCurrentPackage(goConfig: vscode.WorkspaceConfiguration, args: any) {
 	let editor = vscode.window.activeTextEditor;
 	if (!editor) {
 		vscode.window.showInformationMessage('No editor is active.');
@@ -147,16 +152,25 @@ export function testPrevious() {
 }
 
 /**
+ * Reveals the output channel in the UI.
+ */
+export function showTestOutput() {
+	outputChannel.show(true);
+}
+
+/**
  * Runs go test and presents the output in the 'Go' channel.
  *
  * @param goConfig Configuration for the Go extension.
  */
-function goTest(testconfig: TestConfig): Thenable<boolean> {
+export function goTest(testconfig: TestConfig): Thenable<boolean> {
 	return new Promise<boolean>((resolve, reject) => {
-		// Remember this config as the last executed test.
-		lastTestConfig = testconfig;
 		outputChannel.clear();
-		outputChannel.show(2, true);
+		if (!testconfig.background) {
+			// Remember this config as the last executed test.
+			lastTestConfig = testconfig;
+			outputChannel.show(true);
+		}
 
 		let buildTags: string = testconfig.goConfig['buildTags'];
 		let args = ['test', ...testconfig.flags, '-timeout', testconfig.goConfig['testTimeout'], '-tags', buildTags];
@@ -172,6 +186,10 @@ function goTest(testconfig: TestConfig): Thenable<boolean> {
 			args.push('-run');
 			args.push(util.format('^%s$', testconfig.functions.join('|')));
 		}
+
+		outputChannel.appendLine(['Running tool:', goRuntimePath, ...args].join(' '));
+		outputChannel.appendLine('');
+
 		let proc = cp.spawn(goRuntimePath, args, { env: testEnvVars, cwd: testconfig.dir });
 		proc.stdout.on('data', chunk => outputChannel.append(chunk.toString()));
 		proc.stderr.on('data', chunk => outputChannel.append(chunk.toString()));


### PR DESCRIPTION
This is a very straightforward implementation of the testOnSave feature (#581).

I suppose it would be much better to compile sources only one time if buildOnSave, testOnSave, and coverOnSave are on: `go test -c` includes everything from `go build`, cover is obtained from tests.

Also it would be nice to have some sort of progress bar, but I have no idea where it should be placed.