### PR TITLE
Infer go path when debugging

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -228,7 +228,11 @@ class Delve {
 			}
 
 			let env = Object.assign({}, process.env, fileEnv, launchArgs.env);
-			if (!env['GOPATH'] || !getCurrentGoWorkspaceFromGOPATH(env['GOPATH'], isProgramDirectory ? program : path.dirname(program))) {
+
+			// If file/package to debug is not under env['GOPATH'], then infer it from the file/package path
+			// Not applicable to exec mode in which case `program` need not point to source code under GOPATH
+			let programNotUnderGopath = !env['GOPATH'] || !getCurrentGoWorkspaceFromGOPATH(env['GOPATH'], isProgramDirectory ? program : path.dirname(program));
+			if (programNotUnderGopath && (mode === 'debug' || mode === 'test')) {
 				env['GOPATH'] = getInferredGopath(isProgramDirectory ? program : path.dirname(program));
 			}
 

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -11,7 +11,7 @@ import { readFileSync, existsSync, lstatSync } from 'fs';
 import { basename, dirname, extname } from 'path';
 import { spawn, ChildProcess, execSync, spawnSync } from 'child_process';
 import { Client, RPCConnection } from 'json-rpc2';
-import { parseEnvFile, getBinPathWithPreferredGopath, resolvePath, stripBOM, getGoRuntimePath } from '../goPath';
+import { parseEnvFile, getBinPathWithPreferredGopath, resolvePath, stripBOM, getGoRuntimePath, getInferredGopath, getCurrentGoWorkspaceFromGOPATH } from '../goPath';
 import * as logger from 'vscode-debug-logger';
 import * as FS from 'fs';
 
@@ -228,6 +228,10 @@ class Delve {
 			}
 
 			let env = Object.assign({}, process.env, fileEnv, launchArgs.env);
+			if (!env['GOPATH'] || !getCurrentGoWorkspaceFromGOPATH(env['GOPATH'], isProgramDirectory ? program : path.dirname(program))) {
+				env['GOPATH'] = getInferredGopath(isProgramDirectory ? program : path.dirname(program));
+			}
+
 			if (!!launchArgs.noDebug) {
 				if (mode === 'debug' && !isProgramDirectory) {
 					this.noDebug = true;

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -10,12 +10,12 @@ import cp = require('child_process');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
-import { getGoRuntimePath, resolvePath } from './goPath';
+import { getGoRuntimePath, resolvePath, getCurrentGoWorkspaceFromGOPATH } from './goPath';
 import { getCoverage } from './goCover';
 import { outputChannel } from './goStatus';
 import { promptForMissingTool } from './goInstallTools';
 import { goTest } from './goTest';
-import { getBinPath, parseFilePrelude, getCurrentGoWorkspaceFromGOPATH, getToolsEnvVars } from './util';
+import { getBinPath, parseFilePrelude, getCurrentGoPath, getToolsEnvVars } from './util';
 import { getNonVendorPackages } from './goPackages';
 
 let statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
@@ -185,7 +185,7 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 			runningToolsPromises.push(outerBuildPromise);
 		} else {
 			// Find the right importPath instead of directly using `.`. Fixes https://github.com/Microsoft/vscode-go/issues/846
-			let currentGoWorkspace = getCurrentGoWorkspaceFromGOPATH(cwd);
+			let currentGoWorkspace = getCurrentGoWorkspaceFromGOPATH(getCurrentGoPath(), cwd);
 			let importPath = currentGoWorkspace ? cwd.substr(currentGoWorkspace.length + 1) : '.';
 
 			runningToolsPromises.push(runTool(

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -7,11 +7,12 @@
 
 import vscode = require('vscode');
 import cp = require('child_process');
-import { parseFilePrelude, isVendorSupported, getBinPath, getCurrentGoWorkspaceFromGOPATH, getToolsEnvVars } from './util';
+import { parseFilePrelude, isVendorSupported, getBinPath, getCurrentGoPath, getToolsEnvVars } from './util';
 import { documentSymbols } from './goOutline';
 import { promptForMissingTool } from './goInstallTools';
 import path = require('path');
 import { getRelativePackagePath } from './goPackages';
+import { getCurrentGoWorkspaceFromGOPATH } from './goPath';
 
 const missingToolMsg = 'Missing tool: ';
 
@@ -47,7 +48,7 @@ export function listPackages(excludeImportedPkgs: boolean = false): Thenable<str
 			}
 
 			let currentFileDirPath = path.dirname(vscode.window.activeTextEditor.document.fileName);
-			let currentWorkspace = getCurrentGoWorkspaceFromGOPATH(currentFileDirPath);
+			let currentWorkspace = getCurrentGoWorkspaceFromGOPATH(getCurrentGoPath(), currentFileDirPath);
 			let pkgSet = new Set<string>();
 			pkgs.forEach(pkg => {
 				if (!pkg || importedPkgs.indexOf(pkg) > -1) {

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -1,8 +1,8 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import path = require('path');
-import { getGoRuntimePath } from './goPath';
-import { isVendorSupported, getCurrentGoWorkspaceFromGOPATH, getToolsEnvVars } from './util';
+import { getGoRuntimePath, getCurrentGoWorkspaceFromGOPATH } from './goPath';
+import { isVendorSupported, getCurrentGoPath, getToolsEnvVars } from './util';
 
 let allPkgs = new Map<string, string>();
 let goListAllCompleted: boolean = false;
@@ -62,7 +62,7 @@ export function getImportablePackages(filePath: string): Promise<Map<string, str
 	return Promise.all([isVendorSupported(), goListAll()]).then(values => {
 		let isVendorSupported = values[0];
 		let currentFileDirPath = path.dirname(filePath);
-		let currentWorkspace = getCurrentGoWorkspaceFromGOPATH(currentFileDirPath);
+		let currentWorkspace = getCurrentGoWorkspaceFromGOPATH(getCurrentGoPath(), currentFileDirPath);
 		let pkgMap = new Map<string, string>();
 
 		allPkgs.forEach((pkgName, pkgPath) => {

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -148,3 +148,39 @@ export function parseEnvFile(path: string): { [key: string]: string } {
 		throw (`Cannot load environment variables from file ${path}`);
 	}
 }
+
+// Walks up given folder path to return the closest ancestor that has `src` as a child
+export function getInferredGopath(folderPath: string): string {
+	let dirs = folderPath.toLowerCase().split(path.sep);
+
+	// find src directory closest to given folder path
+	let srcIdx = dirs.lastIndexOf('src');
+	if (srcIdx > 0) {
+		return folderPath.substr(0, dirs.slice(0, srcIdx).join(path.sep).length);
+	}
+}
+
+export function getCurrentGoWorkspaceFromGOPATH(gopath: string, currentFileDirPath: string): string {
+	let workspaces: string[] = gopath.split(path.delimiter);
+	let currentWorkspace = '';
+
+	// Workaround for issue in https://github.com/Microsoft/vscode/issues/9448#issuecomment-244804026
+	if (process.platform === 'win32') {
+		currentFileDirPath = currentFileDirPath.substr(0, 1).toUpperCase() + currentFileDirPath.substr(1);
+	}
+
+	// Find current workspace by checking if current file is
+	// under any of the workspaces in $GOPATH
+	for (let i = 0; i < workspaces.length; i++) {
+		let possibleCurrentWorkspace = path.join(workspaces[i], 'src');
+		if (currentFileDirPath.startsWith(possibleCurrentWorkspace)) {
+			// In case of nested workspaces, (example: both /Users/me and /Users/me/src/a/b/c are in $GOPATH)
+			// both parent & child workspace in the nested workspaces pair can make it inside the above if block
+			// Therefore, the below check will take longer (more specific to current file) of the two
+			if (possibleCurrentWorkspace.length > currentWorkspace.length) {
+				currentWorkspace = possibleCurrentWorkspace;
+			}
+		}
+	}
+	return currentWorkspace;
+}

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -160,6 +160,11 @@ export function getInferredGopath(folderPath: string): string {
 	}
 }
 
+/**
+ * Returns the workspace in the given Gopath to which given directory path belongs to
+ * @param gopath string Current Gopath. Can be ; or : separated (as per os) to support multiple paths
+ * @param currentFileDirPath string
+ */
 export function getCurrentGoWorkspaceFromGOPATH(gopath: string, currentFileDirPath: string): string {
 	let workspaces: string[] = gopath.split(path.delimiter);
 	let currentWorkspace = '';


### PR DESCRIPTION
Fix for #840

The only scenario where we may still have issues is when somebody uses `go.gopath` to set multiple gopaths and the file/package being debugged imports pkgs from the different gopaths set in `go.gopath`. In this case, the user will have to provide GOPATH via the launch.json or set the same using the env var `GOPATH` outside of VS Code