### PR TITLE
Normalizes the program path that is stored in Delve object.

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -191,7 +191,7 @@ class Delve {
 	noDebug: boolean;
 
 	constructor(remotePath: string, port: number, host: string, program: string, launchArgs: LaunchRequestArguments) {
-		this.program = program;
+		this.program = normalizePath(program);
 		this.remotePath = remotePath;
 		let mode = launchArgs.mode;
 		let dlvCwd = dirname(program);


### PR DESCRIPTION
The Delve **this.program** is compared against a **normalizedPath in the this.toDebuggerPath() function** and it needs to be noralized before this is done otherwise **it will end up returning the wrong path for the remote file**.  This can be seen when running a Windows 10 64bit host trying to perform remote debugging to an Ubuntu server which requires a remote path.  The non-normalized program path has a lower case for the drive letter returned from the launch configuration ("program": "${fileDirname}") and the normalized program path has a capital letter for the drive.  This difference causes the replacement of the local directory path to fail,  so the remotePath sent to the remote debugger is incorrect thus preventing break points from being set correctly.