### PR TITLE
Add live error feedback as you type

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This extension adds rich language support for the Go language to VS Code, includ
 - Generate unit tests skeleton (using `gotests`)
 - Add Imports (using `gopkgs`)
 - Add/Remove Tags on struct fields (using `gomodifytags`)
+- Semantic/Syntactic error reporting as you type (using `gotype-live`)
 - [_partially implemented_] Debugging (using `delve`)
 
 ### IDE Features

--- a/package.json
+++ b/package.json
@@ -542,16 +542,19 @@
           "description": "Tags and options configured here will be used by the Add Tags command to add tags to struct fields. If promptForTags is true, then user will be prompted for tags and options. By default, json tags are added."
         },
         "go.liveErrors": {
-          "enabled": {
+          "type": "object",
+          "properties": {
+            "enabled": {
             "type":"boolean",
             "default":false,
             "description": "If true, runs gotype on the file currently being edited and reports any semantic or syntactic errors found."
-          },
-          "delay": {
-            "type":"number",
-            "default":500,
-            "description": "The number of milliseconds to delay before execution. Resets with each keystroke."
-          },
+            },
+            "delay": {
+              "type":"number",
+              "default":500,
+              "description": "The number of milliseconds to delay before execution. Resets with each keystroke."
+            }
+          },          
           "default": {
             "enabled": false,
             "delay": 500

--- a/package.json
+++ b/package.json
@@ -559,7 +559,7 @@
             "enabled": false,
             "delay": 500
           },
-          "description": "Tags and options configured here will be used to configure how the live errors system behaves."
+          "description": "Use gotype on the file currently being edited and report any semantic or syntactic errors found after configured delay."
         },
         "go.removeTags": {
           "type": "object",

--- a/package.json
+++ b/package.json
@@ -545,13 +545,13 @@
           "type": "object",
           "properties": {
             "enabled": {
-            "type":"boolean",
-            "default":false,
-            "description": "If true, runs gotype on the file currently being edited and reports any semantic or syntactic errors found."
+              "type": "boolean",
+              "default": false,
+              "description": "If true, runs gotype on the file currently being edited and reports any semantic or syntactic errors found."
             },
             "delay": {
-              "type":"number",
-              "default":500,
+              "type": "number",
+              "default": 500,
               "description": "The number of milliseconds to delay before execution. Resets with each keystroke."
             }
           },          

--- a/package.json
+++ b/package.json
@@ -541,6 +541,23 @@
           },
           "description": "Tags and options configured here will be used by the Add Tags command to add tags to struct fields. If promptForTags is true, then user will be prompted for tags and options. By default, json tags are added."
         },
