### PR TITLE
Snippets for t.Log() and t.Logf()

### DIFF
--- a/snippets/go.json
+++ b/snippets/go.json
@@ -100,6 +100,14 @@
 			"prefix": "lv",
 			"body": "log.Printf(\"${1:var}: %#+v\\\\n\", ${1:var})"
 		},
+		"t.Log": {
+			"prefix": "tp",
+			"body": "t.Log(\"$1\")"
+		},
+		"t.Logf variable content": {
+			"prefix": "tv",
+			"body": "t.Logf(\"${1:var}: %#+v\\\\n\", ${1:var})"
+		},
 		"make(...)": {
 			"prefix": "make",
 			"body": "make(${1:type}, ${2:0})"

--- a/snippets/go.json
+++ b/snippets/go.json
@@ -101,11 +101,15 @@
 			"body": "log.Printf(\"${1:var}: %#+v\\\\n\", ${1:var})"
 		},
 		"t.Log": {
-			"prefix": "tp",
+			"prefix": "tl",
 			"body": "t.Log(\"$1\")"
 		},
+		"t.Logf": {
+			"prefix": "tlf",
+			"body": "t.Logf(\"$1\", ${2:var})"
+		},
 		"t.Logf variable content": {
-			"prefix": "tv",
+			"prefix": "tlv",
 			"body": "t.Logf(\"${1:var}: %#+v\\\\n\", ${1:var})"
 		},
 		"make(...)": {


### PR DESCRIPTION
`t.Log(...) and t.Logf(...)` are also commonly used. I propose adding:

```json
{
	"t.Log": {
		"prefix": "tp",
		"body": "t.Log(\"$1\")"
	},
	"t.Logf variable content": {
		"prefix": "tv",
		"body": "t.Logf(\"${1:var}: %#+v\\\\n\", ${1:var})"
	}
}
```