### PR TITLE
Support configuring gocode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -500,6 +500,19 @@
           "default": {},
           "description": "Environment variables that will passed to the processes that run the Go tools (e.g. CGO_CFLAGS)"
         },
+        "go.gocodeTool": {
+          "type": "string",
+          "default": null,
+          "description": "The gocode tool to run, e.g. '/usr/bin/mygocode'. Defaults to look up gocode in GOPATH."
+        },
+        "go.gocodeFlags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Flags to pass to gocode (e.g. ['-address', '-sock'])"
+        },
         "go.gocodeAutoBuild": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
- support configuring the binary location for gocode
- support passing additional default flags to gocode

This can be used to for example connect to a remote gocode server, use
a different socket type, etc.