### PR TITLE
Set environment variables for go tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -471,6 +471,11 @@
           "default": null,
           "description": "Flags to pass to `go test`. If null, then buildFlags will be used."
         },
+        "go.toolsEnvVars": {
+          "type": "object",
+          "default": {},
+          "description": "Environment variables that will passed to the processes that run the Go tools (e.g. CGO_CFLAGS)"
+        },
         "go.gocodeAutoBuild": {
           "type": "boolean",
           "default": true,
@@ -559,7 +564,7 @@
               "default": 500,
               "description": "The number of milliseconds to delay before execution. Resets with each keystroke."
             }
-          },          
+          },
           "default": {
             "enabled": false,
             "delay": 500
@@ -624,7 +629,7 @@
               "type": "boolean",
               "default": true,
               "description": "If true, adds command to run all tests in the current package to the editor context menu"
-            },          
+            },
             "generateTestForFunction": {
               "type": "boolean",
               "default": true,
@@ -701,7 +706,7 @@
         {
           "when": "editorTextFocus && config.go.editorContextMenuCommands.testPackage && resourceLangId == go",
           "command": "go.test.package"
-        },       
+        },
         {
           "when": "editorTextFocus && config.go.editorContextMenuCommands.generateTestForFunction && resourceLangId == go",
           "command": "go.test.generate.function"

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -44,11 +44,11 @@ export interface ICheckResult {
  * @param toolName The name of the Go tool to run. If none is provided, the go runtime itself is used
  * @param printUnexpectedOutput If true, then output that doesnt match expected format is printed to the output channel
  */
-function runTool(args: string[], cwd: string, severity: string, useStdErr: boolean, toolName: string, printUnexpectedOutput?: boolean): Promise<ICheckResult[]> {
+function runTool(args: string[], cwd: string, severity: string, useStdErr: boolean, toolName: string, env: any, printUnexpectedOutput?: boolean): Promise<ICheckResult[]> {
 	let goRuntimePath = getGoRuntimePath();
 	let cmd = toolName ? getBinPath(toolName) : goRuntimePath;
 	return new Promise((resolve, reject) => {
-		cp.execFile(cmd, args, { cwd: cwd }, (err, stdout, stderr) => {
+		cp.execFile(cmd, args, { env: env, cwd: cwd }, (err, stdout, stderr) => {
 			try {
 				if (err && (<any>err).code === 'ENOENT') {
 					if (toolName) {
@@ -110,6 +110,7 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 	outputChannel.clear();
 	let runningToolsPromises = [];
 	let cwd = path.dirname(filename);
+	let env = Object.assign({}, process.env, goConfig['toolsEnvVars']);
 	let goRuntimePath = getGoRuntimePath();
 
 	if (!goRuntimePath) {
@@ -176,7 +177,8 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 					'error',
 					true,
 					null,
-					true
+					true,
+					env
 				).then(result => resolve(result), err => reject(err));
 			});
 		});
@@ -223,7 +225,8 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 			cwd,
 			'warning',
 			false,
-			lintTool
+			lintTool,
+			env
 		));
 	}
 
@@ -234,7 +237,8 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 			cwd,
 			'warning',
 			true,
-			null
+			null,
+			env
 		));
 	}
 

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -177,8 +177,8 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 					'error',
 					true,
 					null,
-					true,
-					env
+					env,
+					true
 				).then(result => resolve(result), err => reject(err));
 			});
 		});


### PR DESCRIPTION
This will let users set env variables for `go build` (e.g. `CGO_CFLAGS`, `CGO_LDFLAGS` and `LD_LIBRARY_PATH`).