### PR TITLE
Show completion for newly created package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_install:
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
       sh -e /etc/init.d/xvfb start;
       apt-get update && apt-get install -y libsecret-1-0
-      // sleep 3; // the apt-get should buy enough time
+      # disable sleep, the apt-get should buy enough time
+      # sleep 3;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   - go get -u -v github.com/ramya-rao-a/go-outline
   - go get -u -v sourcegraph.com/sqs/goreturns
   - go get -u -v golang.org/x/tools/cmd/gorename
-  - go get -u -v github.com/tpng/gopkgs
+  - go get -u -v github.com/haya14busa/gopkgs/cmd/gopkgs
   - go get -u -v github.com/acroca/go-symbols
   - go get -u -v github.com/alecthomas/gometalinter
   - go get -u -v github.com/cweill/gotests/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
       sh -e /etc/init.d/xvfb start;
-      apt-get update && apt-get install -y libsecret-1-0
-      # disable sleep, the apt-get should buy enough time
-      # sleep 3;
+      sudo apt-get update && apt-get install -y libsecret-1-0;
+      sleep 3;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   - go get -u -v github.com/ramya-rao-a/go-outline
   - go get -u -v sourcegraph.com/sqs/goreturns
   - go get -u -v golang.org/x/tools/cmd/gorename
-  - go get -u -v github.com/haya14busa/gopkgs/cmd/gopkgs
+  - go get -u -v github.com/uudashr/gopkgs/cmd/gopkgs
   - go get -u -v github.com/acroca/go-symbols
   - go get -u -v github.com/alecthomas/gometalinter
   - go get -u -v github.com/cweill/gotests/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
       sh -e /etc/init.d/xvfb start;
       sudo apt-get update && sudo apt-get install -y libsecret-1-0;
-      sleep 3;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.6.x
   - 1.7.x
   - 1.8.x
+  - 1.9.x
   - tip
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
       sh -e /etc/init.d/xvfb start;
-      sudo apt-get update && apt-get install -y libsecret-1-0;
+      sudo apt-get update && sudo apt-get install -y libsecret-1-0;
       sleep 3;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
       sh -e /etc/init.d/xvfb start;
-      sleep 3;
+      apt-get update && apt-get install -y libsecret-1-0
+      // sleep 3; // the apt-get should buy enough time
     fi
 
 install:

--- a/src/goBrowsePackage.ts
+++ b/src/goBrowsePackage.ts
@@ -10,6 +10,9 @@ import cp = require('child_process');
 import { getGoRuntimePath } from './goPath';
 import path = require('path');
 import { getAllPackages } from './goPackages';
+import { promptForMissingTool } from './goInstallTools';
+
+const missingToolMsg = 'Missing tool: ';
 
 export function browsePackages() {
 	let selectedText = '';
@@ -83,6 +86,10 @@ function showPackageList() {
 				if (!pkgFromDropdown) return;
 				showPackageFiles(pkgFromDropdown, false);
 			});
+	},  err => {
+		if (typeof err === 'string' && err.startsWith(missingToolMsg)) {
+			promptForMissingTool(err.substr(missingToolMsg.length));
+		}
 	});
 }
 

--- a/src/goBrowsePackage.ts
+++ b/src/goBrowsePackage.ts
@@ -86,10 +86,6 @@ function showPackageList() {
 				if (!pkgFromDropdown) return;
 				showPackageFiles(pkgFromDropdown, false);
 			});
-	},  err => {
-		if (typeof err === 'string' && err.startsWith(missingToolMsg)) {
-			promptForMissingTool(err.substr(missingToolMsg.length));
-		}
 	});
 }
 

--- a/src/goBrowsePackage.ts
+++ b/src/goBrowsePackage.ts
@@ -9,7 +9,7 @@ import vscode = require('vscode');
 import cp = require('child_process');
 import { getGoRuntimePath } from './goPath';
 import path = require('path');
