### PR TITLE
RunTest with CodeLens

### DIFF
--- a/src/goCodelens.ts
+++ b/src/goCodelens.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------*/
+
+'use strict'
+
+import vscode = require('vscode');
+import { CodeLensProvider, TextDocument, CancellationToken, CodeLens, Command } from 'vscode';
+import { getTestFunctions } from './goTest';
+
+export class GoCodeLensProvider implements CodeLensProvider {
+	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
+		return getTestFunctions(document).then(testFunctions => {
+			return testFunctions.map(func => {
+				let showReferences: Command = {
+					title: 'run test',
+					command: 'go.test.function',
+					arguments: [ func.name ]
+				};
+				return new CodeLens(func.location.range, showReferences);
+			});
+		});
+	}
+}

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -16,7 +16,7 @@ import { GoReferenceProvider } from './goReferences';
 import { GoDocumentFormattingEditProvider, Formatter } from './goFormat';
 import { GoRenameProvider } from './goRename';
 import { GoDocumentSymbolProvider } from './goOutline';
-import { GoCodeLensProvider } from './goCodelens';
+import { GoRunTestCodeLensProvider } from './goRunTestCodelens';
 import { GoSignatureHelpProvider } from './goSignature';
 import { GoWorkspaceSymbolProvider } from './goSymbol';
 import { GoCodeActionProvider } from './goCodeAction';
@@ -83,7 +83,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(GO_MODE, new GoDocumentFormattingEditProvider()));
 	ctx.subscriptions.push(vscode.languages.registerRenameProvider(GO_MODE, new GoRenameProvider()));
 	ctx.subscriptions.push(vscode.languages.registerCodeActionsProvider(GO_MODE, new GoCodeActionProvider()));
-	ctx.subscriptions.push(vscode.languages.registerCodeLensProvider(GO_MODE, new GoCodeLensProvider()));
+	ctx.subscriptions.push(vscode.languages.registerCodeLensProvider(GO_MODE, new GoRunTestCodeLensProvider()));
 
 	errorDiagnosticCollection = vscode.languages.createDiagnosticCollection('go-error');
 	ctx.subscriptions.push(errorDiagnosticCollection);

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -25,7 +25,7 @@ import { updateGoPathGoRootFromConfig, offerToInstallTools } from './goInstallTo
 import { GO_MODE } from './goMode';
 import { showHideStatus } from './goStatus';
 import { coverageCurrentPackage, getCodeCoverage, removeCodeCoverage } from './goCover';
-import { testAtCursor, testFunction, testCurrentPackage, testCurrentFile, testPrevious, showTestOutput, testWorkspace } from './goTest';
+import { testAtCursor, testCurrentPackage, testCurrentFile, testPrevious, showTestOutput, testWorkspace } from './goTest';
 import * as goGenerateTests from './goGenerateTests';
 import { addImport } from './goImport';
 import { installAllTools, checkLanguageServer } from './goInstallTools';
@@ -122,11 +122,6 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.cursor', (args) => {
 		let goConfig = vscode.workspace.getConfiguration('go');
 		testAtCursor(goConfig, args);
-	}));
-
-	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.function', (args) => {
-		let goConfig = vscode.workspace.getConfiguration('go');
-		testFunction(goConfig, args);
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.package', (args) => {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -16,6 +16,7 @@ import { GoReferenceProvider } from './goReferences';
 import { GoDocumentFormattingEditProvider, Formatter } from './goFormat';
 import { GoRenameProvider } from './goRename';
 import { GoDocumentSymbolProvider } from './goOutline';
+import { GoCodeLensProvider } from './goCodelens';
 import { GoSignatureHelpProvider } from './goSignature';
 import { GoWorkspaceSymbolProvider } from './goSymbol';
 import { GoCodeActionProvider } from './goCodeAction';
@@ -24,7 +25,7 @@ import { updateGoPathGoRootFromConfig, offerToInstallTools } from './goInstallTo
 import { GO_MODE } from './goMode';
 import { showHideStatus } from './goStatus';
 import { coverageCurrentPackage, getCodeCoverage, removeCodeCoverage } from './goCover';
-import { testAtCursor, testCurrentPackage, testCurrentFile, testPrevious, showTestOutput, testWorkspace } from './goTest';
+import { testAtCursor, testFunction, testCurrentPackage, testCurrentFile, testPrevious, showTestOutput, testWorkspace } from './goTest';
 import * as goGenerateTests from './goGenerateTests';
 import { addImport } from './goImport';
 import { installAllTools, checkLanguageServer } from './goInstallTools';
