### PR TITLE
Use go list all to get pkgname to use in completions 

### DIFF
--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -11,6 +11,7 @@ import { parseFilePrelude, isVendorSupported, getBinPath, getCurrentGoWorkspaceF
 import { documentSymbols } from './goOutline';
 import { promptForMissingTool } from './goInstallTools';
 import path = require('path');
+import { getRelativePackagePath } from './goPackages';
 
 export function listPackages(excludeImportedPkgs: boolean = false): Thenable<string[]> {
 	let importsPromise = excludeImportedPkgs && vscode.window.activeTextEditor ? getImports(vscode.window.activeTextEditor.document) : Promise.resolve([]);
@@ -51,30 +52,10 @@ export function listPackages(excludeImportedPkgs: boolean = false): Thenable<str
 				if (!pkg || importedPkgs.indexOf(pkg) > -1) {
 					return;
 				}
-
-				let magicVendorString = '/vendor/';
-				let vendorIndex = pkg.indexOf(magicVendorString);
-				if (vendorIndex === -1) {
-					magicVendorString = 'vendor/';
-					if (pkg.startsWith(magicVendorString)) {
-						vendorIndex = 0;
-					}
+				let relativePkgPath = getRelativePackagePath(currentFileDirPath, currentWorkspace, pkg);
+				if (relativePkgPath) {
+					pkgSet.add(relativePkgPath);
 				}
-				// Check if current file and the vendor pkg belong to the same root project
-				// If yes, then vendor pkg can be replaced with its relative path to the "vendor" folder
-				// If not, then the vendor pkg should not be allowed to be imported.
-				if (vendorIndex > -1) {
-					let rootProjectForVendorPkg = path.join(currentWorkspace, pkg.substr(0, vendorIndex));
-					let relativePathForVendorPkg = pkg.substring(vendorIndex + magicVendorString.length);
-
-					if (relativePathForVendorPkg && currentFileDirPath.startsWith(rootProjectForVendorPkg)) {
-						pkgSet.add(relativePathForVendorPkg);
-					}
-					return;
-				}
-
-				// pkg is not a vendor project
-				pkgSet.add(pkg);
 			});
 
 			return Array.from(pkgSet).sort();

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -34,6 +34,7 @@ import { addTags, removeTags } from './goModifytags';
 import { parseLiveFile } from './goLiveErrors';
 import { GoCodeLensProvider } from './goCodelens';
 import { implCursor } from './goImpl';
+import { goListAll } from './goPackages';
 
 export let errorDiagnosticCollection: vscode.DiagnosticCollection;
 let warningDiagnosticCollection: vscode.DiagnosticCollection;
@@ -44,6 +45,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	let toolsGopath = vscode.workspace.getConfiguration('go')['toolsGopath'];
 
 	updateGoPathGoRootFromConfig().then(() => {
+		goListAll();
 		offerToInstallTools();
 		let langServerAvailable = checkLanguageServer();
 		if (langServerAvailable) {

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -1,0 +1,97 @@
+import vscode = require('vscode');
+import cp = require('child_process');
+import path = require('path');
+import { getGoRuntimePath } from './goPath';
+import { isVendorSupported, getCurrentGoWorkspaceFromGOPATH } from './util';
+
+let allPkgs = new Map<string, string>();
+let goListAllCompleted: boolean = false;
+
+/**
+ * Runs go list all
+ * @returns Map<string, string> mapping between package import path and package name
+ */
+export function goListAll(): Promise<Map<string, string>> {
+	let goRuntimePath = getGoRuntimePath();
+
+	if (!goRuntimePath) {
+		vscode.window.showInformationMessage('Cannot find "go" binary. Update PATH or GOROOT appropriately');
+		return Promise.resolve(null);
+	}
+
+	if (goListAllCompleted) {
+		return Promise.resolve(allPkgs);
+	}
+	return new Promise<Map<string, string>>((resolve, reject) => {
+		cp.execFile(goRuntimePath, ['list', '-f', '{{.Name}};{{.ImportPath}}', 'all'], (err, stdout, stderr) => {
+			if (err) return reject();
+			stdout.split('\n').forEach(pkgDetail => {
+				if (!pkgDetail || !pkgDetail.trim() || pkgDetail.indexOf(';') === -1) return;
+				let [pkgName, pkgPath] = pkgDetail.trim().split(';');
+				if (pkgName !== 'main') {
+					allPkgs.set(pkgPath, pkgName);
+				}
+			});
+			goListAllCompleted = true;
+			return resolve(allPkgs);
+		});
+	});
+}
+
+/**
+ * Returns mapping of import path and package name for packages
+ * @param filePath. Used to determine the right relative path for vendor pkgs
+ * @returns Map<string, string> mapping between package import path and package name
+ */
+export function getAllPackageDetails(filePath: string): Promise<Map<string, string>> {
+
+	return Promise.all([isVendorSupported(), goListAll()]).then(values => {
+		let isVendorSupported = values[0];
+		let pkgs: Map<string, string> = values[1];
+		let currentFileDirPath = path.dirname(filePath);
+		let currentWorkspace = getCurrentGoWorkspaceFromGOPATH(currentFileDirPath);
+		if (!isVendorSupported || !currentWorkspace) {
+			return pkgs;
+		}
+
+		let pkgMap = new Map<string, string>();
+		pkgs.forEach((pkgName, pkgPath) => {
+			let relativePkgPath = getRelativePackagePath(currentFileDirPath, currentWorkspace, pkgPath);
+			if (relativePkgPath) {
+				pkgMap.set(relativePkgPath, pkgs.get(pkgPath));
+			}
+		});
+		return pkgMap;
+	});
+
+}
+
+/**
+ * If given pkgPath is not vendor pkg, then the same pkgPath is returned
+ * Else, the import path for the vendor pkg relative to given filePath is returned.
+ */
+export function getRelativePackagePath(currentFileDirPath: string, currentWorkspace: string, pkgPath: string): string {
+	let magicVendorString = '/vendor/';
+	let vendorIndex = pkgPath.indexOf(magicVendorString);
+	if (vendorIndex === -1) {
+		magicVendorString = 'vendor/';
+		if (pkgPath.startsWith(magicVendorString)) {
+			vendorIndex = 0;
+		}
+	}
+	// Check if current file and the vendor pkg belong to the same root project
+	// If yes, then vendor pkg can be replaced with its relative path to the "vendor" folder
+	// If not, then the vendor pkg should not be allowed to be imported.
+	if (vendorIndex > -1) {
+		let rootProjectForVendorPkg = path.join(currentWorkspace, pkgPath.substr(0, vendorIndex));
+		let relativePathForVendorPkg = pkgPath.substring(vendorIndex + magicVendorString.length);
+
+		if (relativePathForVendorPkg && currentFileDirPath.startsWith(rootProjectForVendorPkg)) {
+			return relativePathForVendorPkg;
+		}
+		return '';
+	}
+
+	return pkgPath;
+}
+

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -10,7 +10,8 @@ import cp = require('child_process');
 import { dirname, basename } from 'path';
 import { getBinPath, parameters, parseFilePrelude, isPositionInString, goKeywords, getToolsEnvVars } from './util';
 import { promptForMissingTool } from './goInstallTools';
-import { listPackages, getTextEditForAddImport } from './goImport';
+import { getTextEditForAddImport } from './goImport';
+import { getAllPackageDetails } from './goPackages';
 
 function vscodeKindFromGoCodeClass(kind: string): vscode.CompletionItemKind {
 	switch (kind) {
@@ -34,15 +35,10 @@ interface GoCodeSuggestion {
 	type: string;
 }
 
-interface PackageInfo {
-	name: string;
-	path: string;
-}
-
 export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 
 	private gocodeConfigurationComplete = false;
-	private pkgsList: PackageInfo[] = [];
+	private pkgsList = new Map<string, string>();
 
 	public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.CompletionItem[]> {
 		return this.provideCompletionItemsInternal(document, position, token, vscode.workspace.getConfiguration('go'));
@@ -219,21 +215,11 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 	}
 	// TODO: Shouldn't lib-path also be set?
 	private ensureGoCodeConfigured(): Thenable<void> {
-		let pkgPromise = listPackages(false).then((pkgs: string[]) => {
-			this.pkgsList = pkgs.map(pkg => {
-				let index = pkg.lastIndexOf('/');
-				let pkgName = index === -1 ? pkg : pkg.substr(index + 1);
-				// pkgs from gopkg.in will be of the form gopkg.in/user/somepkg.v3
-				if (pkg.match(/gopkg\.in\/.*\.v\d+/)) {
-					pkgName = pkgName.substr(0, pkgName.lastIndexOf('.v'));
-				}
-				return {
-					name: pkgName,
-					path: pkg
-				};
-			});
+		getAllPackageDetails(vscode.window.activeTextEditor.document.fileName).then(pkgMap => {
+			this.pkgsList = pkgMap;
 		});
-		let configPromise = new Promise<void>((resolve, reject) => {
+
+		return new Promise<void>((resolve, reject) => {
 			// TODO: Since the gocode daemon is shared amongst clients, shouldn't settings be
 			// adjusted per-invocation to avoid conflicts from other gocode-using programs?
 			if (this.gocodeConfigurationComplete) {
@@ -244,33 +230,34 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 			let env = getToolsEnvVars();
 			cp.execFile(gocode, ['set', 'propose-builtins', 'true'], { env }, (err, stdout, stderr) => {
 				cp.execFile(gocode, ['set', 'autobuild', autobuild], {}, (err, stdout, stderr) => {
-					resolve();
+					return resolve();
 				});
 			});
 		});
-		return Promise.all([pkgPromise, configPromise]).then(() => {
-			return Promise.resolve();
-		});
+
 	}
 
 	// Return importable packages that match given word as Completion Items
 	private getMatchingPackages(word: string, suggestionSet: Set<string>): vscode.CompletionItem[] {
 		if (!word) return [];
-		let completionItems = this.pkgsList.filter((pkgInfo: PackageInfo) => {
-			return pkgInfo.name.startsWith(word) && !suggestionSet.has(pkgInfo.name);
-		}).map((pkgInfo: PackageInfo) => {
-			let item = new vscode.CompletionItem(pkgInfo.name, vscode.CompletionItemKind.Keyword);
-			item.detail = pkgInfo.path;
-			item.documentation = 'Imports the package';
-			item.insertText = pkgInfo.name;
-			item.command = {
-				title: 'Import Package',
-				command: 'go.import.add',
-				arguments: [pkgInfo.path]
-			};
-			// Add same sortText to the unimported packages so that they appear after the suggestions from gocode
-			item.sortText = 'z';
-			return item;
+		let completionItems = [];
+
+		this.pkgsList.forEach((pkgName: string, pkgPath: string) => {
+			if (pkgName.startsWith(word) && !suggestionSet.has(pkgName)) {
+
+				let item = new vscode.CompletionItem(pkgName, vscode.CompletionItemKind.Keyword);
+				item.detail = pkgPath;
+				item.documentation = 'Imports the package';
+				item.insertText = pkgName;
+				item.command = {
+					title: 'Import Package',
+					command: 'go.import.add',
+					arguments: [pkgPath]
+				};
+				// Add same sortText to the unimported packages so that they appear after the suggestions from gocode
+				item.sortText = 'z';
+				completionItems.push(item);
+			}
 		});
 		return completionItems;
 	}
@@ -283,14 +270,17 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 			return;
 		}
 
-		let [_, pkgName] = wordmatches;
+		let [_, pkgNameFromWord] = wordmatches;
 		// Word is isolated. Now check pkgsList for a match
-		let matchingPackages = this.pkgsList.filter(pkgInfo => {
-			return pkgInfo.name === pkgName;
+		let matchingPackages = [];
+		this.pkgsList.forEach((pkgName: string, pkgPath: string) => {
+			if (pkgNameFromWord === pkgName) {
+				matchingPackages.push(pkgPath);
+			}
 		});
 
 		if (matchingPackages && matchingPackages.length === 1) {
-			return matchingPackages[0].path;
+			return matchingPackages[0];
 		}
 	}
 }

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -128,7 +128,7 @@ suite('Go Extension Tests', () => {
 			'docsTool': { value: 'gogetdoc' }
 		});
 		getGoVersion().then(version => {
-			if (version.major > 1 || (version.major === 1 && version.minor > 5)) {
+			if (!version || version.major > 1 || (version.major === 1 && version.minor > 5)) {
 				return testDefinitionProvider(config);
 			}
 			return Promise.resolve();
@@ -166,7 +166,7 @@ It returns the number of bytes written and any write error encountered.
 			'docsTool': { value: 'gogetdoc' }
 		});
 		getGoVersion().then(version => {
-			if (version.major > 1 || (version.major === 1 && version.minor > 5)) {
+			if (!version || version.major > 1 || (version.major === 1 && version.minor > 5)) {
 				return testSignatureHelpProvider(config, testCases);
 			}
 			return Promise.resolve();
@@ -217,7 +217,7 @@ It returns the number of bytes written and any write error encountered.
 			'docsTool': { value: 'gogetdoc' }
 		});
 		getGoVersion().then(version => {
-			if (version.major > 1 || (version.major === 1 && version.minor > 5)) {
+			if (!version || version.major > 1 || (version.major === 1 && version.minor > 5)) {
 				return testHoverProvider(config, testCases);
 			}
 			return Promise.resolve();
@@ -305,7 +305,7 @@ It returns the number of bytes written and any write error encountered.
 			{ line: 12, severity: 'error', msg: 'undefined: prin' },
 		];
 		getGoVersion().then(version => {
-			if (version.major === 1 && version.minor < 6) {
+			if (version && version.major === 1 && version.minor < 6) {
 				// golint is not supported in Go 1.5, so skip the test
 				return Promise.resolve();
 			}
@@ -326,7 +326,7 @@ It returns the number of bytes written and any write error encountered.
 
 	test('Test Generate unit tests squeleton for file', (done) => {
 		getGoVersion().then(version => {
-			if (version.major === 1 && version.minor < 6) {
+			if (version && version.major === 1 && version.minor < 6) {
 				// gotests is not supported in Go 1.5, so skip the test
 				return Promise.resolve();
 			}
@@ -352,7 +352,7 @@ It returns the number of bytes written and any write error encountered.
 
 	test('Test Generate unit tests squeleton for a function', (done) => {
 		getGoVersion().then(version => {
-			if (version.major === 1 && version.minor < 6) {
+			if (version && version.major === 1 && version.minor < 6) {
 				// gotests is not supported in Go 1.5, so skip the test
 				return Promise.resolve();
 			}
@@ -381,7 +381,7 @@ It returns the number of bytes written and any write error encountered.
 
 	test('Test Generate unit tests squeleton for package', (done) => {
 		getGoVersion().then(version => {
-			if (version.major === 1 && version.minor < 6) {
+			if (version && version.major === 1 && version.minor < 6) {
 				// gotests is not supported in Go 1.5, so skip the test
 				return Promise.resolve();
 			}
@@ -407,7 +407,7 @@ It returns the number of bytes written and any write error encountered.
 
 	test('Gometalinter error checking', (done) => {
 		getGoVersion().then(version => {
-			if (version.major === 1 && version.minor < 6) {
+			if (version && version.major === 1 && version.minor < 6) {
 				// golint in gometalinter is not supported in Go 1.5, so skip the test
 				return Promise.resolve();
 			}


### PR DESCRIPTION
Fixes #647

`gopkgs` only return the import paths of the packages that can be imported and not the package names.
Since the last part of the import path of a package need not necessarily be the package name, we cannot always decipher package name from the import path.

In this PR, we use `go list all` instead.

`go list all` is expensive. So should be used sparingly. In this case, it is run on extension activation.