### PR TITLE
Fixes #922 Pass file contents to go-outline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - go get -u -v github.com/rogpeppe/godef
   - if [[ "$(go version)" =~ "go version go1.5" ]]; then echo hello; else go get -u -v github.com/zmb3/gogetdoc; fi
   - if [[ "$(go version)" =~ "go version go1.5" ]]; then echo cannot get golint; else go get -u -v github.com/golang/lint/golint; fi
-  - go get -u -v github.com/lukehoban/go-outline
+  - go get -u -v github.com/ramya-rao-a/go-outline
   - go get -u -v sourcegraph.com/sqs/goreturns
   - go get -u -v golang.org/x/tools/cmd/gorename
   - go get -u -v github.com/tpng/gopkgs

--- a/src/goGenerateTests.ts
+++ b/src/goGenerateTests.ts
@@ -29,6 +29,10 @@ function checkActiveEditor(): vscode.TextEditor {
 		vscode.window.showInformationMessage('Cannot generate unit tests. File in the editor is not a Go file.');
 		return;
 	}
+	if (!editor.document.isDirty) {
+		vscode.window.showInformationMessage('File has unsaved changes. Save and try again.');
+		return;
+	}
 	return editor;
 }
 

--- a/src/goGenerateTests.ts
+++ b/src/goGenerateTests.ts
@@ -29,7 +29,7 @@ function checkActiveEditor(): vscode.TextEditor {
 		vscode.window.showInformationMessage('Cannot generate unit tests. File in the editor is not a Go file.');
 		return;
 	}
-	if (!editor.document.isDirty) {
+	if (editor.document.isDirty) {
 		vscode.window.showInformationMessage('File has unsaved changes. Save and try again.');
 		return;
 	}

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -23,7 +23,7 @@ function getTools(goVersion: SemVersion): { [key: string]: string } {
 	let tools: { [key: string]: string } = {
 		'gocode': 'github.com/nsf/gocode',
 		'gopkgs': 'github.com/tpng/gopkgs',
-		'go-outline': 'github.com/lukehoban/go-outline',
+		'go-outline': 'github.com/ramya-rao-a/go-outline',
 		'go-symbols': 'github.com/acroca/go-symbols',
 		'guru': 'golang.org/x/tools/cmd/guru',
 		'gorename': 'golang.org/x/tools/cmd/gorename',

--- a/src/goModifytags.ts
+++ b/src/goModifytags.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import vscode = require('vscode');
-import { byteOffsetAt, getBinPath } from './util';
+import { byteOffsetAt, getBinPath, getFileArchive } from './util';
 import cp = require('child_process');
 import { promptForMissingTool } from './goInstallTools';
 
@@ -125,8 +125,7 @@ function getTagsAndOptions(config: GoTagsConfig, commandArgs: GoTagsConfig): The
 function runGomodifytags(args: string[]) {
 	let gomodifytags = getBinPath('gomodifytags');
 	let editor = vscode.window.activeTextEditor;
-	let fileContents = editor.document.getText();
-	let input = editor.document.fileName + '\n' + Buffer.byteLength(fileContents, 'utf8') + '\n' + fileContents;
+	let input = getFileArchive(editor.document);
 	let p = cp.execFile(gomodifytags, args, (err, stdout, stderr) => {
 		if (err && (<any>err).code === 'ENOENT') {
 			promptForMissingTool('gomodifytags');

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -11,7 +11,7 @@ import path = require('path');
 import { getBinPath, getFileArchive } from './util';
 import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
 
-// Keep in sync with https://github.com/lukehoban/go-outline
+// Keep in sync with https://github.com/ramya-rao-a/go-outline
 export interface GoOutlineRange {
 	start: number;
 	end: number;
@@ -62,7 +62,7 @@ export function documentSymbols(options: GoOutlineOptions): Promise<GoOutlineDec
 				if (err && (<any>err).code === 'ENOENT') {
 					promptForMissingTool('go-outline');
 				}
-				if (stderr && stderr.startsWith('flag provided but not defined: -imports-only')) {
+				if (stderr && stderr.startsWith('flag provided but not defined: ')) {
 					promptForUpdatingTool('go-outline');
 					if (stderr.startsWith('flag provided but not defined: -imports-only')) {
 						options.importsOnly = false;

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -65,7 +65,7 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, args: any)
 		vscode.window.showInformationMessage('No tests found. Current file is not a test file.');
 		return;
 	}
-	if (!editor.document.isDirty) {
+	if (editor.document.isDirty) {
 		vscode.window.showInformationMessage('File has unsaved changes. Save and try again.');
 		return;
 	}

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -65,6 +65,10 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, args: any)
 		vscode.window.showInformationMessage('No tests found. Current file is not a test file.');
 		return;
 	}
+	if (!editor.document.isDirty) {
+		vscode.window.showInformationMessage('File has unsaved changes. Save and try again.');
+		return;
+	}
 	getTestFunctions(editor.document).then(testFunctions => {
 		let testFunction: vscode.SymbolInformation;
 		// Find any test function containing the cursor.

--- a/src/util.ts
+++ b/src/util.ts
@@ -281,3 +281,8 @@ export function getCurrentGoWorkspaceFromGOPATH(currentFileDirPath: string): str
 	}
 	return currentWorkspace;
 }
+
+export function getFileArchive(document: vscode.TextDocument): string {
+	let fileContents = document.getText();
+	return document.fileName + '\n' + Buffer.byteLength(fileContents, 'utf8') + '\n' + fileContents;
+}

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -665,7 +665,7 @@ It returns the number of bytes written and any write error encountered.
 		// will fail and will have to be replaced with any other go project with vendor packages
 
 		let vendorSupportPromise = isVendorSupported();
-		let filePath = path.join(process.env['GOPATH'], 'src', 'github.com', 'lukehoban', 'go-outline', 'main.go');
+		let filePath = path.join(process.env['GOPATH'], 'src', 'github.com', 'ramya-rao-a', 'go-outline', 'main.go');
 		let vendorPkgs = [
 			'github.com/rogpeppe/godef/vendor/9fans.net/go/acme',
 			'github.com/rogpeppe/godef/vendor/9fans.net/go/plan9',


### PR DESCRIPTION
Since https://github.com/lukehoban/go-outline/pull/7 is not being merged in time, we will use a fork of `go-outline`