@@ -82,6 +83,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(GO_MODE, new GoDocumentFormattingEditProvider()));
 	ctx.subscriptions.push(vscode.languages.registerRenameProvider(GO_MODE, new GoRenameProvider()));
 	ctx.subscriptions.push(vscode.languages.registerCodeActionsProvider(GO_MODE, new GoCodeActionProvider()));
+	ctx.subscriptions.push(vscode.languages.registerCodeLensProvider(GO_MODE, new GoCodeLensProvider()));
 
 	errorDiagnosticCollection = vscode.languages.createDiagnosticCollection('go-error');
 	ctx.subscriptions.push(errorDiagnosticCollection);
@@ -118,6 +120,11 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.cursor', (args) => {
 		let goConfig = vscode.workspace.getConfiguration('go');
 		testAtCursor(goConfig, args);
+	}));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.function', (args) => {
+		let goConfig = vscode.workspace.getConfiguration('go');
+		testFunction(goConfig, args);
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.package', (args) => {

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -27,10 +27,10 @@ export class GoRunTestCodeLensProvider implements CodeLensProvider {
 	private getCodeLensForPackage(document: TextDocument): Thenable<CodeLens[]> {
 		let documentSymbolProvider = new GoDocumentSymbolProvider();
 		return documentSymbolProvider.provideDocumentSymbols(document, null)
-				.then(symbols => symbols.filter(sym => sym.kind === vscode.SymbolKind.Package))
-				.then(pkgs => {
-					if (pkgs.length > 0 && pkgs[0].name) {
-						const range = pkgs[0].location.range;
+				.then(symbols => symbols.find(sym => sym.kind === vscode.SymbolKind.Package && !!sym.name))
+				.then(pkg => {
+					if (pkg) {
+						const range = pkg.location.range;
 						return [
 							new CodeLens(range, {
 								title: 'run package tests',

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -9,7 +9,7 @@ import vscode = require('vscode');
 import { CodeLensProvider, TextDocument, CancellationToken, CodeLens, Command } from 'vscode';
 import { getTestFunctions } from './goTest';
 
-export class GoCodeLensProvider implements CodeLensProvider {
+export class GoRunTestCodeLensProvider implements CodeLensProvider {
 	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
 		return getTestFunctions(document).then(testFunctions => {
 			return testFunctions.map(func => {

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -12,6 +12,10 @@ import { GoDocumentSymbolProvider } from './goOutline';
 
 export class GoRunTestCodeLensProvider implements CodeLensProvider {
 	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
+		if (!document.fileName.endsWith('_test.go')) {
+			return;
+		}
+
 		return Promise.all([
 			this.getCodeLensForPackage(document),
 			this.getCodeLensForFunctions(document)
@@ -21,10 +25,6 @@ export class GoRunTestCodeLensProvider implements CodeLensProvider {
 	}
 
 	private getCodeLensForPackage(document: TextDocument): Thenable<CodeLens[]> {
-		if (!document.fileName.endsWith('_test.go')) {
-			return;
-		}
-
 		let documentSymbolProvider = new GoDocumentSymbolProvider();
 		return documentSymbolProvider.provideDocumentSymbols(document, null)
 				.then(symbols => symbols.filter(sym => sym.kind === vscode.SymbolKind.Package))

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------*/
 
-'use strict'
+'use strict';
 
 import vscode = require('vscode');
 import { CodeLensProvider, TextDocument, CancellationToken, CodeLens, Command } from 'vscode';

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -8,17 +8,52 @@
 import vscode = require('vscode');
 import { CodeLensProvider, TextDocument, CancellationToken, CodeLens, Command } from 'vscode';
 import { getTestFunctions } from './goTest';
+import { GoDocumentSymbolProvider } from './goOutline';
 
 export class GoRunTestCodeLensProvider implements CodeLensProvider {
 	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
+		return Promise.all([
+			this.getCodeLensForPackage(document),
+			this.getCodeLensForFunctions(document)
+		]).then(res => {
+			return res[0].concat(res[1]);
+		});
+	}
+
+	private getCodeLensForPackage(document: TextDocument): Thenable<CodeLens[]> {
+		if (!document.fileName.endsWith('_test.go')) {
+			return;
+		}
+
+		let documentSymbolProvider = new GoDocumentSymbolProvider();
+		return documentSymbolProvider.provideDocumentSymbols(document, null)
+				.then(symbols => symbols.filter(sym => sym.kind === vscode.SymbolKind.Package))
+				.then(pkgs => {
+					if (pkgs.length > 0 && pkgs[0].name) {
+						const range = pkgs[0].location.range;
+						return [
+							new CodeLens(range, {
+								title: 'run package tests',
+								command: 'go.test.package'
+							}),
+							new CodeLens(range, {
+								title: 'run file tests',
+								command: 'go.test.file'
+							})
+						];
+					}
+				});
+	}
+
+	private getCodeLensForFunctions(document: TextDocument): Thenable<CodeLens[]> {
 		return getTestFunctions(document).then(testFunctions => {
 			return testFunctions.map(func => {
-				let showReferences: Command = {
+				let command: Command = {
 					title: 'run test',
-					command: 'go.test.function',
-					arguments: [ func.name ]
+					command: 'go.test.cursor',
+					arguments: [ { functionName: func.name} ]
 				};
-				return new CodeLens(func.location.range, showReferences);
+				return new CodeLens(func.location.range, command);
 			});
 		});
 	}

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -95,6 +95,21 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, args: any)
 }
 
 /**
+ * Runs specific given test function.
+ *
+ * @param goConfig Configuration for the Go extension.
+ */
+export function testFunction(goConfig: vscode.WorkspaceConfiguration, functionName: string) {
+	let editor = vscode.window.activeTextEditor;
+	return goTest({
+		goConfig: goConfig,
+		dir: path.dirname(editor.document.fileName),
+		flags: getTestFlags(goConfig, null),
+		functions: [ functionName ]
+	});
+}
+
+/**
  * Runs all tests in the package of the source of the active editor.
  *
  * @param goConfig Configuration for the Go extension.
@@ -237,7 +252,7 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
  * @param the URI of a Go source file.
  * @return test function symbols for the source file.
  */
-function getTestFunctions(doc: vscode.TextDocument): Thenable<vscode.SymbolInformation[]> {
+export function getTestFunctions(doc: vscode.TextDocument): Thenable<vscode.SymbolInformation[]> {
 	let documentSymbolProvider = new GoDocumentSymbolProvider();
 	return documentSymbolProvider
 		.provideDocumentSymbols(doc, null)

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -70,42 +70,35 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, args: any)
 		return;
 	}
 	getTestFunctions(editor.document).then(testFunctions => {
-		let testFunction: vscode.SymbolInformation;
-		// Find any test function containing the cursor.
-		for (let func of testFunctions) {
-			let selection = editor.selection;
-			if (selection && func.location.range.contains(selection.start)) {
-				testFunction = func;
-				break;
-			}
-		};
-		if (!testFunction) {
+		let testFunctionName: string;
+
+		// We use functionName if it was provided as argument
+		// Otherwise find any test function containing the cursor.
+		if (args.functionName) {
+			testFunctionName = args.functionName;
+		} else {
+			for (let func of testFunctions) {
+				let selection = editor.selection;
+				if (selection && func.location.range.contains(selection.start)) {
+					testFunctionName = func.name;
+					break;
+				}
+			};
+		}
+
+		if (!testFunctionName) {
 			vscode.window.showInformationMessage('No test function found at cursor.');
 			return;
 		}
+
 		return goTest({
 			goConfig: goConfig,
 			dir: path.dirname(editor.document.fileName),
 			flags: getTestFlags(goConfig, args),
-			functions: [testFunction.name]
+			functions: [ testFunctionName ]
 		});
 	}).then(null, err => {
 		console.error(err);
-	});
-}
-
-/**
- * Runs specific given test function.
- *
- * @param goConfig Configuration for the Go extension.
- */
-export function testFunction(goConfig: vscode.WorkspaceConfiguration, functionName: string) {
-	let editor = vscode.window.activeTextEditor;
-	return goTest({
-		goConfig: goConfig,
-		dir: path.dirname(editor.document.fileName),
-		flags: getTestFlags(goConfig, null),
-		functions: [ functionName ]
 	});
 }
 


### PR DESCRIPTION
Same feature as Test at Cursor, but in this case there is no need to select anything.

It's based on C# VSCode extension.

What you think about it?

I didn't provide any flag to disable it, because it's possible to do so with standard editor flag: `"editor.codeLens": false`.

![npz78pjlim](https://cloud.githubusercontent.com/assets/94755/25244133/6b157da6-25f7-11e7-805a-f2bda6161df2.gif)
