### PR TITLE
Fix gotype-live errors showing in wrong file

### DIFF
--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -51,7 +51,6 @@ export function parseLiveFile(e: vscode.TextDocumentChangeEvent) {
 
 // processFile does the actual work once the timeout has fired
 function processFile(e: vscode.TextDocumentChangeEvent) {
-	let uri = e.document.uri;
 	let gotypeLive = getBinPath('gotype-live');
 	let fileContents = e.document.getText();
 	let fileName = e.document.fileName;
@@ -62,12 +61,12 @@ function processFile(e: vscode.TextDocumentChangeEvent) {
 			return;
 		}
 
-		errorDiagnosticCollection.delete(uri);
+		errorDiagnosticCollection.clear();
 
 		if (err) {
 			// we want to take the error path here because the command we are calling
 			// returns a non-zero exit status if the checks fail
-			let diagnostics = [];
+			let diagnosticMap: Map<string, vscode.Diagnostic[]> = new Map();
 
 			stderr.split('\n').forEach(error => {
 				if (error === null || error.length === 0) {
@@ -75,22 +74,20 @@ function processFile(e: vscode.TextDocumentChangeEvent) {
 				}
 				// extract the line, column and error message from the gotype output
 				let [_, file, line, column, message] = /^(.+):(\d+):(\d+):\s+(.+)/.exec(error);
-
-				if (file !== uri.path) {
-					// skip the output if it is not in the file currently being edited
-					// a possible improvement here would be to display the additional errors
-					// as a diagnostic for the correct file
-					return;
-				}
-
-				console.log(file,"and",uri.path);
-
 				let range = new vscode.Range(+line - 1, +column, +line - 1, +column);
 				let diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);
+
+				let diagnostics = diagnosticMap.get(file);
+				if (!diagnostics) {
+					diagnostics = [];
+				}
 				diagnostics.push(diagnostic);
+				diagnosticMap.set(file, diagnostics);
 			});
 
-			errorDiagnosticCollection.set(uri, diagnostics);
+			diagnosticMap.forEach((diagnostics, file) => {
+				errorDiagnosticCollection.set(vscode.Uri.parse(file), diagnostics);
+			});
 		}
 	});
 	p.stdin.end(fileContents);

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -86,7 +86,7 @@ function processFile(e: vscode.TextDocumentChangeEvent) {
 			});
 
 			diagnosticMap.forEach((diagnostics, file) => {
-				errorDiagnosticCollection.set(vscode.Uri.parse(file), diagnostics);
+				errorDiagnosticCollection.set(vscode.Uri.parse('file://' + file), diagnostics);
 			});
 		}
 	});

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -20,8 +20,11 @@ export function goLiveErrorsEnabled() {
 	if (goConfig === null || goConfig === undefined || !goConfig.enabled) {
 		return false;
 	}
-	let autoSave = vscode.workspace.getConfiguration('files')['autoSave'];
-	if (autoSave !== null && autoSave !== undefined && autoSave !== 'off') {
+	let files = vscode.workspace.getConfiguration('files');
+	let autoSave = files['autoSave'];
+	let autoSaveDelay = files['autoSaveDelay'];
+	if (autoSave !== null && autoSave !== undefined &&
+			autoSave === 'afterDelay' && autoSaveDelay < goConfig.delay * 1.5) {
 		return false;
 	}
 	return goConfig.enabled;

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -74,7 +74,16 @@ function processFile(e: vscode.TextDocumentChangeEvent) {
 					return;
 				}
 				// extract the line, column and error message from the gotype output
-				let [_, line, column, message] = /^.+:(\d+):(\d+):\s+(.+)/.exec(error);
+				let [_, file, line, column, message] = /^(.+):(\d+):(\d+):\s+(.+)/.exec(error);
+
+				if (file !== uri.path) {
+					// skip the output if it is not in the file currently being edited
+					// a possible improvement here would be to display the additional errors
+					// as a diagnostic for the correct file
+					return;
+				}
+
+				console.log(file,"and",uri.path);
 
 				let range = new vscode.Range(+line - 1, +column, +line - 1, +column);
 				let diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);


### PR DESCRIPTION
There exists an issue with the live error system in that `gotype-live` will report errors for all files in the package, but the document change event is only for a single file. As a result, all the errors, for all the files, were being displayed as errors in the current file. This PR fixes that issue.

It may be worthwhile to investigate the possibility of displaying those errors for the correct file.