### PR TITLE
Exclude 'vendor' directory when test all workspace

### DIFF
--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -23,7 +23,7 @@ export function goListAll(): Promise<Map<string, string>> {
 		return Promise.resolve(allPkgs);
 	}
 	return new Promise<Map<string, string>>((resolve, reject) => {
-		cp.execFile(goRuntimePath, ['list', '-f', '{{.Name}};{{.ImportPath}}', 'all'], (err, stdout, stderr) => {
+		cp.execFile(goRuntimePath, ['list', '-f', '{{.Name}};{{.ImportPath}}', 'all'], {env: {}}, (err, stdout, stderr) => {
 			if (err) return reject();
 			stdout.split('\n').forEach(pkgDetail => {
 				if (!pkgDetail || !pkgDetail.trim() || pkgDetail.indexOf(';') === -1) return;

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -230,31 +230,37 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 			return Promise.resolve();
 		}
 
-		if (testconfig.functions) {
-			args.push('-run');
-			args.push(util.format('^%s$', testconfig.functions.join('|')));
-		} else if (testconfig.includeSubDirectories) {
-			args.push('./...');
-		}
-
-		outputChannel.appendLine(['Running tool:', goRuntimePath, ...args].join(' '));
-		outputChannel.appendLine('');
-
-		let proc = cp.spawn(goRuntimePath, args, { env: testEnvVars, cwd: testconfig.dir });
-		proc.stdout.on('data', chunk => {
-			let testOutput = expandFilePathInOutput(chunk.toString(), testconfig.dir);
-			outputChannel.append(testOutput);
-
-		});
-		proc.stderr.on('data', chunk => outputChannel.append(chunk.toString()));
-		proc.on('close', code => {
-			if (code) {
-				outputChannel.append('Error: Tests failed.');
+		targetArgs(testconfig).then(targets => {
+			let outTargets = args.slice(0)
+			if (targets.length > 2) {
+				outTargets.push('<long arguments omitted>')
 			} else {
-				outputChannel.append('Success: Tests passed.');
+				outTargets.push(...targets)
 			}
-			resolve(code === 0);
-		});
+			outputChannel.appendLine(['Running tool:', goRuntimePath, ...outTargets].join(' '));
+			outputChannel.appendLine('');
+
+			args.push(...targets)
+			let proc = cp.spawn(goRuntimePath, args, { env: testEnvVars, cwd: testconfig.dir });
+			proc.stdout.on('data', chunk => {
+				let testOutput = expandFilePathInOutput(chunk.toString(), testconfig.dir);
+				outputChannel.append(testOutput);
+
+			});
+			proc.stderr.on('data', chunk => outputChannel.append(chunk.toString()));
+			proc.on('close', code => {
+				if (code) {
+					outputChannel.append('Error: Tests failed.');
+				} else {
+					outputChannel.append('Success: Tests passed.');
+				}
+				resolve(code === 0);
+			});
+		}, err => {
+			outputChannel.appendLine('Error: Test failed.')
+			outputChannel.appendLine(err)
+			resolve(false)
+		})
 	});
 }
 
@@ -300,4 +306,49 @@ function expandFilePathInOutput(output: string, cwd: string): string {
 		}
 	}
 	return lines.join('\n');
+}
+
+/**
+ * Get the list of packages on current workspace.
+ *
+ * @param testconfig Configuration for the Go extension.
+ */
+function goList(testconfig: TestConfig): Thenable<Array<string>> {
+	return new Promise<Array<string>>((resolve, reject) => {
+		const goRuntimePath = getGoRuntimePath();
+		const testEnvVars = getTestEnvVars(testconfig.goConfig);
+		const proc = cp.spawn(goRuntimePath, ['list', './...'], { env: testEnvVars, cwd: testconfig.dir })
+
+		let out = ''
+		let err = ''
+		proc.stdout.on('data', chunk => out += chunk.toString())
+		proc.stderr.on('data', chunk => out += chunk.toString())
+		proc.on('close', code => {
+			if (code) {
+				reject(err)
+			} else {
+				// Exclude vendor directory
+				resolve(out.split('\n').filter(line => !line.includes('/vendor/')))
+			}
+		})
+	})
+}
+
+/**
+ * Get the test target arguments.
+ *
+ * @param testconfig Configuration for the Go extension.
+ */
+function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
+	if (testconfig.functions) {
+		return new Promise<Array<string>>((resolve, reject) => {
+			const args = []
+			args.push('-run');
+			args.push(util.format('^%s$', testconfig.functions.join('|')));
+			return Promise.resolve(args)
+		})
+	} else if (testconfig.includeSubDirectories) {
+		return goList(testconfig)
+	}
+	return Promise.resolve([])
 }

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -257,7 +257,7 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 				resolve(code === 0);
 			});
 		}, err => {
-			outputChannel.appendLine('Error: Test failed.');
+			outputChannel.appendLine('Error: Tests failed.');
 			outputChannel.appendLine(err);
 			resolve(false);
 		});

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -345,7 +345,7 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 			const args = [];
 			args.push('-run');
 			args.push(util.format('^%s$', testconfig.functions.join('|')));
