### PR TITLE
Taking advantages of Go version 1.9 (vendor related)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.6.x
   - 1.7.x
   - 1.8.x
+  - 1.9.x
   - tip
 
 sudo: false

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -16,7 +16,7 @@ import { outputChannel } from './goStatus';
 import { promptForMissingTool } from './goInstallTools';
 import { goTest } from './testUtils';
 import { getBinPath, parseFilePrelude, getCurrentGoPath, getToolsEnvVars } from './util';
-import { getNonVendorPackages } from './goPackages';
+import { getPackages } from './goPackages';
 
 let statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 statusBarItem.command = 'go.test.showOutput';
@@ -166,7 +166,7 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 
 		if (goConfig['buildOnSave'] === 'workspace') {
 			let buildPromises = [];
-			let outerBuildPromise = getNonVendorPackages(vscode.workspace.rootPath).then(pkgs => {
+			let outerBuildPromise = getPackages(vscode.workspace.rootPath).then(pkgs => {
 				buildPromises = pkgs.map(pkgPath => {
 					return runTool(
 						buildArgs.concat(pkgPath),

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -8,7 +8,7 @@ import path = require('path');
 import vscode = require('vscode');
 import util = require('util');
 import { parseEnvFile, getGoRuntimePath, resolvePath } from './goPath';
-import { getToolsEnvVars, LineBuffer } from './util';
+import { getToolsEnvVars, getGoVersion, LineBuffer, SemVersion } from './util';
 import { GoDocumentSymbolProvider } from './goOutline';
 import { getPackages } from './goPackages';
 
@@ -194,7 +194,12 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 	if (testconfig.functions) {
 		return Promise.resolve(['-run', util.format('^%s$', testconfig.functions.join('|'))]);
 	} else if (testconfig.includeSubDirectories) {
-		return getPackages(vscode.workspace.rootPath);
+		return getGoVersion().then((ver: SemVersion) => {
+			if (ver && (ver.major > 1 || (ver.major === 1 && ver.minor >= 9))) {
+				return ['./...'];
+			}
+			return getPackages(vscode.workspace.rootPath);
+		});
 	}
 	return Promise.resolve([]);
 }

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -192,12 +192,7 @@ function expandFilePathInOutput(output: string, cwd: string): string {
  */
 function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 	if (testconfig.functions) {
-		return new Promise<Array<string>>((resolve, reject) => {
-			const args = [];
-			args.push('-run');
-			args.push(util.format('^%s$', testconfig.functions.join('|')));
-			return resolve(args);
-		});
+		return Promise.resolve(['-run', util.format('^%s$', testconfig.functions.join('|'))]);
 	} else if (testconfig.includeSubDirectories) {
 		return getPackages(vscode.workspace.rootPath);
 	}

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -10,7 +10,7 @@ import util = require('util');
 import { parseEnvFile, getGoRuntimePath, resolvePath } from './goPath';
 import { getToolsEnvVars, LineBuffer } from './util';
 import { GoDocumentSymbolProvider } from './goOutline';
-import { getNonVendorPackages } from './goPackages';
+import { getPackages } from './goPackages';
 
 let outputChannel = vscode.window.createOutputChannel('Go Tests');
 
@@ -199,7 +199,7 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 			return resolve(args);
 		});
 	} else if (testconfig.includeSubDirectories) {
-		return getNonVendorPackages(vscode.workspace.rootPath);
+		return getPackages(vscode.workspace.rootPath);
 	}
 	return Promise.resolve([]);
 }


### PR DESCRIPTION
Applied only for Go version 1.9:
- Test all workspace using "go test ./.."
- Get packages will also using "go list ./..."
