### PR TITLE
dont run slow linters

### DIFF
--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -412,18 +412,8 @@ It returns the number of bytes written and any write error encountered.
 				'lintFlags': { value: ['--disable-all', '--enable=varcheck', '--enable=errcheck']}
 			});
 			let expected = [
-			//	{ line: 7, severity: 'warning', msg: 'Print2 is unused (deadcode)' },
 				{ line: 11, severity: 'warning', msg: 'error return value not checked (undeclared name: prin) (errcheck)' },
-			//	{ line: 7, severity: 'warning', msg: 'exported function Print2 should have comment or be unexported (golint)' },
-			//	{ line: 10, severity: 'warning', msg: 'main2 is unused (deadcode)' },
-				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (aligncheck)' },
-				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (gosimple)' },
-				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (gotype)' },
-				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (interfacer)' },
-				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (staticcheck)' },
-				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (unconvert)' },
 				{ line: 11, severity: 'error', msg: 'undefined: prin' },
-				//{ line: 11, severity: 'warning', msg: 'unused struct field undeclared name: prin (structcheck)' },
 				{ line: 11, severity: 'warning', msg: 'unused variable or constant undeclared name: prin (varcheck)' },
 			];
 			return check(path.join(fixturePath, 'errorsTest', 'errors.go'), config).then(diagnostics => {

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -408,21 +408,22 @@ It returns the number of bytes written and any write error encountered.
 			}
 
 			let config = Object.create(vscode.workspace.getConfiguration('go'), {
-				'lintTool': { value: 'gometalinter' }
+				'lintTool': { value: 'gometalinter' },
+				'lintFlags': { value: ['--disable-all', '--enable=varcheck', '--enable=errcheck']}
 			});
 			let expected = [
-				{ line: 7, severity: 'warning', msg: 'Print2 is unused (deadcode)' },
+			//	{ line: 7, severity: 'warning', msg: 'Print2 is unused (deadcode)' },
 				{ line: 11, severity: 'warning', msg: 'error return value not checked (undeclared name: prin) (errcheck)' },
-				{ line: 7, severity: 'warning', msg: 'exported function Print2 should have comment or be unexported (golint)' },
-				{ line: 10, severity: 'warning', msg: 'main2 is unused (deadcode)' },
-				{ line: 11, severity: 'warning', msg: 'undeclared name: prin (aligncheck)' },
-				{ line: 11, severity: 'warning', msg: 'undeclared name: prin (gosimple)' },
-				{ line: 11, severity: 'warning', msg: 'undeclared name: prin (gotype)' },
-				{ line: 11, severity: 'warning', msg: 'undeclared name: prin (interfacer)' },
-				{ line: 11, severity: 'warning', msg: 'undeclared name: prin (staticcheck)' },
-				{ line: 11, severity: 'warning', msg: 'undeclared name: prin (unconvert)' },
+			//	{ line: 7, severity: 'warning', msg: 'exported function Print2 should have comment or be unexported (golint)' },
+			//	{ line: 10, severity: 'warning', msg: 'main2 is unused (deadcode)' },
+				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (aligncheck)' },
+				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (gosimple)' },
+				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (gotype)' },
+				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (interfacer)' },
+				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (staticcheck)' },
+				// { line: 11, severity: 'warning', msg: 'undeclared name: prin (unconvert)' },
 				{ line: 11, severity: 'error', msg: 'undefined: prin' },
-				{ line: 11, severity: 'warning', msg: 'unused struct field undeclared name: prin (structcheck)' },
+				//{ line: 11, severity: 'warning', msg: 'unused struct field undeclared name: prin (structcheck)' },
 				{ line: 11, severity: 'warning', msg: 'unused variable or constant undeclared name: prin (varcheck)' },
 			];
 			return check(path.join(fixturePath, 'errorsTest', 'errors.go'), config).then(diagnostics => {


### PR DESCRIPTION
Travis tests have been failing consistently due to gometalinter running slow linters.
This PR is to restrict the #  of linters being run by gometalinter