### PR TITLE
Add testEnvVars from workspace config to debug environment

### DIFF
--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -70,6 +70,7 @@ export class GoRunTestCodeLensProvider implements CodeLensProvider {
 				};
 
 				let config = Object.assign({}, this.debugConfig, { args: ['-test.run', func.name], program: path.dirname(document.fileName) });
+				Object.assign(config.env, vscode.workspace.getConfiguration("go").get("testEnvVars"));
 				let debugTestCmd: Command = {
 					title: 'debug test',
 					command: 'vscode.startDebug',

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -70,7 +70,7 @@ export class GoRunTestCodeLensProvider implements CodeLensProvider {
 				};
 
 				let config = Object.assign({}, this.debugConfig, { args: ['-test.run', func.name], program: path.dirname(document.fileName) });
-				Object.assign(config.env, vscode.workspace.getConfiguration("go").get("testEnvVars"));
+				Object.assign(config.env, vscode.workspace.getConfiguration('go').get('testEnvVars'));
 				let debugTestCmd: Command = {
 					title: 'debug test',
 					command: 'vscode.startDebug',


### PR DESCRIPTION
Command **"debug test"** from codelense did not populate env vars with those from workspace config. Usually this command runs in same environment as plain tests, so it is natural to expect **testEnvVars** from workspace config being used.
This pr fix behavior to expected.
