### PR TITLE
Fixes #728 Add commands to context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ The following Visual Studio Code settings along with their *default* values that
 		"tags": "",						// Comma separated tags that will get removed by the Remove Tags command. If empty, all tags are removed.
 		"options": "",					// Comma separated tag options that will get removed by the Remove Tags command. 
 		"promptForTags": false			// If true, then user will be prompted to provide tags and options to be removed by the Remove Tags command.
+	},
+	"go.editorContextMenuCommands": {	// Enable/Disable commands from the context menu in the editor.
+		"toggleTestFile": true,
+		"addTags": true,
+		"removeTags": true,
+		"testAtCursor": true,
+		"generateTestForFunction": true,
+		"addImport": true
 	}
 }
 ```
@@ -131,13 +139,13 @@ In addition to integrated editing features, the extension also provides several 
 
 * `Go: Add Import` to add an import from the list of packages in your Go context
 * `Go: Current GOPATH` to see your currently configured GOPATH
-* `Go: Run test at cursor` to run a test at the current cursor position in the active document
-* `Go: Run tests in current package` to run all tests in the package containing the active document
-* `Go: Run tests in current file` to run all tests in the current active document
+* `Go: Test at cursor` to run a test at the current cursor position in the active document
+* `Go: Test Package` to run all tests in the package containing the active document
+* `Go: Test File` to run all tests in the current active document
 * `Go: Test Previous` to run the previously run test command
-* `Go: Generates unit tests (package)` Generates unit tests for the current package
-* `Go: Generates unit tests (file)` Generates unit tests for the current file
-* `Go: Generates unit tests (function)` Generates unit tests for the selected function in the current file
+* `Go: Generates unit tests for package` Generates unit tests for the current package
+* `Go: Generates unit tests for file` Generates unit tests for the current file
+* `Go: Generates unit tests for function` Generates unit tests for the selected function in the current file
 * `Go: Install Tools` Installs/updates all the Go tools that the extension depends on
 * `Go: Add Tags` Adds configured tags to selected struct fields.
 * `Go: Remove Tags` Removes configured tags from selected struct fields.

--- a/package.json
+++ b/package.json
@@ -111,17 +111,17 @@
       },
       {
         "command": "go.test.generate.package",
-        "title": "Go: Generate unit tests for current package",
+        "title": "Go: Generate unit tests for package",
         "description": "Generates unit tests for the current package"
       },
       {
         "command": "go.test.generate.file",
-        "title": "Go: Generate unit tests for current file",
+        "title": "Go: Generate unit tests for file",
         "description": "Generates unit tests for the current file"
       },
       {
         "command": "go.test.generate.function",
-        "title": "Go: Generate unit tests for current function",
+        "title": "Go: Generate unit tests for function",
         "description": "Generates unit tests for the selected function in the current file"
       },
       {
@@ -141,12 +141,12 @@
       },
       {
         "command": "go.add.tags",
-        "title": "Go: Add Tags",
+        "title": "Go: Add Tags to struct fields",
         "description": "Add tags configured in go.addTags setting to selected struct using gomodifytags"
       },
       {
         "command": "go.remove.tags",
-        "title": "Go: Remove Tags",
+        "title": "Go: Remove Tags from struct fields",
         "description": "Remove tags configured in go.removeTags setting from selected struct using gomodifytags"
       }
     ],
@@ -522,8 +522,48 @@
             "promptForTags": false
           },
           "description": "Tags and options configured here will be used by the Remove Tags command to remove tags to struct fields. If promptForTags is true, then user will be prompted for tags and options. By default, all tags and options will be removed."
+        },
+        "go.editorContextMenuCommands": {
+          "type": "object",
+          "default": {
+            "toggleTestFile": true,
+            "addTags": true,
+            "removeTags": true,
+            "testAtCursor": true,
+            "generateTestForFunction": true,
+            "addImport": true
+          },
+          "description": "Enable/Disable entries from the context menu in the editor."
         }
       }
+    },
+    "menus": {
+      "editor/context": [
+        {
+          "when": "editorTextFocus && config.go.editorContextMenuCommands.toggleTestFile && resourceLangId == go",
+          "command": "go.toggle.test.file"
+        },
+        {
+          "when": "editorTextFocus && config.go.editorContextMenuCommands.addTags && resourceLangId == go",
+          "command": "go.add.tags"
+        },
+        {
+          "when": "editorTextFocus && config.go.editorContextMenuCommands.removeTags && resourceLangId == go",
+          "command": "go.remove.tags"
+        },
+        {
+          "when": "editorTextFocus && config.go.editorContextMenuCommands.testAtCursor && resourceLangId == go",
+          "command": "go.test.cursor"
+        },
+        {
+          "when": "editorTextFocus && config.go.editorContextMenuCommands.generateTestForFunction && resourceLangId == go",
+          "command": "go.test.generate.function"
+        },
+         {
+          "when": "editorTextFocus && config.go.editorContextMenuCommands.addImport && resourceLangId == go",
+          "command": "go.import.add"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
As a test run, I am planning to ship this in the coming update

![image](https://cloud.githubusercontent.com/assets/16890566/24372205/08f1bd24-12e2-11e7-8c3f-7e22510ef8cc.png)

People who feel this would clutter their menu and are comfortable using the command pallet instead, can change the settings to disable these entries

![image](https://cloud.githubusercontent.com/assets/16890566/24372229/29446630-12e2-11e7-92ef-91dcb1974c38.png)


Sub menus are not supported yet, if they were then we could group these more appropriately.

This can act as a feature discovery tool, which users can prune as per their needs.