### PR TITLE
pass <package> to dlv test/debug if applicable

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -234,15 +234,11 @@ class Delve {
 			if (!fileEnv['GOPATH'] && !launchArgsEnv['GOPATH'] && (mode === 'debug' || mode === 'test')) {
 				// If user hasnt specified GOPATH & file/package to debug is not under env['GOPATH'], then infer it from the file/package path
 				// Not applicable to exec mode in which case `program` need not point to source code under GOPATH
-				let currentGOWorkspace = getCurrentGoWorkspaceFromGOPATH(env['GOPATH'], dirname);
-				let programNotUnderGopath = !env['GOPATH'] || !currentGOWorkspace;
+				let programNotUnderGopath = !env['GOPATH'] || !getCurrentGoWorkspaceFromGOPATH(env['GOPATH'], dirname);
 				if (programNotUnderGopath ) {
 					env['GOPATH'] = getInferredGopath(dirname) || env['GOPATH'];
 				}
 			}
-
-			let currentGOWorkspace = getCurrentGoWorkspaceFromGOPATH(env['GOPATH'], dirname);
-			let importPath = currentGOWorkspace ? dirname.substr(currentGOWorkspace.length + 1) : '.';
 
 			verbose(`Using GOPATH: ${env['GOPATH']}`);
 
@@ -287,11 +283,12 @@ class Delve {
 			}
 			verbose('Using dlv at: ' + dlv);
 
+			let currentGOWorkspace = getCurrentGoWorkspaceFromGOPATH(env['GOPATH'], dirname);
 			let dlvArgs = [mode || 'debug'];
 			if (mode === 'exec') {
 				dlvArgs = dlvArgs.concat([program]);
-			} else if (importPath !== '.') {
-				dlvArgs = dlvArgs.concat([importPath]);
+			} else if (currentGOWorkspace) {
+				dlvArgs = dlvArgs.concat([dirname.substr(currentGOWorkspace.length + 1)]);
 			}
 			dlvArgs = dlvArgs.concat(['--headless=true', '--listen=' + host + ':' + port.toString()]);
 			if (launchArgs.showLog) {

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -129,9 +129,8 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 
 		// append the package name to args if applicable
 		let currentGoWorkspace = getCurrentGoWorkspaceFromGOPATH(getCurrentGoPath(), testconfig.dir);
-		let importPath = currentGoWorkspace ? testconfig.dir.substr(currentGoWorkspace.length + 1) : '.';
-		if (importPath !== '.') {
-			args.push(importPath);
+		if (currentGoWorkspace && !testconfig.includeSubDirectories) {
+			args.push(testconfig.dir.substr(currentGoWorkspace.length + 1));
 		}
 
 		targetArgs(testconfig).then(targets => {

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -7,8 +7,8 @@ import cp = require('child_process');
 import path = require('path');
 import vscode = require('vscode');
 import util = require('util');
-import { parseEnvFile, getGoRuntimePath } from './goPath';
-import { getToolsEnvVars, getGoVersion, LineBuffer, SemVersion, resolvePath } from './util';
+import { parseEnvFile, getGoRuntimePath, getCurrentGoWorkspaceFromGOPATH } from './goPath';
+import { getToolsEnvVars, getGoVersion, LineBuffer, SemVersion, resolvePath, getCurrentGoPath } from './util';
 import { GoDocumentSymbolProvider } from './goOutline';
 import { getNonVendorPackages } from './goPackages';
 
@@ -125,6 +125,13 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 		if (!goRuntimePath) {
 			vscode.window.showInformationMessage('Cannot find "go" binary. Update PATH or GOROOT appropriately');
 			return Promise.resolve();
+		}
+
+		// append the package name to args if applicable
+		let currentGoWorkspace = getCurrentGoWorkspaceFromGOPATH(getCurrentGoPath(), testconfig.dir);
+		let importPath = currentGoWorkspace ? testconfig.dir.substr(currentGoWorkspace.length + 1) : '.';
+		if (importPath !== '.') {
+			args.push(importPath);
 		}
 
 		targetArgs(testconfig).then(targets => {


### PR DESCRIPTION
we should prefer passing package name to `dlv test` or `dlv debug`. this fixes the issue mentioned at https://github.com/Microsoft/vscode-go/issues/846#issuecomment-323589274.