### PR TITLE
Fixes #241 Use absolute path in output pane to support links

### DIFF
--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -244,7 +244,7 @@ function getTestFlags(goConfig: vscode.WorkspaceConfiguration, args: any): strin
 function expandFilePathInOutput(output: string, cwd: string): string {
 	let lines = output.split('\n');
 	for (let i = 0; i < lines.length; i++) {
-		let matches = lines[i].match(/^\t(\w+_test.go):(\d+):/);
+		let matches = lines[i].match(/^\t(\S+_test.go):(\d+):/);
 		if (matches) {
 			lines[i] = lines[i].replace(matches[1], path.join(cwd, matches[1]));
 		}


### PR DESCRIPTION
Fixes #241

The output from `go test -v` in case of test failures look like this:

![image](https://cloud.githubusercontent.com/assets/16890566/24377549/950b0bc8-12f4-11e7-8dbc-05b7c7547d43.png)

This PR is to expand the filename to its absolute path, so that it is clickable and acts as a link to the test file

