### PR TITLE
goBrowsePackages: toString bug fix + do not wait for goListAll

### DIFF
--- a/src/goBrowsePackage.ts
+++ b/src/goBrowsePackage.ts
@@ -26,10 +26,63 @@ export function browsePackages() {
 		selectedText = getImportPath(selectedText);
 	}
 
-	if (isGoListComplete()) {
-		return showPackages(selectedText);
+	showPackageFiles(selectedText);
+}
+
+function showPackageFiles(pkg: string)  {
+	const goRuntimePath = getGoRuntimePath();
+	if (!goRuntimePath) {
+		return vscode.window.showErrorMessage('Could not locate Go path. Make sure you have Go installed');
 	}
 
+	cp.execFile(goRuntimePath, ['list', '-f', '{{.Dir}}:{{.GoFiles}}:{{.TestGoFiles}}:{{.XTestGoFiles}}', pkg], (err, stdout, stderr) => {
+		if (!stdout || stdout.indexOf(':') === -1) {
+			if (isGoListComplete()) {
+				return showPackageList();
+			}
+
+			return showTryAgainLater();
+		}
+
+		let matches = stdout && stdout.match(/(.*):\[(.*)\]:\[(.*)\]:\[(.*)\]/);
+		if (matches) {
+			let dir = matches[1];
+			let files = matches[2] ? matches[2].split(' ') : [];
+			let testfiles = matches[3] ? matches[3].split(' ') : [];
+			let xtestfiles = matches[4] ? matches[4].split(' ') : [];
+			files = files.concat(testfiles);
+			files = files.concat(xtestfiles);
+			vscode.window.showQuickPick(files, { placeHolder: `Below are Go files from ${pkg}` }).then(file => {
+				// if user abandoned list, file will be null and path.join will error out.
+				// therefore return.
+				if (!file) return;
+
+				vscode.workspace.openTextDocument(path.join(dir, file)).then(document => {
+					vscode.window.showTextDocument(document);
+				});
+			});
+		}
+	});
+}
+
+function showPackageList() {
+	goListAll().then(pkgMap => {
+		const pkgs: string[] = Array.from(pkgMap.keys());
+		if (!pkgs || pkgs.length === 0) {
+			return vscode.window.showErrorMessage('Could not find packages. Ensure `go list all` runs successfully.');
+		}
+
+		vscode
+			.window
+			.showQuickPick(pkgs, { placeHolder: 'Select a package to browse' })
+			.then(pkgFromDropdown => {
+				if (!pkgFromDropdown) return;
+				showPackageFiles(pkgFromDropdown);
+			});
+	});
+}
+
+function showTryAgainLater() {
 	// `go list all` has not completed. Wait for a second which is an acceptable duration of delay.
 	setTimeout(() => {
 		// `go list all` still not complete. It takes a long time on slower machines or when there are way too many folders in GOPATH
@@ -37,51 +90,7 @@ export function browsePackages() {
 			vscode.window.showInformationMessage('Finding packages... Try after sometime.');
 			return;
 		}
-		showPackages(selectedText);
 	}, 1000);
-
-}
-
-function showPackages(selectedText: string) {
-	const goRuntimePath = getGoRuntimePath();
-	if (!goRuntimePath) {
-		return;
-	}
-	goListAll().then(pkgMap => {
-		const pkgs: string[] = Array.from(pkgMap.keys());
-		if (!pkgs || pkgs.length === 0) {
-			return vscode.window.showErrorMessage('Could not find packages. Ensure `go list all` runs successfully.');
-		}
-		let selectPkgPromise: Thenable<string> = Promise.resolve(selectedText);
-		if (!selectedText || pkgs.indexOf(selectedText) === -1) {
-			selectPkgPromise = vscode.window.showQuickPick(pkgs, { placeHolder: 'Select a package to browse' });
-		}
-		selectPkgPromise.then(pkg => {
-			cp.execFile(goRuntimePath, ['list', '-f', '{{.Dir}}:{{.GoFiles}}:{{.TestGoFiles}}:{{.XTestGoFiles}}', pkg], (err, stdout, stderr) => {
-				if (!stdout || stdout.indexOf(':') === -1) {
-					return;
-				}
-				let matches = stdout.match(/(.*):\[(.*)\]:\[(.*)\]:\[(.*)\]/);
-				if (matches) {
-					let dir = matches[1];
-					let files = matches[2] ? matches[2].split(' ') : [];
-					let testfiles = matches[3] ? matches[3].split(' ') : [];
-					let xtestfiles = matches[4] ? matches[4].split(' ') : [];
-					files = files.concat(testfiles);
-					files = files.concat(xtestfiles);
-					vscode.window.showQuickPick(files, { placeHolder: `Below are Go files from ${pkg}` }).then(file => {
-						// if user abandoned list, file will be null and path.join will error out.
-						// therefore return.
-						if (!file) return;
-
-						vscode.workspace.openTextDocument(path.join(dir, file)).then(document => {
-							vscode.window.showTextDocument(document);
-						});
-					});
-				}
-			});
-		});
-	});
 }
 
 function getImportPath(text: string): string {

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -39,7 +39,7 @@ export function goListAll(): Promise<Map<string, string>> {
 		});
 
 		cmd.on('close', (status) => {
-			chunks.toString().split('\n').forEach(pkgDetail => {
+			chunks.join('').split('\n').forEach(pkgDetail => {
 				if (!pkgDetail || !pkgDetail.trim() || pkgDetail.indexOf(';') === -1) return;
 				let [pkgName, pkgPath] = pkgDetail.trim().split(';');
 				allPkgs.set(pkgPath, pkgName);


### PR DESCRIPTION
This PR fixes two things:

1. An error in `goListAll()` where we call `chunks.toString()`. The method puts `,`'s between every chunk which causes some lines to not be correct imports. I think this is why the auto-import on tab didn't work for all imports (at least for me)

2. Refactored `goBrowsePackages` so that we don't have to wait for `goListAll` to finish. This should speed up browsing packages a lot at initial time, especially for users with slower computers and very large GOPATH tree.

In `goBrowsePackages` we still need a feature that depends on `goListAll()`, which is to show a list of *all* the packages in your GOPATH to select from. So that logic is still there. 

