### PR TITLE
Ignore stderr outputs of go list all to fix #1152

### DIFF
--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -32,7 +32,7 @@ export function goListAll(): Promise<Map<string, string>> {
 		// Use `{env: {}}` to make the execution faster. Include GOPATH to account if custom work space exists.
 		const env: any = getToolsEnvVars();
 
-		const cmd = cp.spawn(goRuntimePath, ['list', '-f', '{{.Name}};{{.ImportPath}}', 'all'], { env: env });
+		const cmd = cp.spawn(goRuntimePath, ['list', '-f', '{{.Name}};{{.ImportPath}}', 'all'], { env: env, stdio: ['pipe', 'pipe', 'ignore'] });
 		const chunks = [];
 		cmd.stdout.on('data', (d) => {
 			chunks.push(d);


### PR DESCRIPTION
If `go list all` emits warning messages on stderr, it seems stuck forever, and then auto completion (before importing) feature does not work. So just ignore the outputs of stderr.
It fixes #1152. And it's maybe related to #1186.
