### PR TITLE
set GOPATH for debug adaptor automatically

### DIFF
--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -196,6 +196,14 @@ export function activate(ctx: vscode.ExtensionContext): void {
 				'program': '${file}'
 			});
 		}
+
+		if (!config.env || !config.env['GOPATH']) {
+			let binpath = getBinPath('dlv');
+			config.env = config.env || {};
+			if (binpath != 'dlv')
+				config.env['GOPATH'] = path.dirname(path.dirname(binpath));
+		}
+
 		vscode.commands.executeCommand('vscode.startDebug', config);
 	}));
 

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -193,17 +193,12 @@ export function activate(ctx: vscode.ExtensionContext): void {
 				'type': 'go',
 				'request': 'launch',
 				'mode': 'debug',
-				'program': '${file}'
+				'program': '${file}',
+				'env': {
+					'GOPATH': process.env['GOPATH']
+				}
 			});
 		}
-
-		if (!config.env || !config.env['GOPATH']) {
-			let binpath = getBinPath('dlv');
-			config.env = config.env || {};
-			if (binpath != 'dlv')
-				config.env['GOPATH'] = path.dirname(path.dirname(binpath));
-		}
-
 		vscode.commands.executeCommand('vscode.startDebug', config);
 	}));
 


### PR DESCRIPTION
This patch modifies `go.debug.startSession` command to add  environment variable 'GOPATH' to launch configuration JSON object. A proper `GOPATH` is searched using `getBinPath`, which utilizes VSCode settings.

This allows more versatile configuration and provides better out-of-box experience.