### PR TITLE
showCovered/showUncovered

### DIFF
--- a/package.json
+++ b/package.json
@@ -446,19 +446,10 @@
           "description": "Run 'go test' on save for current package. It is not advised to set this to `true` when you have Auto Save enabled."
         },
         "go.coverOnSave": {
-          "type": "boolean",
+          "type": ["boolean", "string"],
+          "enum": [true, false, "showCoveredOnly", "showUncoveredOnly"],
           "default": false,
           "description": "Run 'go test -coverprofile' on save"
-        },
-        "go.showCovered": {
-          "type": "boolean",
-          "default": true,
-          "description": "Decorate covered code"
-        },
-        "go.showUncovered": {
-          "type": "boolean",
-          "default": true,
-          "description": "Decorate uncovered code"
         },
         "go.testTimeout": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -449,7 +449,7 @@
           "type": ["boolean", "string"],
           "enum": [true, false, "showCoveredOnly", "showUncoveredOnly"],
           "default": false,
-          "description": "Run 'go test -coverprofile' on save"
+          "description": "If not false, runs 'go test -coverprofile' on save and shows test coverage. If set to showCoveredOnly, then only covered code is highlighted. If set to showUncoveredOnly, then only uncovered code is highlighted."
         },
         "go.testTimeout": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -450,6 +450,16 @@
           "default": false,
           "description": "Run 'go test -coverprofile' on save"
         },
+        "go.showCovered": {
+          "type": "boolean",
+          "default": true,
+          "description": "Decorate covered code"
+        },
+        "go.showUncovered": {
+          "type": "boolean",
+          "default": true,
+          "description": "Decorate uncovered code"
+        },
         "go.testTimeout": {
           "type": "string",
           "default": "30s",

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -108,8 +108,8 @@ function applyCoverage(remove: boolean = false) {
 function highlightCoverage(editor: vscode.TextEditor, file: CoverageFile, remove: boolean) {
 	let cfg = vscode.workspace.getConfiguration('go');
 	let coverOnSave = cfg.get('coverOnSave', false);
-	let hideUncovered = remove || !coverOnSave || coverOnSave === "showCoveredOnly";
-	let hideCovered = remove || !coverOnSave || coverOnSave === "showUncoveredOnly";
+	let hideUncovered = remove || !coverOnSave || coverOnSave === 'showCoveredOnly';
+	let hideCovered = remove || !coverOnSave || coverOnSave === 'showUncoveredOnly';
 	editor.setDecorations(uncoveredHighLight, hideUncovered ? [] : file.uncoveredRange);
 	editor.setDecorations(coveredHighLight, hideCovered ? [] : file.coveredRange);
 }

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -110,7 +110,7 @@ function highlightCoverage(editor: vscode.TextEditor, file: CoverageFile, remove
 	let showUncovered = cfg.get('showUncovered', true);
 	let showCovered = cfg.get('showCovered', true);
 	editor.setDecorations(uncoveredHighLight, remove || !showUncovered ? [] : file.uncoveredRange);
-	editor.setDecorations(coveredHighLight, remove || ! showCovered? [] : file.coveredRange);
+	editor.setDecorations(coveredHighLight, remove || ! showCovered ? [] : file.coveredRange);
 }
 
 export function getCoverage(coverProfilePath: string, showErrOutput: boolean = false): Promise<any[]> {

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -106,8 +106,11 @@ function applyCoverage(remove: boolean = false) {
 }
 
 function highlightCoverage(editor: vscode.TextEditor, file: CoverageFile, remove: boolean) {
-	editor.setDecorations(uncoveredHighLight, remove ? [] : file.uncoveredRange);
-	editor.setDecorations(coveredHighLight, remove ? [] : file.coveredRange);
+	let cfg = vscode.workspace.getConfiguration('go');
+	let showUncovered = cfg.get('showUncovered', true);
+	let showCovered = cfg.get('showCovered', true);
+	editor.setDecorations(uncoveredHighLight, remove || !showUncovered ? [] : file.uncoveredRange);
+	editor.setDecorations(coveredHighLight, remove || ! showCovered? [] : file.coveredRange);
 }
 
 export function getCoverage(coverProfilePath: string, showErrOutput: boolean = false): Promise<any[]> {

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -107,10 +107,11 @@ function applyCoverage(remove: boolean = false) {
 
 function highlightCoverage(editor: vscode.TextEditor, file: CoverageFile, remove: boolean) {
 	let cfg = vscode.workspace.getConfiguration('go');
-	let showUncovered = cfg.get('showUncovered', true);
-	let showCovered = cfg.get('showCovered', true);
-	editor.setDecorations(uncoveredHighLight, remove || !showUncovered ? [] : file.uncoveredRange);
-	editor.setDecorations(coveredHighLight, remove || ! showCovered ? [] : file.coveredRange);
+	let coverOnSave = cfg.get('coverOnSave', false);
+	let hideUncovered = remove || !coverOnSave || coverOnSave === "showCoveredOnly";
+	let hideCovered = remove || !coverOnSave || coverOnSave === "showUncoveredOnly";
+	editor.setDecorations(uncoveredHighLight, hideUncovered ? [] : file.uncoveredRange);
+	editor.setDecorations(coveredHighLight, hideCovered ? [] : file.coveredRange);
 }
 
 export function getCoverage(coverProfilePath: string, showErrOutput: boolean = false): Promise<any[]> {


### PR DESCRIPTION
Adding two configuration options:
* `go.showCovered` (defaults to true) will decorate covered code in green
* `go.showUncovered` (defaults to true) will decorate uncovered code in red