### PR TITLE
Run on-save tools for entire workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -353,9 +353,14 @@
       "title": "Go configuration",
       "properties": {
         "go.buildOnSave": {
-          "type": "boolean",
-          "default": true,
-          "description": "Run 'go build'/'go test -c' on save."
+          "type": "string",
+          "enum": [
+            "package",
+            "workspace",
+            "off"
+          ],
+          "default": "package",
+          "description": "Run 'go build'/'go test -c' on save on the current workspace, current package or nothing."
         },
         "go.buildFlags": {
           "type": "array",
@@ -371,9 +376,14 @@
           "description": "The Go build tags to use for all commands that support a `-tags '...'` argument"
         },
         "go.lintOnSave": {
-          "type": "boolean",
-          "default": true,
-          "description": "Run Lint tool on save."
+           "type": "string",
+          "enum": [
+            "package",
+            "workspace",
+            "off"
+          ],
+          "default": "package",
+          "description": "Run Lint tool on save on current workspace, current package or nothing."
         },
         "go.lintTool": {
           "type": "string",
@@ -393,9 +403,14 @@
           "description": "Flags to pass to Lint tool (e.g. [\"-min_confidence=.8\"])"
         },
         "go.vetOnSave": {
-          "type": "boolean",
-          "default": true,
-          "description": "Run 'go tool vet' on save."
+          "type": "string",
+          "enum": [
+            "package",
+            "workspace",
+            "off"
+          ],
+          "default": "package",
+          "description": "Run 'go vet' on save on current workspace, current package or nothing."
         },
         "go.vetFlags": {
           "type": "array",
@@ -403,7 +418,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Flags to pass to `go tool vet` (e.g. ['-all', '-shadow'])"
+          "description": "Flags to pass to `go vet` (e.g. ['-all', '-shadow'])"
         },
         "go.formatOnSave": {
           "type": "boolean",

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -145,17 +145,12 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 	if (!!goConfig['buildOnSave']) {
 		let buildFlags = goConfig['buildFlags'] || [];
 		let buildTags = '"' + goConfig['buildTags'] + '"';
-		let tmppath = path.normalize(path.join(os.tmpdir(), 'go-code-check'));
-		let currentGoWorkspace = getCurrentGoWorkspaceFromGOPATH(cwd);
-		let importPath = currentGoWorkspace ? cwd.substr(currentGoWorkspace.length + 1) : '.';
-		let args = ['build', '-i', '-o', tmppath, '-tags', buildTags, ...buildFlags, importPath];
-		if (filename.match(/_test.go$/i)) {
-			args = ['test', '-i', '-copybinary', '-o', tmppath, '-c', '-tags', buildTags, ...buildFlags, importPath];
-		}
+
+		let args = ['build', '-i', '-tags', buildTags, ...buildFlags, './...'];
 
 		runningToolsPromises.push(runTool(
 			args,
-			cwd,
+			vscode.workspace.rootPath,
 			'error',
 			true,
 			null,

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -202,9 +202,12 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 			args.push('--aggregate');
 		}
 
+		// Lint the entire workspace recursively.
+		args.push('./...');
+
 		runningToolsPromises.push(runTool(
 			args,
-			cwd,
+			vscode.workspace.rootPath,
 			'warning',
 			false,
 			lintTool,
@@ -215,8 +218,8 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 	if (!!goConfig['vetOnSave']) {
 		let vetFlags = goConfig['vetFlags'] || [];
 		runningToolsPromises.push(runTool(
-			['tool', 'vet', ...vetFlags, filename],
-			cwd,
+			['vet', ...vetFlags, './...'],
+			vscode.workspace.rootPath,
 			'warning',
 			true,
 			null,


### PR DESCRIPTION
Changes the default behavior from running lint/vet/build for the package of the current active file to running it for the entire workspace.

Potential downside is not having a flag which allows the behavior to be changed between `current package` and `workspace` (as with #830). Something for the future.