+        "go.liveErrors": {
+          "enabled": {
+            "type":"boolean",
+            "default":false,
+            "description": "If true, runs gotype on the file currently being edited and reports any semantic or syntactic errors found."
+          },
+          "delay": {
+            "type":"number",
+            "default":500,
+            "description": "The number of milliseconds to delay before execution. Resets with each keystroke."
+          },
+          "default": {
+            "enabled": false,
+            "delay": 500
+          },
+          "description": "Tags and options configured here will be used to configure how the live errors system behaves."
+        },
         "go.removeTags": {
           "type": "object",
           "properties": {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -26,7 +26,8 @@ function getTools(goVersion: SemVersion): { [key: string]: string } {
 		'go-symbols': 'github.com/acroca/go-symbols',
 		'guru': 'golang.org/x/tools/cmd/guru',
 		'gorename': 'golang.org/x/tools/cmd/gorename',
-		'gomodifytags': 'github.com/fatih/gomodifytags'
+		'gomodifytags': 'github.com/fatih/gomodifytags',
+		'gotype-live': 'github.com/tylerb/gotype-live'
 	};
 
 	// Install the doc/def tool that was chosen by the user

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -14,7 +14,7 @@ import { showGoStatus, hideGoStatus } from './goStatus';
 import { getGoRuntimePath, resolvePath } from './goPath';
 import { outputChannel } from './goStatus';
 import { getBinPath, getToolsGopath, getGoVersion, SemVersion, isVendorSupported } from './util';
-import { goLiveErrorsEnabled } from "./goLiveErrors";
+import { goLiveErrorsEnabled } from './goLiveErrors';
 
 let updatesDeclinedTools: string[] = [];
 
@@ -27,7 +27,7 @@ function getTools(goVersion: SemVersion): { [key: string]: string } {
 		'go-symbols': 'github.com/acroca/go-symbols',
 		'guru': 'golang.org/x/tools/cmd/guru',
 		'gorename': 'golang.org/x/tools/cmd/gorename',
-		'gomodifytags': 'github.com/fatih/gomodifytags'		
+		'gomodifytags': 'github.com/fatih/gomodifytags'
 	};
 	if (goLiveErrorsEnabled()) {
 		tools['gotype-live'] = 'github.com/tylerb/gotype-live';

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -14,6 +14,7 @@ import { showGoStatus, hideGoStatus } from './goStatus';
 import { getGoRuntimePath, resolvePath } from './goPath';
 import { outputChannel } from './goStatus';
 import { getBinPath, getToolsGopath, getGoVersion, SemVersion, isVendorSupported } from './util';
+import { goLiveErrorsEnabled } from "./goLiveErrors";
 
 let updatesDeclinedTools: string[] = [];
 
@@ -26,9 +27,11 @@ function getTools(goVersion: SemVersion): { [key: string]: string } {
 		'go-symbols': 'github.com/acroca/go-symbols',
 		'guru': 'golang.org/x/tools/cmd/guru',
 		'gorename': 'golang.org/x/tools/cmd/gorename',
-		'gomodifytags': 'github.com/fatih/gomodifytags',
-		'gotype-live': 'github.com/tylerb/gotype-live'
+		'gomodifytags': 'github.com/fatih/gomodifytags'		
 	};
+	if (goLiveErrorsEnabled()) {
+		tools['gotype-live'] = 'github.com/tylerb/gotype-live';
+	}
 
 	// Install the doc/def tool that was chosen by the user
 	if (goConfig['docsTool'] === 'godoc') {

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -40,7 +40,7 @@ export function parseLiveFile(e: vscode.TextDocumentChangeEvent) {
 }
 
 export function goLiveErrorsEnabled() {
-	return <GoLiveErrorsConfig>vscode.workspace.getConfiguration('go')['liveErrors'].enabled;	
+	return <GoLiveErrorsConfig>vscode.workspace.getConfiguration('go')['liveErrors'].enabled;
 }
 
 // processFile does the actual work once the timeout has fired
@@ -76,9 +76,9 @@ function processFile(e: vscode.TextDocumentChangeEvent) {
 		// we want to keep all non-error level diagnostics that were previously
 		// reported, so add them back in
 		oldDiagnostics.forEach((value) => {
-			if (value.severity != vscode.DiagnosticSeverity.Error) {
-				newDiagnostics.push(value)
-			} 
+			if (value.severity !== vscode.DiagnosticSeverity.Error) {
+				newDiagnostics.push(value);
+			}
 		});
 
 		if (err) {
@@ -91,10 +91,10 @@ function processFile(e: vscode.TextDocumentChangeEvent) {
 
 				let range = new vscode.Range(+line - 1, +column, +line - 1, +column);
 				let diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);
-				newDiagnostics.push(diagnostic)
-			});			
+				newDiagnostics.push(diagnostic);
+			});
 		}
-		diagnosticCollection.set(uri, newDiagnostics);		
+		diagnosticCollection.set(uri, newDiagnostics);
 	});
 	p.stdin.end(fileContents);
 }

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -5,7 +5,7 @@ import { byteOffsetAt, getBinPath } from './util';
 import cp = require('child_process');
 import path = require('path');
 import { promptForMissingTool } from './goInstallTools';
