### PR TITLE
Guru ImplementationProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "console-stamp": "^0.2.2",
     "diff": "~3.3.0",
     "json-rpc2": "^1.0.2",
-    "vscode": "^1.1.1",
+    "vscode": "^1.1.4",
     "vscode-debug-logger": "^0.0.4",
     "vscode-debugadapter": "^1.11.0",
     "vscode-debugprotocol": "^1.11.0",
@@ -49,10 +49,10 @@
     "fs-extra": "^1.0.0",
     "tslint": "^4.0.2",
     "typescript": "^2.1.5",
-    "vscode": "^1.0.3"
+    "vscode": "^1.1.4"
   },
   "engines": {
-    "vscode": "^1.8.0"
+    "vscode": "^1.9.0"
   },
   "activationEvents": [
     "onLanguage:go",

--- a/src/goImplementations.ts
+++ b/src/goImplementations.ts
@@ -5,7 +5,7 @@ import cp = require('child_process');
 import path = require('path');
 import { byteOffsetAt, getBinPath, canonicalizeGOPATHPrefix } from './util';
 import { promptForMissingTool } from './goInstallTools';
-import { getGoVersion, SemVersion, goKeywords, isPositionInString } from './util';
+import { goKeywords, isPositionInString } from './util';
 import { getGoRuntimePath, resolvePath } from './goPath';
 
 interface GoListOutput {
@@ -26,67 +26,52 @@ interface GuruImplementsOutput {
 }
 
 export class GoImplementationProvider implements vscode.ImplementationProvider {
-	private goConfig = null;
-
-	constructor(goConfig?: vscode.WorkspaceConfiguration) {
-		this.goConfig = goConfig;
-	}
-
 	public provideImplementation(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Definition> {
-		return getGoVersion().then((ver: SemVersion) => {
-			return new Promise<vscode.Definition>((resolve, reject) => {
-				if (token.isCancellationRequested) {
-					resolve(null);
-					return;
-				}
+		return new Promise<vscode.Definition>((resolve, reject) => {
+			if (token.isCancellationRequested) {
+				return resolve(null);
+			}
 
-				cp.execFile(getGoRuntimePath(), ['list', '-e', '-json'], { cwd: vscode.workspace.rootPath }, (err, stdout, stderr) => {
+			let listProcess = cp.execFile(getGoRuntimePath(), ['list', '-e', '-json'], { cwd: vscode.workspace.rootPath }, (err, stdout, stderr) => {
+				if (err) {
+					return reject(err);
+				}
+				let listOutput = <GoListOutput>JSON.parse(stdout.toString());
+				let scope = listOutput.ImportPath;
+				let filename = canonicalizeGOPATHPrefix(document.fileName);
+				let cwd = path.dirname(filename);
+				let offset = byteOffsetAt(document, position);
+				let goGuru = getBinPath('guru');
+				let buildTags = '"' + vscode.workspace.getConfiguration('go')['buildTags'] + '"';
+				let args = ['-scope', `${scope}/...`, '-json', '-tags', buildTags, 'implements', `${filename}:#${offset.toString()}`];
+
+				let guruProcess = cp.execFile(goGuru, args, {}, (err, stdout, stderr) => {
+					if (err && (<any>err).code === 'ENOENT') {
+						promptForMissingTool('guru');
+						return resolve(null);
+					}
+
 					if (err) {
 						return reject(err);
 					}
-					let listOutput = <GoListOutput>JSON.parse(stdout.toString());
-					let scope = listOutput.ImportPath;
-					let filename = canonicalizeGOPATHPrefix(document.fileName);
-					let cwd = path.dirname(filename);
-					let offset = byteOffsetAt(document, position);
-					let goGuru = getBinPath('guru');
-					let buildTags = '"' + vscode.workspace.getConfiguration('go')['buildTags'] + '"';
-					let args = ['-scope', `${scope}/...`, '-json', '-tags', buildTags, 'implements', `${filename}:#${offset.toString()}`];
 
-					let process = cp.execFile(goGuru, args, {}, (err, stdout, stderr) => {
-						if (err && (<any>err).code === 'ENOENT') {
-							promptForMissingTool('guru');
-							return resolve(null);
-						}
-
-						if (err) {
-							console.error(err);
-							return resolve(null);
-						}
-
-						let guruOutput = <GuruImplementsOutput>JSON.parse(stdout.toString());
-						let results: vscode.Location[] = [];
-						guruOutput.to.forEach(ref => {
-							let match = /^(.*):(\d+):(\d+)/.exec(ref.pos);
-							if (!match) return;
-							let [_, file, lineStartStr, colStartStr] = match;
-							let referenceResource = vscode.Uri.file(path.resolve(cwd, file));
-							let range = new vscode.Range(
-								+lineStartStr - 1, +colStartStr - 1, +lineStartStr - 1, +colStartStr
-							);
-							results.push(new vscode.Location(referenceResource, range));
-						});
-						resolve(results);
+					let guruOutput = <GuruImplementsOutput>JSON.parse(stdout.toString());
+					let results: vscode.Location[] = [];
+					guruOutput.to.forEach(ref => {
+						let match = /^(.*):(\d+):(\d+)/.exec(ref.pos);
+						if (!match) return;
+						let [_, file, lineStartStr, colStartStr] = match;
+						let referenceResource = vscode.Uri.file(path.resolve(cwd, file));
+						let range = new vscode.Range(
+							+lineStartStr - 1, +colStartStr - 1, +lineStartStr - 1, +colStartStr
+						);
+						results.push(new vscode.Location(referenceResource, range));
 					});
-
-					token.onCancellationRequested(e => process.kill());
+					return resolve(results);
 				});
+				token.onCancellationRequested(() => guruProcess.kill());
 			});
-		}, err => {
-			if (err) {
-				console.log(err);
-			}
-			return Promise.resolve(null);
+			token.onCancellationRequested(() => listProcess.kill());
 		});
 	}
 }

--- a/src/goImplementations.ts
+++ b/src/goImplementations.ts
@@ -1,0 +1,92 @@
+'use strict';
+
+import vscode = require('vscode');
+import cp = require('child_process');
+import path = require('path');
+import { byteOffsetAt, getBinPath, canonicalizeGOPATHPrefix } from './util';
+import { promptForMissingTool } from './goInstallTools';
+import { getGoVersion, SemVersion, goKeywords, isPositionInString } from './util';
+import { getGoRuntimePath, resolvePath } from './goPath';
+
+interface GoListOutput {
+	Dir: string;
+	ImportPath: string;
+}
+
+interface GuruImplementsRef {
+	name: string;
+	pos: string;
+	kind: string;
+}
+
+interface GuruImplementsOutput {
+	type: GuruImplementsRef;
+	to: GuruImplementsRef[];
+	from: GuruImplementsRef[];
+}
+
+export class GoImplementationProvider implements vscode.ImplementationProvider {
+	private goConfig = null;
+
+	constructor(goConfig?: vscode.WorkspaceConfiguration) {
+		this.goConfig = goConfig;
+	}
+
+	public provideImplementation(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Definition> {
+		return getGoVersion().then((ver: SemVersion) => {
+			return new Promise<vscode.Definition>((resolve, reject) => {
+				if (token.isCancellationRequested) {
+					resolve(null);
+					return;
+				}
+
+				cp.execFile(getGoRuntimePath(), ['list', '-e', '-json'], { cwd: vscode.workspace.rootPath }, (err, stdout, stderr) => {
+					if (err) {
+						return reject(err);
+					}
+					let listOutput = <GoListOutput>JSON.parse(stdout.toString());
+					let scope = listOutput.ImportPath;
+					let filename = canonicalizeGOPATHPrefix(document.fileName);
+					let cwd = path.dirname(filename);
+					let offset = byteOffsetAt(document, position);
+					let goGuru = getBinPath('guru');
+					let buildTags = '"' + vscode.workspace.getConfiguration('go')['buildTags'] + '"';
+					let args = ['-scope', `${scope}/...`, '-json', '-tags', buildTags, 'implements', `${filename}:#${offset.toString()}`];
+
+					let process = cp.execFile(goGuru, args, {}, (err, stdout, stderr) => {
+						if (err && (<any>err).code === 'ENOENT') {
+							promptForMissingTool('guru');
+							return resolve(null);
+						}
+
+						if (err) {
+							console.error(err);
+							return resolve(null);
+						}
+
+						let guruOutput = <GuruImplementsOutput>JSON.parse(stdout.toString());
+						let results: vscode.Location[] = [];
+						guruOutput.to.forEach(ref => {
+							let match = /^(.*):(\d+):(\d+)/.exec(ref.pos);
+							if (!match) return;
+							let [_, file, lineStartStr, colStartStr] = match;
+							let referenceResource = vscode.Uri.file(path.resolve(cwd, file));
+							let range = new vscode.Range(
+								+lineStartStr - 1, +colStartStr - 1, +lineStartStr - 1, +colStartStr
+							);
+							results.push(new vscode.Location(referenceResource, range));
+						});
+						resolve(results);
+					});
+
+					token.onCancellationRequested(e => process.kill());
+				});
+			});
+		}, err => {
+			if (err) {
+				console.log(err);
+			}
+			return Promise.resolve(null);
+		});
+	}
+}

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -10,6 +10,7 @@ import { GoCompletionItemProvider } from './goSuggest';
 import { GoHoverProvider } from './goExtraInfo';
 import { GoDefinitionProvider } from './goDeclaration';
 import { GoReferenceProvider } from './goReferences';
+import { GoImplementationProvider } from './goImplementations';
 import { GoDocumentFormattingEditProvider, Formatter } from './goFormat';
 import { GoRenameProvider } from './goRename';
 import { GoDocumentSymbolProvider } from './goOutline';
@@ -89,6 +90,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 			ctx.subscriptions.push(vscode.languages.registerHoverProvider(GO_MODE, new GoHoverProvider()));
 			ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(GO_MODE, new GoDefinitionProvider()));
 			ctx.subscriptions.push(vscode.languages.registerReferenceProvider(GO_MODE, new GoReferenceProvider()));
+			ctx.subscriptions.push(vscode.languages.registerImplementationProvider(GO_MODE, new GoImplementationProvider()));
 			ctx.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(GO_MODE, new GoDocumentSymbolProvider()));
 			ctx.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new GoWorkspaceSymbolProvider()));
 			ctx.subscriptions.push(vscode.languages.registerSignatureHelpProvider(GO_MODE, new GoSignatureHelpProvider(), '(', ','));


### PR DESCRIPTION
Add an ImplementationProvider based on the Go `guru` tool.

Based on @codmajik's work in https://github.com/codmajik/vscode-go/commit/3bf018bab0b86ccf16aeefb6286cab6a8f63e8aa.

Fixes https://github.com/Microsoft/vscode-go/issues/771.

TODO:
- [x] Progress/working indicator (How? cc @ramya-rao-a)
- [x] Audit necessary library updates (Split into a prerequisite PR? @ramya-rao-a)
- [ ] Docs/comments