-import { goListAll, isGoListComplete } from './goPackages';
+import { goListAll } from './goPackages';
 
 export function browsePackages() {
 	let selectedText = '';
@@ -70,28 +70,20 @@ function showPackageFiles(pkg: string, showAllPkgsIfPkgNotFound: boolean)  {
 }
 
 function showPackageList() {
-	if (!isGoListComplete()) {
-		return showTryAgainLater();
-	}
-
 	goListAll().then(pkgMap => {
 		const pkgs: string[] = Array.from(pkgMap.keys());
-		if (!pkgs || pkgs.length === 0) {
+		if (pkgs.length === 0) {
 			return vscode.window.showErrorMessage('Could not find packages. Ensure `go list all` runs successfully.');
 		}
 
 		vscode
 			.window
-			.showQuickPick(pkgs, { placeHolder: 'Select a package to browse' })
+			.showQuickPick(pkgs.sort(), { placeHolder: 'Select a package to browse' })
 			.then(pkgFromDropdown => {
 				if (!pkgFromDropdown) return;
 				showPackageFiles(pkgFromDropdown, false);
 			});
 	});
-}
-
-function showTryAgainLater() {
-	vscode.window.showInformationMessage('Finding packages... Try after sometime.');
 }
 
 function getImportPath(text: string): string {

--- a/src/goBrowsePackage.ts
+++ b/src/goBrowsePackage.ts
@@ -10,9 +10,6 @@ import cp = require('child_process');
 import { getGoRuntimePath } from './goPath';
 import path = require('path');
 import { getAllPackages } from './goPackages';
-import { promptForMissingTool } from './goInstallTools';
-
-const missingToolMsg = 'Missing tool: ';
 
 export function browsePackages() {
 	let selectedText = '';

--- a/src/goBrowsePackage.ts
+++ b/src/goBrowsePackage.ts
@@ -9,7 +9,7 @@ import vscode = require('vscode');
 import cp = require('child_process');
 import { getGoRuntimePath } from './goPath';
 import path = require('path');
-import { goListAll } from './goPackages';
+import { getAllPackages } from './goPackages';
 
 export function browsePackages() {
 	let selectedText = '';
@@ -70,7 +70,7 @@ function showPackageFiles(pkg: string, showAllPkgsIfPkgNotFound: boolean)  {
 }
 
 function showPackageList() {
-	goListAll().then(pkgMap => {
+	getAllPackages().then(pkgMap => {
 		const pkgs: string[] = Array.from(pkgMap.keys());
 		if (pkgs.length === 0) {
 			return vscode.window.showErrorMessage('Could not find packages. Ensure `go list all` runs successfully.');

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -16,7 +16,7 @@ import { outputChannel } from './goStatus';
 import { promptForMissingTool } from './goInstallTools';
 import { goTest } from './testUtils';
 import { getBinPath, parseFilePrelude, getCurrentGoPath, getToolsEnvVars } from './util';
-import { getPackages } from './goPackages';
+import { getNonVendorPackages } from './goPackages';
 
 let statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 statusBarItem.command = 'go.test.showOutput';
@@ -166,7 +166,7 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 
 		if (goConfig['buildOnSave'] === 'workspace') {
 			let buildPromises = [];
-			let outerBuildPromise = getPackages(vscode.workspace.rootPath).then(pkgs => {
+			let outerBuildPromise = getNonVendorPackages(vscode.workspace.rootPath).then(pkgs => {
 				buildPromises = pkgs.map(pkgPath => {
 					return runTool(
 						buildArgs.concat(pkgPath),

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -16,7 +16,7 @@ import { outputChannel } from './goStatus';
 import { promptForMissingTool } from './goInstallTools';
 import { goTest } from './testUtils';
 import { getBinPath, parseFilePrelude, getCurrentGoPath, getToolsEnvVars } from './util';
-import { getNonVendorPackages } from './goPackages';
+import { getPackages } from './goPackages';
 
 let statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 statusBarItem.command = 'go.test.showOutput';
@@ -166,7 +166,7 @@ export function check(filename: string, goConfig: vscode.WorkspaceConfiguration)
 
 		if (goConfig['buildOnSave'] === 'workspace') {
 			let buildPromises = [];
-			let outerBuildPromise = getNonVendorPackages(vscode.workspace.rootPath).then(pkgs => {
+			let outerBuildPromise = getPackages(vscode.workspace.rootPath).then(pkgs => {
 				buildPromises = pkgs.map(pkgPath => {
 					return runTool(
 						buildArgs.concat(pkgPath),

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -26,8 +26,8 @@ export function listPackages(excludeImportedPkgs: boolean = false): Thenable<str
 
 	return Promise.all([pkgsPromise, importsPromise]).then(([pkgMap, importedPkgs]) => {
 		let pkgs = Array.from(pkgMap.keys());
-		pkgs = pkgs.filter(pkg => importedPkgs.indexOf(pkg) === -1)
-		return Array.from(new Set(pkgs)).sort()
+		pkgs = pkgs.filter(pkg => importedPkgs.indexOf(pkg) === -1);
+		return Array.from(new Set(pkgs)).sort();
 	});
 }
 

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -20,7 +20,7 @@ export function listPackages(excludeImportedPkgs: boolean = false): Thenable<str
 	let importsPromise = excludeImportedPkgs && vscode.window.activeTextEditor ? getImports(vscode.window.activeTextEditor.document) : Promise.resolve([]);
 	let vendorSupportPromise = isVendorSupported();
 	let goPkgsPromise = new Promise<string[]>((resolve, reject) => {
-		let cmd = cp.spawn(getBinPath('gopkgs'), ['-short=false'], { env: getToolsEnvVars() });
+		let cmd = cp.spawn(getBinPath('gopkgs'), ['-f', '{{.ImportPath}}'], { env: getToolsEnvVars() });
 		let chunks = [];
 		let err;
 		cmd.stdout.on('data', (d) => chunks.push(d));

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -11,8 +11,6 @@ import { parseFilePrelude, isVendorSupported, getBinPath, getCurrentGoPath, getT
 import { documentSymbols } from './goOutline';
 import { promptForMissingTool } from './goInstallTools';
 import path = require('path');
-import { getRelativePackagePath } from './goPackages';
-import { getCurrentGoWorkspaceFromGOPATH } from './goPath';
 import { getImportablePackages } from './goPackages';
 
 const missingToolMsg = 'Missing tool: ';

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -20,7 +20,7 @@ export function listPackages(excludeImportedPkgs: boolean = false): Thenable<str
 	let importsPromise = excludeImportedPkgs && vscode.window.activeTextEditor ? getImports(vscode.window.activeTextEditor.document) : Promise.resolve([]);
 	let vendorSupportPromise = isVendorSupported();
 	let goPkgsPromise = new Promise<string[]>((resolve, reject) => {
-		cp.execFile(getBinPath('gopkgs'), [], {env: getToolsEnvVars()}, (err, stdout, stderr) => {
+		cp.execFile(getBinPath('gopkgs'), ['-short=false'], {env: getToolsEnvVars()}, (err, stdout, stderr) => {
 			if (err && (<any>err).code === 'ENOENT') {
 				return reject(missingToolMsg + 'gopkgs');
 			}

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -19,15 +19,13 @@ const missingToolMsg = 'Missing tool: ';
 
 export function listPackages(excludeImportedPkgs: boolean = false): Thenable<string[]> {
 	let importsPromise = excludeImportedPkgs && vscode.window.activeTextEditor ? getImports(vscode.window.activeTextEditor.document) : Promise.resolve([]);
-
-	let currentFileDirPath = path.dirname(vscode.window.activeTextEditor.document.fileName);
-	let currentWorkspace = getCurrentGoWorkspaceFromGOPATH(getCurrentGoPath(), currentFileDirPath);
 	let pkgsPromise = getImportablePackages(vscode.window.activeTextEditor.document.fileName);
 
 	return Promise.all([pkgsPromise, importsPromise]).then(([pkgMap, importedPkgs]) => {
-		let pkgs = Array.from(pkgMap.keys());
-		pkgs = pkgs.filter(pkg => importedPkgs.indexOf(pkg) === -1);
-		return Array.from(new Set(pkgs)).sort();
+		importedPkgs.forEach(pkg => {
+			pkgMap.delete(pkg);
+		});
+		return Array.from(pkgMap.keys()).sort();
 	});
 }
 

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -16,9 +16,7 @@ import { getCurrentGoWorkspaceFromGOPATH } from './goPath';
 
 const missingToolMsg = 'Missing tool: ';
 
-let allPkgsCache: string[];
-
-function goPkgsNoCache(): Promise<string[]> {
+function goPkgs(): Promise<string[]> {
 	return new Promise<string[]>((resolve, reject) => {
 		let cmd = cp.spawn(getBinPath('gopkgs'), ['-f', '{{.ImportPath}}'], { env: getToolsEnvVars() });
 		let chunks = [];
@@ -33,19 +31,6 @@ function goPkgsNoCache(): Promise<string[]> {
 			let lines = chunks.join('').split('\n').filter((pkg) => pkg);
 			return resolve(lines);
 		});
-	});
-}
-
-function goPkgs(): Promise<string[]> {
-	if (allPkgsCache) {
-		goPkgsNoCache().then((pkgs: string[]) => {
-			allPkgsCache = pkgs;
-		});
-		return Promise.resolve(allPkgsCache);
-	}
-
-	return goPkgsNoCache().then((pkgs: string[]) => {
-		return allPkgsCache = pkgs;
 	});
 }
 

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -18,7 +18,7 @@ const missingToolMsg = 'Missing tool: ';
 
 function goPkgs(): Promise<string[]> {
 	return new Promise<string[]>((resolve, reject) => {
-		let cmd = cp.spawn(getBinPath('gopkgs'), ['-f', '{{.ImportPath}}'], { env: getToolsEnvVars() });
+		let cmd = cp.spawn(getBinPath('gopkgs'), ['-format', '{{.ImportPath}}'], { env: getToolsEnvVars() });
 		let chunks = [];
 		let err;
 		cmd.stdout.on('data', (d) => chunks.push(d));

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -38,6 +38,9 @@ function goPkgsNoCache(): Promise<string[]> {
 
 function goPkgs(): Promise<string[]> {
 	if (allPkgsCache) {
+		goPkgsNoCache().then((pkgs: string[]) => {
+			allPkgsCache = pkgs;
+		});
 		return Promise.resolve(allPkgsCache);
 	}
 

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -40,9 +40,7 @@ export function listPackages(excludeImportedPkgs: boolean = false): Thenable<str
 	let goPkgsPromise = goPkgs();
 
 	return vendorSupportPromise.then((vendorSupport: boolean) => {
-		return Promise.all<string[]>([goPkgsPromise, importsPromise]).then(values => {
-			let pkgs = values[0];
-			let importedPkgs = values[1];
+		return Promise.all<string[]>([goPkgsPromise, importsPromise]).then(([pkgs, importedPkgs]) => {
 
 			if (!vendorSupport) {
 				if (importedPkgs.length > 0) {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -291,7 +291,7 @@ function gopkgsMissing(): Promise<boolean> {
 
 		cmd.stderr.on('data', (d) => {
 			// expect the correct gopkgs, scan the output of the usage
-			const lines = d.toString().split('\n').filter((line) => (line.indexOf('Usage of gopkgs') > -1) || (line.indexOf('output format of the package') > -1) || (line.indexOf('Use -f to custom') > -1));
+			const lines = d.toString().split('\n').filter((line) => (line.indexOf('Usage of') > -1) || (line.indexOf('output format of the package') > -1) || (line.indexOf('Use -f to custom the output using template syntax') > -1));
 			resolve(lines.length !== 3);
 		});
 

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -291,7 +291,7 @@ function gopkgsMissing(): Promise<boolean> {
 
 		cmd.stderr.on('data', (d) => {
 			// expect the correct gopkgs, scan the output of the usage
-			const lines = d.toString().split('\n').filter((line) => (line.indexOf('Usage of') > -1) || (line.indexOf('output format of the package') > -1) || (line.indexOf('Use -f to custom the output using template syntax') > -1));
+			const lines = d.toString().split('\n').filter((line) => (line.indexOf('Usage of') > -1) || (line.indexOf('custom output format') > -1) || (line.indexOf('Use -format to custom the output using template syntax') > -1));
 			resolve(lines.length !== 3);
 		});
 

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -23,7 +23,7 @@ function getTools(goVersion: SemVersion): { [key: string]: string } {
 	let goConfig = vscode.workspace.getConfiguration('go');
 	let tools: { [key: string]: string } = {
 		'gocode': 'github.com/nsf/gocode',
-		'gopkgs': 'github.com/haya14busa/gopkgs/cmd/gopkgs',
+		'gopkgs': 'github.com/uudashr/gopkgs/cmd/gopkgs',
 		'go-outline': 'github.com/ramya-rao-a/go-outline',
 		'go-symbols': 'github.com/acroca/go-symbols',
 		'guru': 'golang.org/x/tools/cmd/guru',
@@ -290,8 +290,8 @@ function gopkgsMissing(): Promise<boolean> {
 		});
 
 		cmd.stderr.on('data', (d) => {
-			// expect the correct gopkgs
-			const lines = d.toString().split('\n').filter((line) => (line.indexOf('Usage of') > -1) || (line.indexOf('-fullpath') > -1) || (line.indexOf('-short') > -1));
+			// expect the correct gopkgs, scan the output of the usage
+			const lines = d.toString().split('\n').filter((line) => (line.indexOf('Usage of gopkgs') > -1) || (line.indexOf('output format of the package') > -1) || (line.indexOf('Use -f to custom') > -1));
 			resolve(lines.length !== 3);
 		});
 

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -282,38 +282,9 @@ export function offerToInstallTools() {
 	}
 }
 
-function gopkgsMissing(): Promise<boolean> {
-	return new Promise<boolean>((resolve, reject) => {
-		const cmd = cp.spawn(getBinPath('gopkgs'), ['-help']);
-		cmd.stdout.on('data', (d) => {
-			resolve(true);
-		});
-
-		cmd.stderr.on('data', (d) => {
-			// expect the correct gopkgs, scan the output of the usage
-			const lines = d.toString().split('\n').filter((line) => (line.indexOf('Usage of') > -1) || (line.indexOf('custom output format') > -1) || (line.indexOf('Use -format to custom the output using template syntax') > -1));
-			resolve(lines.length !== 3);
-		});
-
-		cmd.on('error', (err) => {
-			if ((<any>err).code === 'ENOENT') {
-				return resolve(true);
-			}
-			reject(err);
-		});
-	});
-}
-
 function getMissingTools(goVersion: SemVersion): Promise<string[]> {
 	let keys = Object.keys(getTools(goVersion));
 	return Promise.all<string>(keys.map(tool => new Promise<string>((resolve, reject) => {
-		if (tool === 'gopkgs') {
-			gopkgsMissing().then((missing) => {
-				resolve(missing ? tool : null);
-			});
-			return;
-		}
-
 		let toolPath = getBinPath(tool);
 		fs.exists(toolPath, exists => {
 			resolve(exists ? null : tool);

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -23,7 +23,7 @@ function getTools(goVersion: SemVersion): { [key: string]: string } {
 	let goConfig = vscode.workspace.getConfiguration('go');
 	let tools: { [key: string]: string } = {
 		'gocode': 'github.com/nsf/gocode',
-		'gopkgs': 'github.com/tpng/gopkgs',
+		'gopkgs': 'github.com/haya14busa/gopkgs/cmd/gopkgs',
 		'go-outline': 'github.com/ramya-rao-a/go-outline',
 		'go-symbols': 'github.com/acroca/go-symbols',
 		'guru': 'golang.org/x/tools/cmd/guru',

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -66,7 +66,6 @@ export function activate(ctx: vscode.ExtensionContext): void {
 				}
 			}
 		});
-		goListAll();
 		offerToInstallTools();
 		let langServerAvailable = checkLanguageServer();
 		if (langServerAvailable) {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -36,7 +36,7 @@ import { addTags, removeTags } from './goModifytags';
 import { parseLiveFile } from './goLiveErrors';
 import { GoCodeLensProvider } from './goCodelens';
 import { implCursor } from './goImpl';
-import { goListAll } from './goPackages';
+import { getAllPackages } from './goPackages';
 import { browsePackages } from './goBrowsePackage';
 
 export let errorDiagnosticCollection: vscode.DiagnosticCollection;

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -36,7 +36,6 @@ import { addTags, removeTags } from './goModifytags';
 import { parseLiveFile } from './goLiveErrors';
 import { GoCodeLensProvider } from './goCodelens';
 import { implCursor } from './goImpl';
-import { getAllPackages } from './goPackages';
 import { browsePackages } from './goBrowsePackage';
 
 export let errorDiagnosticCollection: vscode.DiagnosticCollection;

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -4,12 +4,9 @@ import path = require('path');
 import { getGoRuntimePath, getCurrentGoWorkspaceFromGOPATH } from './goPath';
 import { isVendorSupported, getCurrentGoPath, getToolsEnvVars, getGoVersion, getBinPath, SemVersion } from './util';
 
+let allPkgMapCache: Map<string, string>;
 
-/**
- * Runs go list all
- * @returns Map<string, string> mapping between package import path and package name
- */
-export function goListAll(): Promise<Map<string, string>> {
+function goListAllNoCache(): Promise<Map<string, string>> {
 	return new Promise<Map<string, string>>((resolve, reject) => {
 		const cmd = cp.spawn(getBinPath('gopkgs'), ['-f', '{{.Name}};{{.ImportPath}}'], { env: getToolsEnvVars() });
 		const chunks = [];
@@ -26,6 +23,20 @@ export function goListAll(): Promise<Map<string, string>> {
 			});
 			return resolve(pkgs);
 		});
+	});
+}
+
+/**
+ * Runs go list all
+ * @returns Map<string, string> mapping between package import path and package name
+ */
+export function goListAll(): Promise<Map<string, string>> {
+	if (allPkgMapCache) {
+		return Promise.resolve(allPkgMapCache);
+	}
+
+	return goListAllNoCache().then((pkgs: Map<string, string>) => {
+		return allPkgMapCache = pkgs;
 	});
 }
 

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -6,7 +6,7 @@ import { isVendorSupported, getCurrentGoPath, getToolsEnvVars, getGoVersion, get
 import { promptForMissingTool } from './goInstallTools';
 
 /**
- * Runs go list all
+ * Runs gopkgs
  * @returns Map<string, string> mapping between package import path and package name
  */
 export function goListAll(): Promise<Map<string, string>> {

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -32,6 +32,9 @@ function goListAllNoCache(): Promise<Map<string, string>> {
  */
 export function goListAll(): Promise<Map<string, string>> {
 	if (allPkgMapCache) {
+		goListAllNoCache().then((pkgs: Map<string, string>) => {
+			allPkgMapCache = pkgs;
+		});
 		return Promise.resolve(allPkgMapCache);
 	}
 

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -9,7 +9,7 @@ import { promptForMissingTool } from './goInstallTools';
  * Runs gopkgs
  * @returns Map<string, string> mapping between package import path and package name
  */
-export function goListAll(): Promise<Map<string, string>> {
+export function getAllPackages(): Promise<Map<string, string>> {
 	return new Promise<Map<string, string>>((resolve, reject) => {
 		const cmd = cp.spawn(getBinPath('gopkgs'), ['-format', '{{.Name}};{{.ImportPath}}'], { env: getToolsEnvVars() });
 		const chunks = [];
@@ -40,7 +40,7 @@ export function goListAll(): Promise<Map<string, string>> {
  */
 export function getImportablePackages(filePath: string): Promise<Map<string, string>> {
 
-	return Promise.all([isVendorSupported(), goListAll()]).then(values => {
+	return Promise.all([isVendorSupported(), getAllPackages()]).then(values => {
 		let isVendorSupported = values[0];
 		let pkgs = values[1];
 		let currentFileDirPath = path.dirname(filePath);

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -97,7 +97,7 @@ export function getRelativePackagePath(currentFileDirPath: string, currentWorksp
 /**
  * Returns import paths for all packages under given folder (vendor will be excluded)
  */
-export function getPackages(folderPath: string): Promise<string[]> {
+export function getNonVendorPackages(folderPath: string): Promise<string[]> {
 	let goRuntimePath = getGoRuntimePath();
 
 	if (!goRuntimePath) {

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -5,8 +5,6 @@ import { getGoRuntimePath, getCurrentGoWorkspaceFromGOPATH } from './goPath';
 import { isVendorSupported, getCurrentGoPath, getToolsEnvVars, getGoVersion, getBinPath, SemVersion } from './util';
 import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
 
-const missingToolMsg = 'Missing tool: ';
-
 let allPkgsCache: Map<string, string>;
 let allPkgsLastHit: number;
 

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -94,7 +94,7 @@ export function getImportablePackages(filePath: string): Promise<Map<string, str
  * If given pkgPath is not vendor pkg, then the same pkgPath is returned
  * Else, the import path for the vendor pkg relative to given filePath is returned.
  */
-export function getRelativePackagePath(currentFileDirPath: string, currentWorkspace: string, pkgPath: string): string {
+function getRelativePackagePath(currentFileDirPath: string, currentWorkspace: string, pkgPath: string): string {
 	let magicVendorString = '/vendor/';
 	let vendorIndex = pkgPath.indexOf(magicVendorString);
 	if (vendorIndex === -1) {

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -7,7 +7,7 @@ import { promptForMissingTool } from './goInstallTools';
 
 const missingToolMsg = 'Missing tool: ';
 
-let allPkgsCache: Map<string, string>
+let allPkgsCache: Map<string, string>;
 let allPkgsLastHit: number;
 
 function getAllPackagesNoCache(): Promise<Map<string, string>> {

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -5,6 +5,8 @@ import { getGoRuntimePath, getCurrentGoWorkspaceFromGOPATH } from './goPath';
 import { isVendorSupported, getCurrentGoPath, getToolsEnvVars, getGoVersion, getBinPath, SemVersion } from './util';
 import { promptForMissingTool } from './goInstallTools';
 
+const missingToolMsg = 'Missing tool: ';
+
 /**
  * Runs gopkgs
  * @returns Map<string, string> mapping between package import path and package name
@@ -19,8 +21,9 @@ export function getAllPackages(): Promise<Map<string, string>> {
 		cmd.on('close', () => {
 			let pkgs = new Map<string, string>();
 			if (err && (<any>err).code === 'ENOENT') {
-				promptForMissingTool('gopkgs');
+				return reject(missingToolMsg + 'gopkgs');
 			}
+
 			if (err) return resolve(pkgs);
 
 			chunks.join('').split('\n').forEach((pkgDetail) => {

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -10,7 +10,7 @@ import { isVendorSupported, getCurrentGoPath, getToolsEnvVars, getGoVersion, get
  */
 export function goListAll(): Promise<Map<string, string>> {
 	return new Promise<Map<string, string>>((resolve, reject) => {
-		const cmd = cp.spawn(getBinPath('gopkgs'), ['-f', '{{.Name}};{{.ImportPath}}'], { env: getToolsEnvVars() });
+		const cmd = cp.spawn(getBinPath('gopkgs'), ['-format', '{{.Name}};{{.ImportPath}}'], { env: getToolsEnvVars() });
 		const chunks = [];
 		cmd.stdout.on('data', (d) => {
 			chunks.push(d);

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -12,7 +12,7 @@ let allPkgsLastHit: number;
 
 function getAllPackagesNoCache(): Promise<Map<string, string>> {
 	return new Promise<Map<string, string>>((resolve, reject) => {
-		const cmd = cp.spawn(getBinPath('gopkgs'), ['-format', '{{.Name}};{{.ImportPath}}'], { env: getToolsEnvVars() });
+		const cmd = cp.spawn(getBinPath('gopkgs'), ['-format', '{{.Name}};{{.ImportPath}}'], { env: getToolsEnvVars(), stdio: ['pipe', 'pipe', 'ignore'] });
 		const chunks = [];
 		let err: any;
 		cmd.stdout.on('data', d => chunks.push(d));

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -4,9 +4,11 @@ import path = require('path');
 import { getGoRuntimePath, getCurrentGoWorkspaceFromGOPATH } from './goPath';
 import { isVendorSupported, getCurrentGoPath, getToolsEnvVars, getGoVersion, getBinPath, SemVersion } from './util';
 
-let allPkgMapCache: Map<string, string>;
-
-function goListAllNoCache(): Promise<Map<string, string>> {
+/**
+ * Runs go list all
+ * @returns Map<string, string> mapping between package import path and package name
+ */
+export function goListAll(): Promise<Map<string, string>> {
 	return new Promise<Map<string, string>>((resolve, reject) => {
 		const cmd = cp.spawn(getBinPath('gopkgs'), ['-f', '{{.Name}};{{.ImportPath}}'], { env: getToolsEnvVars() });
 		const chunks = [];
@@ -23,23 +25,6 @@ function goListAllNoCache(): Promise<Map<string, string>> {
 			});
 			return resolve(pkgs);
 		});
-	});
-}
-
-/**
- * Runs go list all
- * @returns Map<string, string> mapping between package import path and package name
- */
-export function goListAll(): Promise<Map<string, string>> {
-	if (allPkgMapCache) {
-		goListAllNoCache().then((pkgs: Map<string, string>) => {
-			allPkgMapCache = pkgs;
-		});
-		return Promise.resolve(allPkgMapCache);
-	}
-
-	return goListAllNoCache().then((pkgs: Map<string, string>) => {
-		return allPkgMapCache = pkgs;
 	});
 }
 

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -37,7 +37,6 @@ interface GoCodeSuggestion {
 
 export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 
-	private gocodeConfigurationComplete = false;
 	private pkgsList = new Map<string, string>();
 
 	public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.CompletionItem[]> {
@@ -215,16 +214,12 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 	}
 	// TODO: Shouldn't lib-path also be set?
 	private ensureGoCodeConfigured(): Thenable<void> {
-		getImportablePackages(vscode.window.activeTextEditor.document.fileName).then(pkgMap => {
+		let setPkgsList = getImportablePackages(vscode.window.activeTextEditor.document.fileName).then(pkgMap => {
 			this.pkgsList = pkgMap;
+			return;
 		});
 
-		return new Promise<void>((resolve, reject) => {
-			// TODO: Since the gocode daemon is shared amongst clients, shouldn't settings be
-			// adjusted per-invocation to avoid conflicts from other gocode-using programs?
-			if (this.gocodeConfigurationComplete) {
-				return resolve();
-			}
+		let setGocodeProps = new Promise<void>((resolve, reject) => {
 			let gocode = getBinPath('gocode');
 			let autobuild = vscode.workspace.getConfiguration('go')['gocodeAutoBuild'];
 			let env = getToolsEnvVars();
@@ -235,6 +230,9 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 			});
 		});
 
+		return Promise.all([setPkgsList, setGocodeProps]).then(() => {
+			return;
+		})
 	}
 
 	// Return importable packages that match given word as Completion Items

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -232,7 +232,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 
 		return Promise.all([setPkgsList, setGocodeProps]).then(() => {
 			return;
-		})
+		});
 	}
 
 	// Return importable packages that match given word as Completion Items

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -8,7 +8,7 @@ import path = require('path');
 import vscode = require('vscode');
 import util = require('util');
 import { parseEnvFile, getGoRuntimePath, resolvePath } from './goPath';
-import { getToolsEnvVars, LineBuffer } from './util';
+import { getToolsEnvVars, getGoVersion, LineBuffer, SemVersion } from './util';
 import { GoDocumentSymbolProvider } from './goOutline';
 import { getPackages } from './goPackages';
 
@@ -194,7 +194,12 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 	if (testconfig.functions) {
 		return Promise.resolve(['-run', util.format('^%s$', testconfig.functions.join('|'))]);
 	} else if (testconfig.includeSubDirectories) {
-		return getPackages(vscode.workspace.rootPath);
+		return getGoVersion().then((ver: SemVersion) => {
+			if (ver && (ver.major > 1 || (ver.major === 1 && ver.minor >= 9))) {
+				return ['./...'];
+			}
+			return getPackages(vscode.workspace.rootPath);
+		});
 	}
 	return Promise.resolve([]);
 }

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -192,12 +192,7 @@ function expandFilePathInOutput(output: string, cwd: string): string {
  */
 function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 	if (testconfig.functions) {
-		return new Promise<Array<string>>((resolve, reject) => {
-			const args = [];
-			args.push('-run');
-			args.push(util.format('^%s$', testconfig.functions.join('|')));
-			return resolve(args);
-		});
+		return Promise.resolve(['-run', util.format('^%s$', testconfig.functions.join('|'))]);
 	} else if (testconfig.includeSubDirectories) {
 		return getPackages(vscode.workspace.rootPath);
 	}

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -10,7 +10,7 @@ import util = require('util');
 import { parseEnvFile, getGoRuntimePath, resolvePath } from './goPath';
 import { getToolsEnvVars, getGoVersion, LineBuffer, SemVersion } from './util';
 import { GoDocumentSymbolProvider } from './goOutline';
-import { getPackages } from './goPackages';
+import { getNonVendorPackages } from './goPackages';
 
 let outputChannel = vscode.window.createOutputChannel('Go Tests');
 
@@ -199,7 +199,7 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 			if (ver && (ver.major > 1 || (ver.major === 1 && ver.minor >= 9))) {
 				return ['./...'];
 			}
-			return getPackages(vscode.workspace.rootPath);
+			return getNonVendorPackages(vscode.workspace.rootPath);
 		});
 	}
 	return Promise.resolve([]);

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -10,7 +10,7 @@ import util = require('util');
 import { parseEnvFile, getGoRuntimePath, resolvePath } from './goPath';
 import { getToolsEnvVars, LineBuffer } from './util';
 import { GoDocumentSymbolProvider } from './goOutline';
-import { getNonVendorPackages } from './goPackages';
+import { getPackages } from './goPackages';
 
 let outputChannel = vscode.window.createOutputChannel('Go Tests');
 
@@ -199,7 +199,7 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 			return resolve(args);
 		});
 	} else if (testconfig.includeSubDirectories) {
-		return getNonVendorPackages(vscode.workspace.rootPath);
+		return getPackages(vscode.workspace.rootPath);
 	}
 	return Promise.resolve([]);
 }

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -582,8 +582,8 @@ It returns the number of bytes written and any write error encountered.
 
 			return Promise.all<string[]>([gopkgsPromise, listPkgPromise]).then((values: string[][]) => {
 				if (!vendorSupport) {
-					let originalPkgs = values[0];
-					let updatedPkgs = values[1];
+					let originalPkgs = values[0].sort();
+					let updatedPkgs = values[1].sort();
 					assert.equal(originalPkgs.length, updatedPkgs.length);
 					for (let index = 0; index < originalPkgs.length; index++) {
 						assert.equal(updatedPkgs[index], originalPkgs[index]);

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -21,7 +21,6 @@ import { getBinPath, getGoVersion, isVendorSupported } from '../src/util';
 import { documentSymbols } from '../src/goOutline';
 import { listPackages } from '../src/goImport';
 import { generateTestCurrentFile, generateTestCurrentPackage, generateTestCurrentFunction } from '../src/goGenerateTests';
-import { getAllPackages } from '../src/goPackages';
 
 suite('Go Extension Tests', () => {
 	let gopath = process.env['GOPATH'];

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -616,7 +616,7 @@ It returns the number of bytes written and any write error encountered.
 			let gopkgsPromise = new Promise<void>((resolve, reject) => {
 				let cmd = cp.execFile(getBinPath('gopkgs'), ['-short=false'], { env: process.env });
 				let chunks = [];
-				cmd.stdout.on('data', (d) => chunks.push(d))
+				cmd.stdout.on('data', (d) => chunks.push(d));
 				cmd.on('close', () => {
 					let pkgs = chunks.join('').split('\n').filter((pkg) => pkg).sort();
 					if (vendorSupport) {

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -551,7 +551,7 @@ It returns the number of bytes written and any write error encountered.
 
 		vendorSupportPromise.then((vendorSupport: boolean) => {
 			let gopkgsPromise = new Promise<string[]>((resolve, reject) => {
-				let cmd = cp.spawn(getBinPath('gopkgs'), ['-short=false'], { env: process.env });
+				let cmd = cp.spawn(getBinPath('gopkgs'), ['-f', '{{.ImportPath}}'], { env: process.env });
 				let chunks = [];
 				cmd.stdout.on('data', (d) => chunks.push(d));
 				cmd.on('close', () => {
@@ -614,7 +614,7 @@ It returns the number of bytes written and any write error encountered.
 
 		vendorSupportPromise.then((vendorSupport: boolean) => {
 			let gopkgsPromise = new Promise<void>((resolve, reject) => {
-				let cmd = cp.spawn(getBinPath('gopkgs'), ['-short=false'], { env: process.env });
+				let cmd = cp.spawn(getBinPath('gopkgs'), ['-f', '{{.ImportPath}}'], { env: process.env });
 				let chunks = [];
 				cmd.stdout.on('data', (d) => chunks.push(d));
 				cmd.on('close', () => {

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -21,7 +21,7 @@ import { getBinPath, getGoVersion, isVendorSupported } from '../src/util';
 import { documentSymbols } from '../src/goOutline';
 import { listPackages } from '../src/goImport';
 import { generateTestCurrentFile, generateTestCurrentPackage, generateTestCurrentFunction } from '../src/goGenerateTests';
-import { goListAll } from '../src/goPackages';
+import { getAllPackages } from '../src/goPackages';
 
 suite('Go Extension Tests', () => {
 	let gopath = process.env['GOPATH'];

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -614,7 +614,7 @@ It returns the number of bytes written and any write error encountered.
 
 		vendorSupportPromise.then((vendorSupport: boolean) => {
 			let gopkgsPromise = new Promise<void>((resolve, reject) => {
-				let cmd = cp.execFile(getBinPath('gopkgs'), ['-short=false'], { env: process.env });
+				let cmd = cp.spawn(getBinPath('gopkgs'), ['-short=false'], { env: process.env });
 				let chunks = [];
 				cmd.stdout.on('data', (d) => chunks.push(d));
 				cmd.on('close', () => {

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -31,7 +31,6 @@ suite('Go Extension Tests', () => {
 	let generateTestsSourcePath = path.join(repoPath, 'generatetests');
 	let generateFunctionTestSourcePath = path.join(repoPath, 'generatefunctiontest');
 	let generatePackageTestSourcePath = path.join(repoPath, 'generatePackagetest');
-	let goListAllPromise = goListAll();
 
 	suiteSetup(() => {
 		assert.ok(gopath !== null, 'GOPATH is not defined');
@@ -727,17 +726,15 @@ It returns the number of bytes written and any write error encountered.
 					editbuilder.insert(new vscode.Position(12, 1), 'by\n');
 					editbuilder.insert(new vscode.Position(13, 0), 'math.\n');
 				}).then(() => {
-					return goListAllPromise.then(() => {
-						let promises = testCases.map(([position, expected]) =>
-							provider.provideCompletionItemsInternal(editor.document, position, null, config).then(items => {
-								let labels = items.map(x => x.label);
-								for (let entry of expected) {
-									assert.equal(labels.indexOf(entry) > -1, true, `missing expected item in completion list: ${entry} Actual: ${labels}`);
-								}
-							})
-						);
-						return Promise.all(promises);
-					});
+					let promises = testCases.map(([position, expected]) =>
+						provider.provideCompletionItemsInternal(editor.document, position, null, config).then(items => {
+							let labels = items.map(x => x.label);
+							for (let entry of expected) {
+								assert.equal(labels.indexOf(entry) > -1, true, `missing expected item in completion list: ${entry} Actual: ${labels}`);
+							}
+						})
+					);
+					return Promise.all(promises);
 				});
 			}).then(() => {
 				vscode.commands.executeCommand('workbench.action.closeActiveEditor');

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -552,8 +552,11 @@ It returns the number of bytes written and any write error encountered.
 
 		vendorSupportPromise.then((vendorSupport: boolean) => {
 			let gopkgsPromise = new Promise<string[]>((resolve, reject) => {
-				cp.execFile(getBinPath('gopkgs'), [], (err, stdout, stderr) => {
-					let pkgs = stdout.split('\n').sort().slice(1);
+				let cmd = cp.spawn(getBinPath('gopkgs'), ['-short=false'], { env: process.env });
+				let chunks = [];
+				cmd.stdout.on('data', (d) => chunks.push(d));
+				cmd.on('close', () => {
+					let pkgs = chunks.join('').split('\n').filter((pkg) => pkg).sort();
 					if (vendorSupport) {
 						vendorPkgsFullPath.forEach(pkg => {
 							assert.equal(pkgs.indexOf(pkg) > -1, true, `Package not found by goPkgs: ${pkg}`);
@@ -612,8 +615,11 @@ It returns the number of bytes written and any write error encountered.
 
 		vendorSupportPromise.then((vendorSupport: boolean) => {
 			let gopkgsPromise = new Promise<void>((resolve, reject) => {
-				cp.execFile(getBinPath('gopkgs'), [], (err, stdout, stderr) => {
-					let pkgs = stdout.split('\n').sort().slice(1);
+				let cmd = cp.execFile(getBinPath('gopkgs'), ['-short=false'], { env: process.env });
+				let chunks = [];
+				cmd.stdout.on('data', (d) => chunks.push(d))
+				cmd.on('close', () => {
+					let pkgs = chunks.join('').split('\n').filter((pkg) => pkg).sort();
 					if (vendorSupport) {
 						vendorPkgs.forEach(pkg => {
 							assert.equal(pkgs.indexOf(pkg) > -1, true, `Package not found by goPkgs: ${pkg}`);

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -551,7 +551,7 @@ It returns the number of bytes written and any write error encountered.
 
 		vendorSupportPromise.then((vendorSupport: boolean) => {
 			let gopkgsPromise = new Promise<string[]>((resolve, reject) => {
-				let cmd = cp.spawn(getBinPath('gopkgs'), ['-f', '{{.ImportPath}}'], { env: process.env });
+				let cmd = cp.spawn(getBinPath('gopkgs'), ['-format', '{{.ImportPath}}'], { env: process.env });
 				let chunks = [];
 				cmd.stdout.on('data', (d) => chunks.push(d));
 				cmd.on('close', () => {
@@ -614,7 +614,7 @@ It returns the number of bytes written and any write error encountered.
 
 		vendorSupportPromise.then((vendorSupport: boolean) => {
 			let gopkgsPromise = new Promise<void>((resolve, reject) => {
-				let cmd = cp.spawn(getBinPath('gopkgs'), ['-f', '{{.ImportPath}}'], { env: process.env });
+				let cmd = cp.spawn(getBinPath('gopkgs'), ['-format', '{{.ImportPath}}'], { env: process.env });
 				let chunks = [];
 				cmd.stdout.on('data', (d) => chunks.push(d));
 				cmd.on('close', () => {


### PR DESCRIPTION
Previously the `goListAll()` cache the packages, resulting completion for newly created package not shown because the outdated cache and it quite irritating.

To takeout cache, we need to invoke `go list all` on demand. But the execution time is unacceptable, it will try to load packages from GOROOT, GOPATH and also user home directory. That is why `cp.spawn('go', [], { env: process.env })` took so long, and by not providing the env will execute faster.

Better implementation package listing tools `https://github.com/haya14busa/gopkgs`. It search the packages from golang `src`. So I replace the `go list all` using `gopkgs`.

`go list all` took 4.87s
`gopkgs` took 0.08s

- No more cache on `goListAll()` and it fast.
- Browse package also can lookup non-installed package (based on src, not the binary)
- The extension will check if the gopkgs is not the expected one and prompt as missing tool