-import { diagnosticCollection } from "./goMain";
+import { diagnosticCollection } from './goMain';
 
 // Interface for settings configuration for adding and removing tags
 interface GoLiveErrorsConfig {
@@ -13,7 +13,7 @@ interface GoLiveErrorsConfig {
 	enabled: boolean;
 }
 
-var runner;
+let runner;
 
 // parseLiveFile runs the gotype command in live mode to check for any syntactic or
 // semantic errors and reports them immediately
@@ -25,12 +25,12 @@ export function parseLiveFile(e: vscode.TextDocumentChangeEvent) {
 		return;
 	}
 
-	let config = <GoLiveErrorsConfig>vscode.workspace.getConfiguration('go')['liveErrors']
+	let config = <GoLiveErrorsConfig>vscode.workspace.getConfiguration('go')['liveErrors'];
 	if (config == null || !config.enabled) {
 		return;
 	}
 
-	if (runner != null){
+	if (runner != null) {
 		clearTimeout(runner);
 	}
 	runner = setTimeout(function(){
@@ -44,27 +44,27 @@ function processFile(e: vscode.TextDocumentChangeEvent) {
 	let uri = e.document.uri;
 	let gotypeLive = getBinPath('gotype-live');
 	let fileContents = e.document.getText();
-	let fileName = e.document.fileName	
-	let args = ['-e','-a','-lf='+fileName,path.dirname(fileName)]
+	let fileName = e.document.fileName;
+	let args = ['-e', '-a', '-lf=' + fileName, path.dirname(fileName)];
 	let p = cp.execFile(gotypeLive, args, (err, stdout, stderr) => {
 		if (err && (<any>err).code === 'ENOENT') {
 			promptForMissingTool('gotype-live');
 			return;
 		}
-		
-		diagnosticCollection.clear();		
+
+		diagnosticCollection.clear();
 		if (err) {
 			// we want to take the error path here because the command we are calling
 			// returns a non-zero exit status if the checks fail
 			let diagnosticMap: Map<string, vscode.Diagnostic[]> = new Map();
-			
-			stderr.split("\n").forEach(error => {
-				if (error == null || error.length == 0) {
+
+			stderr.split('\n').forEach(error => {
+				if (error === null || error.length === 0) {
 					return;
 				}
 				// extract the line, column and error message from the gotype output
 				let [_, line, column, message] = /^.+:(\d+):(\d+):\s+(.+)/.exec(error);
-				
+
 				let range = new vscode.Range(+line - 1, +column, +line - 1, +column);
 				let diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);
 				let diagnostics = diagnosticMap.get(uri.toString());

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -68,9 +68,6 @@ function processFile(e: vscode.TextDocumentChangeEvent) {
 			// we want to take the error path here because the command we are calling
 			// returns a non-zero exit status if the checks fail
 			let diagnostics = [];
-			if (!diagnostics) {
-				diagnostics = [];
-			}
 
 			stderr.split('\n').forEach(error => {
 				if (error === null || error.length === 0) {

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -15,6 +15,18 @@ interface GoLiveErrorsConfig {
 
 let runner;
 
+export function goLiveErrorsEnabled() {
+	let goConfig = <GoLiveErrorsConfig>vscode.workspace.getConfiguration('go')['liveErrors'];
+	if (goConfig === null || goConfig === undefined || !goConfig.enabled) {
+		return false;
+	}
+	let autoSave = vscode.workspace.getConfiguration('files')['autoSave'];
+	if (autoSave !== null && autoSave !== undefined && autoSave !== 'off') {
+		return false;
+	}
+	return goConfig.enabled;
+}
+
 // parseLiveFile runs the gotype command in live mode to check for any syntactic or
 // semantic errors and reports them immediately
 export function parseLiveFile(e: vscode.TextDocumentChangeEvent) {
@@ -24,9 +36,7 @@ export function parseLiveFile(e: vscode.TextDocumentChangeEvent) {
 	if (e.document.languageId !== 'go') {
 		return;
 	}
-
-	let config = <GoLiveErrorsConfig>vscode.workspace.getConfiguration('go')['liveErrors'];
-	if (config == null || !config.enabled) {
+	if (!goLiveErrorsEnabled()) {
 		return;
 	}
 
@@ -36,11 +46,7 @@ export function parseLiveFile(e: vscode.TextDocumentChangeEvent) {
 	runner = setTimeout(function(){
 		processFile(e);
 		runner = null;
-	}, config.delay);
-}
-
-export function goLiveErrorsEnabled() {
-	return <GoLiveErrorsConfig>vscode.workspace.getConfiguration('go')['liveErrors'].enabled;
+	}, vscode.workspace.getConfiguration('go')['liveErrors']['delay']);
 }
 
 // processFile does the actual work once the timeout has fired

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -5,7 +5,7 @@ import { byteOffsetAt, getBinPath } from './util';
 import cp = require('child_process');
 import path = require('path');
 import { promptForMissingTool } from './goInstallTools';
-import { diagnosticCollection } from './goMain';
+import { errorDiagnosticCollection } from './goMain';
 
 // Interface for settings configuration for adding and removing tags
 interface GoLiveErrorsConfig {
@@ -62,32 +62,16 @@ function processFile(e: vscode.TextDocumentChangeEvent) {
 			return;
 		}
 
-		// we want to take the error path here because the command we are calling
-		// returns a non-zero exit status if the checks fail
-		let newDiagnostics = [];
-		if (!newDiagnostics) {
-			newDiagnostics = [];
-		}
-
-		// grab a copy of the existing diagnostics that are being reported for the
-		// current file
-		let oldDiagnostics = diagnosticCollection.get(uri);
-
-		// delete the existing diagnostics for the current file
-		//
-		// error-level diagnostics will be reported by this process, so we want to
-		// clear out the existing errors to avoid getting duplicates
-		diagnosticCollection.delete(uri);
-
-		// we want to keep all non-error level diagnostics that were previously
-		// reported, so add them back in
-		oldDiagnostics.forEach((value) => {
-			if (value.severity !== vscode.DiagnosticSeverity.Error) {
-				newDiagnostics.push(value);
-			}
-		});
+		errorDiagnosticCollection.delete(uri);
 
 		if (err) {
+			// we want to take the error path here because the command we are calling
+			// returns a non-zero exit status if the checks fail
+			let diagnostics = [];
+			if (!diagnostics) {
+				diagnostics = [];
+			}
+
 			stderr.split('\n').forEach(error => {
 				if (error === null || error.length === 0) {
 					return;
@@ -97,10 +81,11 @@ function processFile(e: vscode.TextDocumentChangeEvent) {
 
 				let range = new vscode.Range(+line - 1, +column, +line - 1, +column);
 				let diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);
-				newDiagnostics.push(diagnostic);
+				diagnostics.push(diagnostic);
 			});
+
+			errorDiagnosticCollection.set(uri, diagnostics);
 		}
-		diagnosticCollection.set(uri, newDiagnostics);
 	});
 	p.stdin.end(fileContents);
 }

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -39,6 +39,10 @@ export function parseLiveFile(e: vscode.TextDocumentChangeEvent) {
 	}, config.delay);
 }
 
+export function goLiveErrorsEnabled() {
+	return <GoLiveErrorsConfig>vscode.workspace.getConfiguration('go')['liveErrors'].enabled;	
+}
+
 // processFile does the actual work once the timeout has fired
 function processFile(e: vscode.TextDocumentChangeEvent) {
 	let uri = e.document.uri;

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -1,0 +1,84 @@
+'use strict';
+
+import vscode = require('vscode');
+import { byteOffsetAt, getBinPath } from './util';
+import cp = require('child_process');
+import path = require('path');
+import { promptForMissingTool } from './goInstallTools';
+import { diagnosticCollection } from "./goMain";
+
+// Interface for settings configuration for adding and removing tags
+interface GoLiveErrorsConfig {
+	delay: number;
+	enabled: boolean;
+}
+
+var runner;
+
+// parseLiveFile runs the gotype command in live mode to check for any syntactic or
+// semantic errors and reports them immediately
+export function parseLiveFile(e: vscode.TextDocumentChangeEvent) {
+	if (e.document.isUntitled) {
+		return;
+	}
+	if (e.document.languageId !== 'go') {
+		return;
+	}
+
+	let config = <GoLiveErrorsConfig>vscode.workspace.getConfiguration('go')['liveErrors']
+	if (config == null || !config.enabled) {
+		return;
+	}
+
+	if (runner != null){
+		clearTimeout(runner);
+	}
+	runner = setTimeout(function(){
+		processFile(e);
+		runner = null;
+	}, config.delay);
+}
+
+// processFile does the actual work once the timeout has fired
+function processFile(e: vscode.TextDocumentChangeEvent) {
+	let uri = e.document.uri;
+	let gotypeLive = getBinPath('gotype-live');
+	let fileContents = e.document.getText();
+	let fileName = e.document.fileName	
+	let args = ['-e','-a','-lf='+fileName,path.dirname(fileName)]
+	let p = cp.execFile(gotypeLive, args, (err, stdout, stderr) => {
+		if (err && (<any>err).code === 'ENOENT') {
+			promptForMissingTool('gotype-live');
+			return;
+		}
+		
+		diagnosticCollection.clear();		
+		if (err) {
+			// we want to take the error path here because the command we are calling
+			// returns a non-zero exit status if the checks fail
+			let diagnosticMap: Map<string, vscode.Diagnostic[]> = new Map();
+			
+			stderr.split("\n").forEach(error => {
+				if (error == null || error.length == 0) {
+					return;
+				}
+				// extract the line, column and error message from the gotype output
+				let [_, line, column, message] = /^.+:(\d+):(\d+):\s+(.+)/.exec(error);
+				
+				let range = new vscode.Range(+line - 1, +column, +line - 1, +column);
+				let diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);
+				let diagnostics = diagnosticMap.get(uri.toString());
+				if (!diagnostics) {
+					diagnostics = [];
+				}
+				diagnostics.push(diagnostic);
+				diagnosticMap.set(uri.toString(), diagnostics);
+			});
+			diagnosticMap.forEach((diags, file) => {
+				diagnosticCollection.set(vscode.Uri.parse(file), diags);
+			});
+			return;
+		}
+	});
+	p.stdin.end(fileContents);
+}

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -32,8 +32,9 @@ import { isGoPathSet, getBinPath, sendTelemetryEvent } from './util';
 import { LanguageClient } from 'vscode-languageclient';
 import { clearCacheForTools } from './goPath';
 import { addTags, removeTags } from './goModifytags';
+import { parseLiveFile } from './goLiveErrors';
 
-let diagnosticCollection: vscode.DiagnosticCollection;
+export let diagnosticCollection: vscode.DiagnosticCollection;
 
 export function activate(ctx: vscode.ExtensionContext): void {
 	let useLangServer = vscode.workspace.getConfiguration('go')['useLanguageServer'];
@@ -87,6 +88,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	vscode.workspace.onDidChangeTextDocument(removeTestStatus, null, ctx.subscriptions);
 	vscode.window.onDidChangeActiveTextEditor(showHideStatus, null, ctx.subscriptions);
 	vscode.window.onDidChangeActiveTextEditor(getCodeCoverage, null, ctx.subscriptions);
+	vscode.workspace.onDidChangeTextDocument(parseLiveFile, null, ctx.subscriptions);
 
 	startBuildOnSaveWatcher(ctx.subscriptions);
 


### PR DESCRIPTION
This PR adds an optional (disabled by default) live error reporting system.

Closes #883

## Motivation

I've used many editors in which a live as-you-type feedback system was available. I've found that it helps me catch errors as they happen and fix them immediately. This constant feedback allows me to code more quickly, as I am still in the context of an error when I see it, rather than having to come back to it after the build has failed.

## Implementation

To implement this feature, I have taken advantage of my custom fork of [gotype](https://godoc.org/golang.org/x/tools/cmd/gotype), called [gotype-live](https://github.com/tylerb/gotype-live).

My fork enables the processing of an in-memory version of a file by accepting the contents via stdin. This allows us to get errors back from `gotype` as we code, rather than having to save the file first.

## Configuration

The default configuration for this feature, as of now, is as follows:

```json
"go.liveErrors": {
    "enabled": false,
    "delay": 500
}
```

The `delay` value configures a timer that waits for `n`ms after a keystroke before running the process. If a keystroke occurs during that window, the timer is reset.

## Example

Below is a short video showing the feature in action. This video was recorded with a 250ms delay time.

![feedback](https://cloud.githubusercontent.com/assets/70804/24563489/adca5aaa-160b-11e7-9863-f46d79c93d9d.gif)

