### PR TITLE
Add goenv support.

### DIFF
--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -76,7 +76,9 @@ function correctBinname(binname: string) {
 export function getGoRuntimePath(): string {
 	if (runtimePathCache) return runtimePathCache;
 	let correctBinNameGo = correctBinname('go');
-	if (process.env['GOROOT']) {
+	if (process.env['GOENV_ROOT']) {
+		runtimePathCache = path.join(process.env['GOENV_ROOT'], 'shims', correctBinNameGo);
+	} else if (process.env['GOROOT']) {
 		runtimePathCache = path.join(process.env['GOROOT'], 'bin', correctBinNameGo);
 	} else if (process.env['PATH']) {
 		let pathparts = (<string>process.env.PATH).split(path.delimiter);


### PR DESCRIPTION
Developing standard Go app and AppEngine GoApp is quite common.
Using the [goenv](https://github.com/crsmithdev/goenv) tool is quite usefull to switch between golang version.

`goenv` is using the same strategy as the well known `rbenv` and
`pyenv` and include the different versions in $HOME. It also
aliases the `go` runtime binary to `GOENV_ROOT/shims/go`.

Using `goenv` was preventing the extension to find the golang binary.