### PR TITLE
📚 Fix misspelling of "editor context menu" setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ In addition to integrated editing features, the extension also provides several 
 
 You can access all of the above commands from the command pallet (`Cmd+Shift+P` or `Ctrl+Shift+P`).
 
-Few of these are available in the editor context menu as an experimental feature as well. To control which of these commands show up in the editor context menu, update the setting `go.editortorContextMenuCommands`
+Few of these are available in the editor context menu as an experimental feature as well. To control which of these commands show up in the editor context menu, update the setting `go.editorContextMenuCommands`
 
 
 ### _Optional_: Debugging


### PR DESCRIPTION
[`go.editorContextMenuCommands`](https://github.com/Microsoft/vscode-go/blob/master/package.json#L691) is misspelled as `go. editortorContextMenuCommands` in the README.