### PR TITLE
Long variable values in debug mode get truncated

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -641,12 +641,8 @@ class GoDebugSession extends DebugSession {
 				variablesReference: this._variableHandles.create(v)
 			};
 		} else if (v.kind === GoReflectKind.String) {
-			let val = v.value;
-			if (v.value && v.value.length < v.len) {
-				val += `...+${v.len - v.value.length} more`;
-			}
 			return {
-				result: v.unreadable ? ('<' + v.unreadable + '>') : ('"' + val + '"'),
+				result: v.unreadable ? ('<' + v.unreadable + '>') : ('"' + v.value + '"'),
 				variablesReference: 0
 			};
 		} else {


### PR DESCRIPTION
Visual Studio Code truncates the values of local debug variables today, so they fit nicely in the sidebar.  vscode-go seems to apply additional measures on top of the default behavior for truncating variable values with string types.  As a result, we cannot access the full value of the variable if it exceeds the limit in place (appears to be 64: https://github.com/derekparker/delve/issues/659#issuecomment-256945278), while debugging.

What I've done here, is simply remove that limit and return the entire value of the variable that we're debugging.

#868