-			return Promise.resolve(args);
+			return resolve(args);
 		});
 	} else if (testconfig.includeSubDirectories) {
 		return goList(testconfig);

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -322,7 +322,7 @@ function goList(testconfig: TestConfig): Thenable<Array<string>> {
 		let out = '';
 		let err = '';
 		proc.stdout.on('data', chunk => out += chunk.toString());
-		proc.stderr.on('data', chunk => out += chunk.toString());
+		proc.stderr.on('data', chunk => err += chunk.toString());
 		proc.on('close', code => {
 			if (code) {
 				reject(err);

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -231,16 +231,16 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 		}
 
 		targetArgs(testconfig).then(targets => {
-			let outTargets = args.slice(0)
+			let outTargets = args.slice(0);
 			if (targets.length > 2) {
-				outTargets.push('<long arguments omitted>')
+				outTargets.push('<long arguments omitted>');
 			} else {
-				outTargets.push(...targets)
+				outTargets.push(...targets);
 			}
 			outputChannel.appendLine(['Running tool:', goRuntimePath, ...outTargets].join(' '));
 			outputChannel.appendLine('');
 
-			args.push(...targets)
+			args.push(...targets);
 			let proc = cp.spawn(goRuntimePath, args, { env: testEnvVars, cwd: testconfig.dir });
 			proc.stdout.on('data', chunk => {
 				let testOutput = expandFilePathInOutput(chunk.toString(), testconfig.dir);
@@ -257,10 +257,10 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 				resolve(code === 0);
 			});
 		}, err => {
-			outputChannel.appendLine('Error: Test failed.')
-			outputChannel.appendLine(err)
-			resolve(false)
-		})
+			outputChannel.appendLine('Error: Test failed.');
+			outputChannel.appendLine(err);
+			resolve(false);
+		});
 	});
 }
 
@@ -317,21 +317,21 @@ function goList(testconfig: TestConfig): Thenable<Array<string>> {
 	return new Promise<Array<string>>((resolve, reject) => {
 		const goRuntimePath = getGoRuntimePath();
 		const testEnvVars = getTestEnvVars(testconfig.goConfig);
-		const proc = cp.spawn(goRuntimePath, ['list', './...'], { env: testEnvVars, cwd: testconfig.dir })
+		const proc = cp.spawn(goRuntimePath, ['list', './...'], { env: testEnvVars, cwd: testconfig.dir });
 
-		let out = ''
-		let err = ''
-		proc.stdout.on('data', chunk => out += chunk.toString())
-		proc.stderr.on('data', chunk => out += chunk.toString())
+		let out = '';
+		let err = '';
+		proc.stdout.on('data', chunk => out += chunk.toString());
+		proc.stderr.on('data', chunk => out += chunk.toString());
 		proc.on('close', code => {
 			if (code) {
-				reject(err)
+				reject(err);
 			} else {
 				// Exclude vendor directory
-				resolve(out.split('\n').filter(line => !line.includes('/vendor/')))
+				resolve(out.split('\n').filter(line => !line.includes('/vendor/')));
 			}
-		})
-	})
+		});
+	});
 }
 
 /**
@@ -342,13 +342,13 @@ function goList(testconfig: TestConfig): Thenable<Array<string>> {
 function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 	if (testconfig.functions) {
 		return new Promise<Array<string>>((resolve, reject) => {
-			const args = []
+			const args = [];
 			args.push('-run');
 			args.push(util.format('^%s$', testconfig.functions.join('|')));
-			return Promise.resolve(args)
-		})
+			return Promise.resolve(args);
+		});
 	} else if (testconfig.includeSubDirectories) {
-		return goList(testconfig)
+		return goList(testconfig);
 	}
-	return Promise.resolve([])
+	return Promise.resolve([]);
 }


### PR DESCRIPTION
This is to avoid test vendor directory when using vendor tools such as Glide