### PR TITLE
add support for testEnvFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -486,7 +486,7 @@
         },
         "go.testEnvFile": {
           "type": "string",
-          "default": {},
+          "default": null,
           "description": "Absolute path to a file containing environment variables definitions"
         },
         "go.testFlags": {

--- a/package.json
+++ b/package.json
@@ -484,6 +484,11 @@
           "default": {},
           "description": "Environment variables that will passed to the process that runs the Go tests"
         },
+        "go.testEnvFile": {
+          "type": "string",
+          "default": {},
+          "description": "Absolute path to a file containing environment variables definitions"
+        },
         "go.testFlags": {
           "type": [
             "array",

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -11,7 +11,7 @@ import { readFileSync, existsSync, lstatSync } from 'fs';
 import { basename, dirname, extname } from 'path';
 import { spawn, ChildProcess, execSync, spawnSync } from 'child_process';
 import { Client, RPCConnection } from 'json-rpc2';
-import { getBinPathWithPreferredGopath, resolvePath, stripBOM, getGoRuntimePath } from '../goPath';
+import { parseEnvFile, getBinPathWithPreferredGopath, resolvePath, stripBOM, getGoRuntimePath } from '../goPath';
 import * as logger from 'vscode-debug-logger';
 import * as FS from 'fs';
 
@@ -207,24 +207,12 @@ class Delve {
 				return reject('The program attribute must point to valid directory, .go file or executable.');
 			}
 
-			// read env from disk and merge into envVars
+			// read env from disk and merge into env variables
 			let fileEnv = {};
-			if (launchArgs.envFile) {
-				try {
-					const buffer = stripBOM(FS.readFileSync(launchArgs.envFile, 'utf8'));
-					buffer.split('\n').forEach( line => {
-						const r = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
-						if (r !== null) {
-							let value = r[2] || '';
-							if (value.length > 0 && value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') {
-								value = value.replace(/\\n/gm, '\n');
-							}
-							fileEnv[r[1]] = value.replace(/(^['"]|['"]$)/g, '');
-						}
-					});
-				} catch (e) {
-					return reject('Cannot load environment variables from file');
-				}
+			try {
+				fileEnv = parseEnvFile(launchArgs.envFile);
+			} catch (e) {
+				return reject(e);
 			}
 
 			let env = Object.assign({}, process.env, fileEnv, launchArgs.env);

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -120,3 +120,27 @@ export function stripBOM(s: string): string {
 	}
 	return s;
 }
+
+export function parseEnvFile(path: string): { [key: string]: string } {
+	const env = { };
+	if (!path) {
+		return env;
+	}
+
+	try {
+		const buffer = stripBOM(fs.readFileSync(path, 'utf8'));
+		buffer.split('\n').forEach( line => {
+			const r = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
+			if (r !== null) {
+				let value = r[2] || '';
+				if (value.length > 0 && value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') {
+					value = value.replace(/\\n/gm, '\n');
+				}
+				env[r[1]] = value.replace(/(^['"]|['"]$)/g, '');
+			}
+		});
+		return env;
+	} catch (e) {
+		throw(`Cannot load environment variables from file ${path}`);
+	}
+}

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -9,6 +9,7 @@ import vscode = require('vscode');
 import path = require('path');
 import { CodeLensProvider, TextDocument, CancellationToken, CodeLens, Command } from 'vscode';
 import { getTestFunctions } from './goTest';
+import { getTestEnvVars } from './util';
 import { GoDocumentSymbolProvider } from './goOutline';
 
 export class GoRunTestCodeLensProvider implements CodeLensProvider {
@@ -17,9 +18,7 @@ export class GoRunTestCodeLensProvider implements CodeLensProvider {
 				'type': 'go',
 				'request': 'launch',
 				'mode': 'test',
-				'env': {
-					'GOPATH': process.env['GOPATH']
-				}
+				'env': getTestEnvVars()
 			};
 
 	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -12,7 +12,7 @@ import util = require('util');
 import os = require('os');
 import { getGoRuntimePath } from './goPath';
 import { GoDocumentSymbolProvider } from './goOutline';
-import { getToolsEnvVars } from './util';
+import { getTestEnvVars } from './util';
 
 let outputChannel = vscode.window.createOutputChannel('Go Tests');
 
@@ -204,7 +204,7 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 
 		let buildTags: string = testconfig.goConfig['buildTags'];
 		let args = ['test', ...testconfig.flags, '-timeout', testconfig.goConfig['testTimeout'], '-tags', buildTags];
-		let testEnvVars = Object.assign({}, getToolsEnvVars(), testconfig.goConfig['testEnvVars']);
+		let testEnvVars = getTestEnvVars();
 		let goRuntimePath = getGoRuntimePath();
 
 		if (!goRuntimePath) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,9 +5,10 @@
 
 import vscode = require('vscode');
 import path = require('path');
-import { getGoRuntimePath, getBinPathWithPreferredGopath, resolvePath } from './goPath';
+import { getGoRuntimePath, getBinPathWithPreferredGopath, resolvePath, stripBOM } from './goPath';
 import cp = require('child_process');
 import TelemetryReporter from 'vscode-extension-telemetry';
+import fs = require('fs');
 
 const extensionId: string = 'lukehoban.Go';
 const extensionVersion: string = vscode.extensions.getExtension(extensionId).packageJSON.version;
@@ -294,6 +295,31 @@ export function getToolsEnvVars(): any {
 		return process.env;
 	}
 	return Object.assign({}, process.env, toolsEnvVars);
+}
+
+export function getTestEnvVars(): any {
+	let config = vscode.workspace.getConfiguration('go');
+	let testEnvFile = config['testEnvFile'];
+	let fileEnv = {};
+	if (testEnvFile) {
+		try {
+			testEnvFile = testEnvFile.replace(/\${workspaceRoot}/g, vscode.workspace.rootPath);
+			const buffer = stripBOM(fs.readFileSync(testEnvFile, 'utf8'));
+			buffer.split('\n').forEach( line => {
+				const r = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
+				if (r !== null) {
+					let value = r[2] || '';
+					if (value.length > 0 && value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') {
+						value = value.replace(/\\n/gm, '\n');
+					}
+					fileEnv[r[1]] = value.replace(/(^['"]|['"]$)/g, '');
+				}
+			});
+		} catch (e) {
+			throw('Cannot load environment variables from file');
+		}
+	}
+	return Object.assign({}, fileEnv, getToolsEnvVars(), config['testEnvVars'] || {});
 }
 
 export function getExtensionCommands(): any[] {

--- a/src/util.ts
+++ b/src/util.ts
@@ -309,7 +309,7 @@ export function getTestEnvVars(): any {
 		fileEnv = parseEnvFile(testEnvFile);
 	}
 
-	return Object.assign({}, fileEnv, toolsEnv, testEnv);
+	return Object.assign({}, toolsEnv, fileEnv, testEnv);
 }
 
 export function getExtensionCommands(): any[] {


### PR DESCRIPTION
The main purpose of this pull request is to enable use of .env files when running/debugging tests through VSCode no matter what triggered it (CodeLens, Tasks, Command ...)

This pull request contains:

1) New `go.testEnvFile` configuration option with same intent as envFile from vscode debug settings;
2) Any test function ran by vscode-go will load env variables from: `process.env`, `go.toolsEnvVars`, `go.testEnvFile` and `go.testEnvVars`;
3) Debug CodeLens now loads `go.testEnvFile` and `go.testEnvVars`;
4) moved .env parser to a specific function for reusability purpose;

I didn't like this bit here `testEnvFile = testEnvFile.replace(/\${workspaceRoot}/g, vscode.workspace.rootPath);`, but didn't find any other way to do so.

Regards,
Guilherme