### PR TITLE
Add support for megacheck as the lintTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ If you want to run only specific linters (some linters are slow), you can modify
   "go.lintFlags": ["--disable-all", "--enable=errcheck"],
 ```
 
+Alternatively, you can use [megacheck](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck) which 
+may have significantly better performance than `go-tools`, while only supporting a subset of the tools.
+
 Finally, the result of those linters will show right in the code (locations with suggestions will be underlined),
 as well as in the output pane.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you want to run only specific linters (some linters are slow), you can modify
 ```
 
 Alternatively, you can use [megacheck](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck) which 
-may have significantly better performance than `go-tools`, while only supporting a subset of the tools.
+may have significantly better performance than `gometalinter`, while only supporting a subset of the tools.
 
 Finally, the result of those linters will show right in the code (locations with suggestions will be underlined),
 as well as in the output pane.

--- a/package.json
+++ b/package.json
@@ -376,7 +376,7 @@
           "description": "The Go build tags to use for all commands that support a `-tags '...'` argument"
         },
         "go.lintOnSave": {
-           "type": "string",
+          "type": "string",
           "enum": [
             "package",
             "workspace",
@@ -391,7 +391,8 @@
           "description": "Specifies Lint tool name.",
           "enum": [
             "golint",
-            "gometalinter"
+            "gometalinter",
+            "megacheck"
           ]
         },
         "go.lintFlags": {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -59,6 +59,10 @@ function getTools(goVersion: SemVersion): { [key: string]: string } {
 		tools['gometalinter'] = 'github.com/alecthomas/gometalinter';
 	}
 
+	if (goConfig['lintTool'] === 'megacheck') {
+		tools['megacheck'] = 'honnef.co/go/tools/...';
+	}
+
 	if (goConfig['useLanguageServer'] && process.platform !== 'win32') {
 		tools['go-langserver'] = 'github.com/sourcegraph/go-langserver';
 	}


### PR DESCRIPTION
This PR adds support for @dominikh's all-in-one linter tool. Generally it's much quicker than `gometalinter` and uses fewer resources, as it shares work between all checks. 