### PR TITLE
Stream 'go list' cmd for large Browse Packages imports

### DIFF
--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -29,13 +29,13 @@ export function goListAll(): Promise<Map<string, string>> {
 				if (!pkgDetail || !pkgDetail.trim() || pkgDetail.indexOf(';') === -1) return;
 				let [pkgName, pkgPath] = pkgDetail.trim().split(';');
 				allPkgs.set(pkgPath, pkgName);
-			})
+			});
 		});
 
 		cmd.on('close', (status) => {
 			// this command usually exists with 1 because `go list` expists certain folders
-			// to be packages but they can just be regular folders and therefore the cmd will 
-			// send those "failed imports" to stderr and exist with error 1. 
+			// to be packages but they can just be regular folders and therefore the cmd will
+			// send those "failed imports" to stderr and exist with error 1.
 			if (status > 1) {
 				return reject();
 			}


### PR DESCRIPTION
1. In certain cases, `go list all` was throwing "buffer too large" so it needed to be streamed.
2. No need to highlight an import path to get `Browse Packages` to show the files of that import path. 