### PR TITLE
Multi root support

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "vscode": "^1.1.4"
   },
   "engines": {
-    "vscode": "^1.9.0"
+    "vscode": "^1.15.0"
   },
   "activationEvents": [
     "onLanguage:go",
@@ -366,7 +366,8 @@
             "off"
           ],
           "default": "package",
-          "description": "On save, compiles the current workspace, current package or nothing at all."
+          "description": "On save, compiles the current workspace, current package or nothing at all.",
+          "scope": "resource"
         },
         "go.buildFlags": {
           "type": "array",
@@ -374,12 +375,14 @@
             "type": "string"
           },
           "default": [],
-          "description": "Flags to `go build`/`go test` used during build-on-save or running tests. (e.g. ['-ldflags=\"-s\"'])"
+          "description": "Flags to `go build`/`go test` used during build-on-save or running tests. (e.g. ['-ldflags=\"-s\"'])",
+          "scope": "resource"
         },
         "go.buildTags": {
           "type": "string",
           "default": "",
-          "description": "The Go build tags to use for all commands that support a `-tags '...'` argument"
+          "description": "The Go build tags to use for all commands that support a `-tags '...'` argument",
+          "scope": "resource"
         },
         "go.lintOnSave": {
           "type": "string",
@@ -389,12 +392,14 @@
             "off"
           ],
           "default": "package",
-          "description": "On save, runs the configured Lint tool on current workspace, current package or nothing at all."
+          "description": "On save, runs the configured Lint tool on current workspace, current package or nothing at all.",
+          "scope": "resource"
         },
         "go.lintTool": {
           "type": "string",
           "default": "golint",
           "description": "Specifies Lint tool name.",
+          "scope": "resource",
           "enum": [
             "golint",
             "gometalinter",
@@ -407,7 +412,8 @@
             "type": "string"
           },
           "default": [],
-          "description": "Flags to pass to Lint tool (e.g. [\"-min_confidence=.8\"])"
+          "description": "Flags to pass to Lint tool (e.g. [\"-min_confidence=.8\"])",
+          "scope": "resource"
         },
         "go.vetOnSave": {
           "type": "string",
@@ -417,7 +423,8 @@
             "off"
           ],
           "default": "package",
-          "description": "On save, runs 'go vet' on current workspace, current package or nothing."
+          "description": "On save, runs 'go vet' on current workspace, current package or nothing.",
+          "scope": "resource"
         },
         "go.vetFlags": {
           "type": "array",
@@ -425,17 +432,20 @@
             "type": "string"
           },
           "default": [],
-          "description": "Flags to pass to `go vet` (e.g. ['-all', '-shadow'])"
+          "description": "Flags to pass to `go vet` (e.g. ['-all', '-shadow'])",
+          "scope": "resource"
         },
         "go.formatOnSave": {
           "type": "boolean",
           "default": true,
-          "description": "Runs formatting tool on save."
+          "description": "Runs formatting tool on save.",
+          "scope": "resource"
         },
         "go.formatTool": {
           "type": "string",
           "default": "goreturns",
           "description": "Pick 'gofmt', 'goimports' or 'goreturns' to run on format.",
+          "scope": "resource",
           "enum": [
             "gofmt",
             "goimports",
@@ -448,17 +458,20 @@
             "type": "string"
           },
           "default": [],
-          "description": "Flags to pass to format tool (e.g. ['-s'])"
+          "description": "Flags to pass to format tool (e.g. ['-s'])",
+          "scope": "resource"
         },
         "go.useDiffForFormatting": {
           "type": "boolean",
           "default": true,
-          "description": "Run the formatting tools with the -d flag"
+          "description": "Run the formatting tools with the -d flag",
+          "scope": "resource"
         },
         "go.inferGopath": {
           "type": "boolean",
           "default": false,
-          "description": "Infer GOPATH from the workspace root."
+          "description": "Infer GOPATH from the workspace root.",
+          "scope": "resource"
         },
         "go.gopath": {
           "type": [
@@ -466,12 +479,14 @@
             "null"
           ],
           "default": null,
-          "description": "Specify GOPATH here to override the one that is set as environment variable. The inferred GOPATH from workspace root overrides this, if go.inferGopath is set to true."
+          "description": "Specify GOPATH here to override the one that is set as environment variable. The inferred GOPATH from workspace root overrides this, if go.inferGopath is set to true.",
+          "scope": "resource"
         },
         "go.toolsGopath": {
           "type": "string",
           "default": "",
-          "description": "Location to install the Go tools that the extension depends on if you don't want them in your GOPATH."
+          "description": "Location to install the Go tools that the extension depends on if you don't want them in your GOPATH.",
+          "scope": "resource"
         },
         "go.goroot": {
           "type": [
@@ -479,17 +494,20 @@
             "null"
           ],
           "default": null,
-          "description": "Specifies the GOROOT to use when no environment variable is set."
+          "description": "Specifies the GOROOT to use when no environment variable is set.",
+          "scope": "resource"
         },
         "go.testOnSave": {
           "type": "boolean",
           "default": false,
-          "description": "Run 'go test' on save for current package. It is not advised to set this to `true` when you have Auto Save enabled."
+          "description": "Run 'go test' on save for current package. It is not advised to set this to `true` when you have Auto Save enabled.",
+          "scope": "resource"
         },
         "go.coverOnSave": {
           "type": "boolean",
           "default": false,
-          "description": "If true, runs 'go test -coverprofile' on save and shows test coverage."
+          "description": "If true, runs 'go test -coverprofile' on save and shows test coverage.",
+          "scope": "resource"
         },
         "go.coverOnTestPackage": {
           "type": "boolean",
@@ -504,7 +522,8 @@
             "showBothCoveredAndUncoveredCode"
           ],
           "default": "showBothCoveredAndUncoveredCode",
-          "description": "Use these options to control whether only covered or only uncovered code or both should be highlighted after running test coverage"
+          "description": "Use these options to control whether only covered or only uncovered code or both should be highlighted after running test coverage",
+          "scope": "resource"
         },
         "go.coverageDecorator": {
           "type": "string",
@@ -513,22 +532,26 @@
             "gutter"
           ],
           "default": "highlight",
-          "description": "This option lets you choose the way to display code coverage. Highlight, as its name states, highlights the line in red or green, gutter shows the colors in the gutter of the editor."
+          "description": "This option lets you choose the way to display code coverage. Highlight, as its name states, highlights the line in red or green, gutter shows the colors in the gutter of the editor.",
+          "scope": "resource"
         },
         "go.testTimeout": {
           "type": "string",
           "default": "30s",
-          "description": "Specifies the timeout for go test in ParseDuration format."
+          "description": "Specifies the timeout for go test in ParseDuration format.",
+          "scope": "resource"
         },
         "go.testEnvVars": {
           "type": "object",
           "default": {},
-          "description": "Environment variables that will passed to the process that runs the Go tests"
+          "description": "Environment variables that will passed to the process that runs the Go tests",
+          "scope": "resource"
         },
         "go.testEnvFile": {
           "type": "string",
           "default": null,
-          "description": "Absolute path to a file containing environment variables definitions. File contents should be of the form key=value."
+          "description": "Absolute path to a file containing environment variables definitions. File contents should be of the form key=value.",
+          "scope": "resource"
         },
         "go.testFlags": {
           "type": [
@@ -539,32 +562,38 @@
             "type": "string"
           },
           "default": null,
-          "description": "Flags to pass to `go test`. If null, then buildFlags will be used."
+          "description": "Flags to pass to `go test`. If null, then buildFlags will be used.",
+          "scope": "resource"
         },
         "go.toolsEnvVars": {
           "type": "object",
           "default": {},
-          "description": "Environment variables that will passed to the processes that run the Go tools (e.g. CGO_CFLAGS)"
+          "description": "Environment variables that will passed to the processes that run the Go tools (e.g. CGO_CFLAGS)",
+          "scope": "resource"
         },
         "go.gocodeAutoBuild": {
           "type": "boolean",
           "default": true,
-          "description": "Enable gocode's autobuild feature"
+          "description": "Enable gocode's autobuild feature",
+          "scope": "resource"
         },
         "go.useCodeSnippetsOnFunctionSuggest": {
           "type": "boolean",
           "default": false,
-          "description": "Complete functions with their parameter signature"
+          "description": "Complete functions with their parameter signature",
+          "scope": "resource"
         },
         "go.autocompleteUnimportedPackages": {
           "type": "boolean",
           "default": false,
-          "description": "Include unimported packages in auto-complete suggestions."
+          "description": "Include unimported packages in auto-complete suggestions.",
+          "scope": "resource"
         },
         "go.docsTool": {
           "type": "string",
           "default": "godoc",
           "description": "Pick 'godoc' or 'gogetdoc' to get documentation. In Go 1.5, godoc is used regardless of the choice here.",
+          "scope": "resource",
           "enum": [
             "godoc",
             "gogetdoc",
@@ -584,7 +613,8 @@
         "go.gotoSymbol.includeImports": {
           "type": "boolean",
           "default": false,
-          "description": "If false, the import statements will be excluded while using the Go to Symbol in File feature"
+          "description": "If false, the import statements will be excluded while using the Go to Symbol in File feature",
+          "scope": "resource"
         },
         "go.enableCodeLens": {
           "type": "object",
@@ -604,7 +634,8 @@
             "references": false,
             "runtest": true
           },
-          "description": "Feature level setting to enable/disable code lens for references and run/debug tests"
+          "description": "Feature level setting to enable/disable code lens for references and run/debug tests",
+          "scope": "resource"
         },
         "go.addTags": {
           "type": "object",
@@ -640,7 +671,8 @@
             "promptForTags": false,
             "transform": "snakecase"
           },
-          "description": "Tags and options configured here will be used by the Add Tags command to add tags to struct fields. If promptForTags is true, then user will be prompted for tags and options. By default, json tags are added."
+          "description": "Tags and options configured here will be used by the Add Tags command to add tags to struct fields. If promptForTags is true, then user will be prompted for tags and options. By default, json tags are added.",
+          "scope": "resource"
         },
         "go.liveErrors": {
           "type": "object",
@@ -660,7 +692,8 @@
             "enabled": false,
             "delay": 500
           },
-          "description": "Use gotype on the file currently being edited and report any semantic or syntactic errors found after configured delay."
+          "description": "Use gotype on the file currently being edited and report any semantic or syntactic errors found after configured delay.",
+          "scope": "resource"
         },
         "go.removeTags": {
           "type": "object",
@@ -686,7 +719,8 @@
             "options": "",
             "promptForTags": false
           },
-          "description": "Tags and options configured here will be used by the Remove Tags command to remove tags to struct fields. If promptForTags is true, then user will be prompted for tags and options. By default, all tags and options will be removed."
+          "description": "Tags and options configured here will be used by the Remove Tags command to remove tags to struct fields. If promptForTags is true, then user will be prompted for tags and options. By default, all tags and options will be removed.",
+          "scope": "resource"
         },
         "go.editorContextMenuCommands": {
           "type": "object",
@@ -760,7 +794,8 @@
             "addImport": true,
             "testCoverage": true
           },
-          "description": "Experimental Feature: Enable/Disable entries from the context menu in the editor."
+          "description": "Experimental Feature: Enable/Disable entries from the context menu in the editor.",
+          "scope": "resource"
         },
         "go.gotoSymbol.ignoreFolders": {
           "type": "array",
@@ -768,7 +803,8 @@
             "type": "string"
           },
           "default": [],
-          "description": "Folder names (not paths) to ignore while using Go to Symbol in Workspace feature"
+          "description": "Folder names (not paths) to ignore while using Go to Symbol in Workspace feature",
+          "scope": "resource"
         }
       }
     },

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -117,7 +117,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 	outputChannel.clear();
 	let runningToolsPromises = [];
 	let cwd = path.dirname(fileUri.fsPath);
-	let currentWorkspace = vscode.workspace.getWorkspaceFolder(fileUri).uri.fsPath;
+	let currentWorkspace = vscode.workspace.getWorkspaceFolder(fileUri) ? vscode.workspace.getWorkspaceFolder(fileUri).uri.fsPath : '';
 	let env = getToolsEnvVars();
 	let goRuntimePath = getGoRuntimePath();
 

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -165,7 +165,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 			buildArgs.push('"' + goConfig['buildTags'] + '"');
 		}
 
-		if (goConfig['buildOnSave'] === 'workspace') {
+		if (goConfig['buildOnSave'] === 'workspace' && currentWorkspace) {
 			let buildPromises = [];
 			let outerBuildPromise = getNonVendorPackages(currentWorkspace).then(pkgs => {
 				buildPromises = pkgs.map(pkgPath => {
@@ -248,7 +248,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 
 		let lintWorkDir = cwd;
 
-		if (goConfig['lintOnSave'] === 'workspace') {
+		if (goConfig['lintOnSave'] === 'workspace' && currentWorkspace) {
 			args.push('./...');
 			lintWorkDir = currentWorkspace;
 		}
@@ -268,7 +268,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 		let vetArgs = ['tool', 'vet', ...vetFlags, '.'];
 		let vetWorkDir = cwd;
 
-		if (goConfig['vetOnSave'] === 'workspace') {
+		if (goConfig['vetOnSave'] === 'workspace' && currentWorkspace) {
 			vetWorkDir = currentWorkspace;
 		}
 

--- a/src/goCodelens.ts
+++ b/src/goCodelens.ts
@@ -19,7 +19,7 @@ class ReferencesCodeLens extends CodeLens {
 
 export class GoCodeLensProvider implements CodeLensProvider {
 	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
-		let codeLensConfig = vscode.workspace.getConfiguration('go').get('enableCodeLens');
+		let codeLensConfig = vscode.workspace.getConfiguration('go', document.uri).get('enableCodeLens');
 		let codelensEnabled = codeLensConfig ? codeLensConfig['references'] : false;
 		if (!codelensEnabled) {
 			return Promise.resolve([]);

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -92,7 +92,6 @@ export function toggleCoverageCurrentPackage() {
 		}
 	}
 
-	// FIXME: is there a better way to get goConfig?
 	let goConfig = vscode.workspace.getConfiguration('go', editor.document.uri);
 	let cwd = path.dirname(editor.document.uri.fsPath);
 

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -93,7 +93,7 @@ export function toggleCoverageCurrentPackage() {
 	}
 
 	// FIXME: is there a better way to get goConfig?
-	let goConfig = vscode.workspace.getConfiguration('go');
+	let goConfig = vscode.workspace.getConfiguration('go', editor.document.uri);
 	let cwd = path.dirname(editor.document.uri.fsPath);
 
 	let buildFlags = goConfig['testFlags'] || goConfig['buildFlags'] || [];
@@ -143,7 +143,7 @@ function applyCoverage(remove: boolean = false) {
 }
 
 function highlightCoverage(editor: vscode.TextEditor, file: CoverageFile, remove: boolean) {
-	let cfg = vscode.workspace.getConfiguration('go');
+	let cfg = vscode.workspace.getConfiguration('go', editor.document.uri);
 	let coverageOptions = cfg['coverageOptions'];
 	let coverageDecorator = cfg['coverageDecorator'];
 	let hideUncovered = remove || coverageOptions === 'showCoveredCodeOnly';

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -32,7 +32,7 @@ export function definitionLocation(document: vscode.TextDocument, position: vsco
 		return Promise.resolve(null);
 	}
 	if (!goConfig) {
-		goConfig = vscode.workspace.getConfiguration('go');
+		goConfig = vscode.workspace.getConfiguration('go', document.uri);
 	}
 	let toolForDocs = goConfig['docsTool'] || 'godoc';
 	let offset = byteOffsetAt(document, position);
@@ -120,7 +120,7 @@ function definitionLocation_gogetdoc(document: vscode.TextDocument, position: vs
 	return new Promise<GoDefinitionInformation>((resolve, reject) => {
 		let gogetdoc = getBinPath('gogetdoc');
 		let gogetdocFlagsWithoutTags = ['-u', '-json', '-modified', '-pos', document.fileName + ':#' + offset.toString()];
-		let buildTags = vscode.workspace.getConfiguration('go')['buildTags'];
+		let buildTags = vscode.workspace.getConfiguration('go', document.uri)['buildTags'];
 		let gogetdocFlags = (buildTags && useTags) ? [...gogetdocFlagsWithoutTags, '-tags', '"' + buildTags + '"'] : gogetdocFlagsWithoutTags;
 		let p = cp.execFile(gogetdoc, gogetdocFlags, {env}, (err, stdout, stderr) => {
 			try {

--- a/src/goExtraInfo.ts
+++ b/src/goExtraInfo.ts
@@ -14,13 +14,14 @@ export class GoHoverProvider implements HoverProvider {
 
 	constructor(goConfig?: WorkspaceConfiguration) {
 		this.goConfig = goConfig;
-		if (!this.goConfig) {
-			this.goConfig = vscode.workspace.getConfiguration('go');
-		}
 	}
 
 	public provideHover(document: TextDocument, position: Position, token: CancellationToken): Thenable<Hover> {
 		let goConfig = this.goConfig;
+		if (!this.goConfig) {
+			this.goConfig = vscode.workspace.getConfiguration('go', document.uri);
+		}
+
 		// Temporary fix to fall back to godoc if guru is the set docsTool
 		if (goConfig['docsTool'] === 'guru') {
 			goConfig = Object.assign({}, goConfig, {'docsTool': 'godoc'});

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -18,10 +18,11 @@ export class Formatter {
 	public formatDocument(document: vscode.TextDocument): Thenable<vscode.TextEdit[]> {
 		return new Promise((resolve, reject) => {
 			let filename = document.fileName;
-			let formatTool = vscode.workspace.getConfiguration('go')['formatTool'] || 'goreturns';
+			let goConfig = vscode.workspace.getConfiguration('go', document.uri);
+			let formatTool = goConfig['formatTool'] || 'goreturns';
 			let formatCommandBinPath = getBinPath(formatTool);
-			let formatFlags = vscode.workspace.getConfiguration('go')['formatFlags'] || [];
-			let canFormatToolUseDiff = vscode.workspace.getConfiguration('go')['useDiffForFormatting'] && isDiffToolAvailable();
+			let formatFlags = goConfig['formatFlags'] || [];
+			let canFormatToolUseDiff = goConfig['useDiffForFormatting'] && isDiffToolAvailable();
 			if (canFormatToolUseDiff && formatFlags.indexOf('-d') === -1) {
 				formatFlags.push('-d');
 			}

--- a/src/goImplementations.ts
+++ b/src/goImplementations.ts
@@ -28,13 +28,23 @@ interface GuruImplementsOutput {
 
 export class GoImplementationProvider implements vscode.ImplementationProvider {
 	public provideImplementation(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Definition> {
+		// To keep `guru implements` fast we want to restrict the scope of the search to current workpsace
+		// If no workpsace is open, then no-op
+		let root = vscode.workspace.rootPath;
+		if (vscode.workspace.getWorkspaceFolder(document.uri)) {
+			root = vscode.workspace.getWorkspaceFolder(document.uri).uri.fsPath;
+		}
+		if (!root) {
+			vscode.window.showInformationMessage('Cannot find implementations when there is no workspace open.');
+			return;
+		}
+
 		return new Promise<vscode.Definition>((resolve, reject) => {
 			if (token.isCancellationRequested) {
 				return resolve(null);
 			}
 			let env = getToolsEnvVars();
-			let cwd = vscode.workspace.getWorkspaceFolder(document.uri).uri.fsPath;
-			let listProcess = cp.execFile(getGoRuntimePath(), ['list', '-e', '-json'], { cwd, env }, (err, stdout, stderr) => {
+			let listProcess = cp.execFile(getGoRuntimePath(), ['list', '-e', '-json'], { cwd: root, env }, (err, stdout, stderr) => {
 				if (err) {
 					return reject(err);
 				}
@@ -47,7 +57,7 @@ export class GoImplementationProvider implements vscode.ImplementationProvider {
 				let buildTags = '"' + vscode.workspace.getConfiguration('go', document.uri)['buildTags'] + '"';
 				let args = ['-scope', `${scope}/...`, '-json', '-tags', buildTags, 'implements', `${filename}:#${offset.toString()}`];
 
-				let guruProcess = cp.execFile(goGuru, args, {env}, (err, stdout, stderr) => {
+				let guruProcess = cp.execFile(goGuru, args, { env }, (err, stdout, stderr) => {
 					if (err && (<any>err).code === 'ENOENT') {
 						promptForMissingTool('guru');
 						return resolve(null);

--- a/src/goImplementations.ts
+++ b/src/goImplementations.ts
@@ -33,7 +33,8 @@ export class GoImplementationProvider implements vscode.ImplementationProvider {
 				return resolve(null);
 			}
 			let env = getToolsEnvVars();
-			let listProcess = cp.execFile(getGoRuntimePath(), ['list', '-e', '-json'], { cwd: vscode.workspace.rootPath, env }, (err, stdout, stderr) => {
+			let cwd = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath;
+			let listProcess = cp.execFile(getGoRuntimePath(), ['list', '-e', '-json'], { cwd, env }, (err, stdout, stderr) => {
 				if (err) {
 					return reject(err);
 				}
@@ -43,7 +44,7 @@ export class GoImplementationProvider implements vscode.ImplementationProvider {
 				let cwd = path.dirname(filename);
 				let offset = byteOffsetAt(document, position);
 				let goGuru = getBinPath('guru');
-				let buildTags = '"' + vscode.workspace.getConfiguration('go')['buildTags'] + '"';
+				let buildTags = '"' + vscode.workspace.getConfiguration('go', document.uri)['buildTags'] + '"';
 				let args = ['-scope', `${scope}/...`, '-json', '-tags', buildTags, 'implements', `${filename}:#${offset.toString()}`];
 
 				let guruProcess = cp.execFile(goGuru, args, {env}, (err, stdout, stderr) => {

--- a/src/goImplementations.ts
+++ b/src/goImplementations.ts
@@ -33,7 +33,7 @@ export class GoImplementationProvider implements vscode.ImplementationProvider {
 				return resolve(null);
 			}
 			let env = getToolsEnvVars();
-			let cwd = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath;
+			let cwd = vscode.workspace.getWorkspaceFolder(document.uri).uri.fsPath;
 			let listProcess = cp.execFile(getGoRuntimePath(), ['list', '-e', '-json'], { cwd, env }, (err, stdout, stderr) => {
 				if (err) {
 					return reject(err);

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -39,7 +39,7 @@ const allTools: { [key: string]: string } = {
 	'megacheck': 'honnef.co/go/tools/...',
 	'go-langserver': 'github.com/sourcegraph/go-langserver',
 	'dlv': 'github.com/derekparker/delve/cmd/dlv'
-}
+};
 
 function getTools(goVersion: SemVersion): string[] {
 	let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
@@ -248,7 +248,7 @@ function installTools(goVersion: SemVersion, missing?: string[]) {
 }
 
 export function updateGoPathGoRootFromConfig(): Promise<void> {
-	let goroot = vscode.workspace.getConfiguration('go')['goroot'];
+	let goroot = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null)['goroot'];
 	if (goroot) {
 		process.env['GOROOT'] = goroot;
 	}

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -346,18 +346,8 @@ function allFoldersHaveSameGopath(): boolean {
 		return true;
 	}
 
-	let sameGopath = true;
 	let tempGopath = getCurrentGoPath(vscode.workspace.workspaceFolders[0].uri);
-
-	for (let i = 1; i < vscode.workspace.workspaceFolders.length; i++) {
-		let gopath = getCurrentGoPath(vscode.workspace.workspaceFolders[i].uri);
-		if (tempGopath !== gopath) {
-			sameGopath = false;
-			break;
-		}
-	}
-
-	return sameGopath;
+	return vscode.workspace.workspaceFolders.find(x => tempGopath !== getCurrentGoPath(x.uri)) ? false: true;
 }
 
 

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -347,7 +347,7 @@ function allFoldersHaveSameGopath(): boolean {
 	}
 
 	let tempGopath = getCurrentGoPath(vscode.workspace.workspaceFolders[0].uri);
-	return vscode.workspace.workspaceFolders.find(x => tempGopath !== getCurrentGoPath(x.uri)) ? false: true;
+	return vscode.workspace.workspaceFolders.find(x => tempGopath !== getCurrentGoPath(x.uri)) ? false : true;
 }
 
 

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -299,7 +299,7 @@ function getMissingTools(goVersion: SemVersion): Promise<string[]> {
 // If langserver needs to be used, and is installed, this will return true
 // Returns false in all other cases
 export function checkLanguageServer(): boolean {
-	if (process.platform === 'win32') return false;
+	if (process.platform === 'win32' || !allFoldersHaveSameGopath()) return false;
 	let latestGoConfig = vscode.workspace.getConfiguration('go');
 	if (!latestGoConfig['useLanguageServer']) return false;
 
@@ -309,6 +309,25 @@ export function checkLanguageServer(): boolean {
 		vscode.window.showInformationMessage('Reload VS Code window after installing the Go language server');
 	}
 	return langServerAvailable;
+}
+
+function allFoldersHaveSameGopath(): boolean {
+	if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length <= 1) {
+		return true;
+	}
+
+	let sameGopath = true;
+	let tempGopath = getCurrentGoPath(vscode.workspace.workspaceFolders[0].uri);
+
+	for (let i = 1; i < vscode.workspace.workspaceFolders.length; i++) {
+		let gopath = getCurrentGoPath(vscode.workspace.workspaceFolders[i].uri);
+		if (tempGopath !== gopath) {
+			sameGopath = false;
+			break;
+		}
+	}
+
+	return sameGopath;
 }
 
 

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -18,58 +18,81 @@ import { goLiveErrorsEnabled } from './goLiveErrors';
 
 let updatesDeclinedTools: string[] = [];
 let installsDeclinedTools: string[] = [];
+const allTools: { [key: string]: string } = {
+	'gocode': 'github.com/nsf/gocode',
+	'gopkgs': 'github.com/tpng/gopkgs',
+	'go-outline': 'github.com/ramya-rao-a/go-outline',
+	'go-symbols': 'github.com/acroca/go-symbols',
+	'guru': 'golang.org/x/tools/cmd/guru',
+	'gorename': 'golang.org/x/tools/cmd/gorename',
+	'gomodifytags': 'github.com/fatih/gomodifytags',
+	'impl': 'github.com/josharian/impl',
+	'gotype-live': 'github.com/tylerb/gotype-live',
+	'godef': 'github.com/rogpeppe/godef',
+	'godoc': 'golang.org/x/tools/cmd/godoc',
+	'gogetdoc': 'github.com/zmb3/gogetdoc',
+	'goimports': 'golang.org/x/tools/cmd/goimports',
+	'goreturns': 'sourcegraph.com/sqs/goreturns',
+	'golint': 'github.com/golang/lint/golint',
+	'gotests': 'github.com/cweill/gotests/...',
+	'gometalinter': 'github.com/alecthomas/gometalinter',
+	'megacheck': 'honnef.co/go/tools/...',
+	'go-langserver': 'github.com/sourcegraph/go-langserver',
+	'dlv': 'github.com/derekparker/delve/cmd/dlv'
+}
 
-function getTools(goVersion: SemVersion): { [key: string]: string } {
-	let goConfig = vscode.workspace.getConfiguration('go');
-	let tools: { [key: string]: string } = {
-		'gocode': 'github.com/nsf/gocode',
-		'gopkgs': 'github.com/tpng/gopkgs',
-		'go-outline': 'github.com/ramya-rao-a/go-outline',
-		'go-symbols': 'github.com/acroca/go-symbols',
-		'guru': 'golang.org/x/tools/cmd/guru',
-		'gorename': 'golang.org/x/tools/cmd/gorename',
-		'gomodifytags': 'github.com/fatih/gomodifytags',
-		'impl': 'github.com/josharian/impl'
-	};
+function getTools(goVersion: SemVersion): string[] {
+	let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
+	let tools: string[] = [
+		'gocode',
+		'gopkgs',
+		'go-outline',
+		'go-symbols',
+		'guru',
+		'gorename',
+		'gomodifytags',
+		'impl'
+	];
+
 	if (goLiveErrorsEnabled()) {
-		tools['gotype-live'] = 'github.com/tylerb/gotype-live';
+		tools.push('gotype-live');
 	}
 
 	// Install the doc/def tool that was chosen by the user
 	if (goConfig['docsTool'] === 'godoc') {
-		tools['godef'] = 'github.com/rogpeppe/godef';
-		tools['godoc'] = 'golang.org/x/tools/cmd/godoc';
+		tools.push('godef');
+		tools.push('godoc');
 	} else if (goConfig['docsTool'] === 'gogetdoc') {
-		tools['gogetdoc'] = 'github.com/zmb3/gogetdoc';
+		tools.push('gogetdoc');
 	}
 
 	// Install the formattool that was chosen by the user
 	if (goConfig['formatTool'] === 'goimports') {
-		tools['goimports'] = 'golang.org/x/tools/cmd/goimports';
+		tools.push('goimports');
 	} else if (goConfig['formatTool'] === 'goreturns') {
-		tools['goreturns'] = 'sourcegraph.com/sqs/goreturns';
+		tools.push('goreturns');
 	}
 
 	// golint and gotests are not supported in go1.5
 	if (!goVersion || (goVersion.major > 1 || (goVersion.major === 1 && goVersion.minor > 5))) {
-		tools['golint'] = 'github.com/golang/lint/golint';
-		tools['gotests'] = 'github.com/cweill/gotests/...';
+		tools.push('golint');
+		tools.push('gotests');
 	}
 
 	if (goConfig['lintTool'] === 'gometalinter') {
-		tools['gometalinter'] = 'github.com/alecthomas/gometalinter';
+		tools.push('gometalinter');
 	}
 
 	if (goConfig['lintTool'] === 'megacheck') {
-		tools['megacheck'] = 'honnef.co/go/tools/...';
+		tools.push('megacheck');
 	}
 
 	if (goConfig['useLanguageServer'] && process.platform !== 'win32') {
-		tools['go-langserver'] = 'github.com/sourcegraph/go-langserver';
+		tools.push('go-langserver');
 	}
 
 	if (process.platform !== 'darwin') {
-		tools['dlv'] = 'github.com/derekparker/delve/cmd/dlv';
+		tools.push('dlv');
 	}
 	return tools;
 }
@@ -95,7 +118,7 @@ export function promptForMissingTool(tool: string) {
 			}
 		}
 
-		vscode.window.showInformationMessage(`The "${tool}" command is not available.  Use "go get -v ${getTools(goVersion)[tool]}" to install.`, 'Install', 'Install All').then(selected => {
+		vscode.window.showInformationMessage(`The "${tool}" command is not available.  Use "go get -v ${allTools[tool]}" to install.`, 'Install', 'Install All').then(selected => {
 			if (selected === 'Install') {
 				installTools(goVersion, [tool]);
 			} else if (selected === 'Install All') {
@@ -114,7 +137,7 @@ export function promptForUpdatingTool(tool: string) {
 		return;
 	}
 	getGoVersion().then((goVersion) => {
-		vscode.window.showInformationMessage(`The Go extension is better with the latest version of "${tool}". Use "go get -u -v ${getTools(goVersion)[tool]}" to update`, 'Update').then(selected => {
+		vscode.window.showInformationMessage(`The Go extension is better with the latest version of "${tool}". Use "go get -u -v ${allTools[tool]}" to update`, 'Update').then(selected => {
 			if (selected === 'Update') {
 				installTools(goVersion, [tool]);
 			} else {
@@ -130,14 +153,13 @@ export function promptForUpdatingTool(tool: string) {
  * @param string[] array of tool names to be installed
  */
 function installTools(goVersion: SemVersion, missing?: string[]) {
-	let tools = getTools(goVersion);
 	let goRuntimePath = getGoRuntimePath();
 	if (!goRuntimePath) {
 		vscode.window.showInformationMessage('Cannot find "go" binary. Update PATH or GOROOT appropriately');
 		return;
 	}
 	if (!missing) {
-		missing = Object.keys(tools);
+		missing = getTools(goVersion);
 	}
 
 	// http.proxy setting takes precedence over environment variables
@@ -179,13 +201,13 @@ function installTools(goVersion: SemVersion, missing?: string[]) {
 
 	missing.reduce((res: Promise<string[]>, tool: string) => {
 		return res.then(sofar => new Promise<string[]>((resolve, reject) => {
-			cp.execFile(goRuntimePath, ['get', '-u', '-v', tools[tool]], { env: envForTools }, (err, stdout, stderr) => {
+			cp.execFile(goRuntimePath, ['get', '-u', '-v', allTools[tool]], { env: envForTools }, (err, stdout, stderr) => {
 				if (err) {
-					outputChannel.appendLine('Installing ' + tools[tool] + ' FAILED');
+					outputChannel.appendLine('Installing ' + allTools[tool] + ' FAILED');
 					let failureReason = tool + ';;' + err + stdout.toString() + stderr.toString();
 					resolve([...sofar, failureReason]);
 				} else {
-					outputChannel.appendLine('Installing ' + tools[tool] + ' SUCCEEDED');
+					outputChannel.appendLine('Installing ' + allTools[tool] + ' SUCCEEDED');
 					if (tool === 'gometalinter') {
 						// Gometalinter needs to install all the linters it uses.
 						outputChannel.appendLine('Installing all linters used by gometalinter....');
@@ -283,7 +305,7 @@ export function offerToInstallTools() {
 }
 
 function getMissingTools(goVersion: SemVersion): Promise<string[]> {
-	let keys = Object.keys(getTools(goVersion));
+	let keys = getTools(goVersion);
 	return Promise.all<string>(keys.map(tool => new Promise<string>((resolve, reject) => {
 		let toolPath = getBinPath(tool);
 		fs.exists(toolPath, exists => {
@@ -307,7 +329,7 @@ export function checkLanguageServer(): boolean {
 		vscode.window.showInformationMessage('The Go language server is not supported in a multi root set up with different GOPATHs.');
 		return false;
 	}
-	
+
 	let latestGoConfig = vscode.workspace.getConfiguration('go');
 	if (!latestGoConfig['useLanguageServer']) return false;
 

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -299,7 +299,15 @@ function getMissingTools(goVersion: SemVersion): Promise<string[]> {
 // If langserver needs to be used, and is installed, this will return true
 // Returns false in all other cases
 export function checkLanguageServer(): boolean {
-	if (process.platform === 'win32' || !allFoldersHaveSameGopath()) return false;
+	if (process.platform === 'win32') {
+		vscode.window.showInformationMessage('The Go language server is not supported on Windows yet.');
+		return false;
+	}
+	if (!allFoldersHaveSameGopath()) {
+		vscode.window.showInformationMessage('The Go language server is not supported in a multi root set up with different GOPATHs.');
+		return false;
+	}
+	
 	let latestGoConfig = vscode.workspace.getConfiguration('go');
 	if (!latestGoConfig['useLanguageServer']) return false;
 

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -49,7 +49,7 @@ export function parseLiveFile(e: vscode.TextDocumentChangeEvent) {
 	runner = setTimeout(function(){
 		processFile(e);
 		runner = null;
-	}, vscode.workspace.getConfiguration('go')['liveErrors']['delay']);
+	}, vscode.workspace.getConfiguration('go', e.document.uri)['liveErrors']['delay']);
 }
 
 // processFile does the actual work once the timeout has fired

--- a/src/goLiveErrors.ts
+++ b/src/goLiveErrors.ts
@@ -16,7 +16,7 @@ interface GoLiveErrorsConfig {
 let runner;
 
 export function goLiveErrorsEnabled() {
-	let goConfig = <GoLiveErrorsConfig>vscode.workspace.getConfiguration('go')['liveErrors'];
+	let goConfig = <GoLiveErrorsConfig>vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null)['liveErrors'];
 	if (goConfig === null || goConfig === undefined || !goConfig.enabled) {
 		return false;
 	}

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -29,7 +29,7 @@ import { showTestOutput } from './testUtils';
 import * as goGenerateTests from './goGenerateTests';
 import { addImport } from './goImport';
 import { installAllTools, checkLanguageServer } from './goInstallTools';
-import { isGoPathSet, getBinPath, sendTelemetryEvent, getExtensionCommands, getGoVersion, getCurrentGoPath } from './util';
+import { isGoPathSet, getBinPath, sendTelemetryEvent, getExtensionCommands, getGoVersion, getCurrentGoPath, getToolsGopath } from './util';
 import { LanguageClient } from 'vscode-languageclient';
 import { clearCacheForTools } from './goPath';
 import { addTags, removeTags } from './goModifytags';
@@ -45,7 +45,6 @@ let warningDiagnosticCollection: vscode.DiagnosticCollection;
 export function activate(ctx: vscode.ExtensionContext): void {
 	let useLangServer = vscode.workspace.getConfiguration('go')['useLanguageServer'];
 	let langServerFlags: string[] = vscode.workspace.getConfiguration('go')['languageServerFlags'] || [];
-	let toolsGopath = vscode.workspace.getConfiguration('go')['toolsGopath'];
 
 	updateGoPathGoRootFromConfig().then(() => {
 		getGoVersion().then(currentVersion => {
@@ -134,7 +133,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 		// not only if it was configured, but if it was successful.
 		if (wasInfered && root.indexOf(gopath) === 0) {
-			const inferredFrom = vscode.window.activeTextEditor ? 'current folder': 'workspace root';
+			const inferredFrom = vscode.window.activeTextEditor ? 'current folder' : 'workspace root';
 			vscode.window.showInformationMessage(`Current GOPATH is inferred from ${inferredFrom}: ${gopath}`);
 		} else {
 			vscode.window.showInformationMessage('Current GOPATH: ' + gopath);
@@ -215,9 +214,8 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		useLangServer = updatedGoConfig['useLanguageServer'];
 
 		// If there was a change in "toolsGopath" setting, then clear cache for go tools
-		if (toolsGopath !== updatedGoConfig['toolsGopath']) {
+		if (getToolsGopath() !== getToolsGopath(false)) {
 			clearCacheForTools();
-			toolsGopath = updatedGoConfig['toolsGopath'];
 		}
 
 	}));
@@ -276,7 +274,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
 	});
 
-	sendTelemetryEventForConfig(vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri: null));
+	sendTelemetryEventForConfig(vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null));
 }
 
 function deactivate() {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -127,7 +127,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		let gopath = getCurrentGoPath();
 
 		let wasInfered = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null)['inferGopath'];
-		let root = vscode.window.activeTextEditor ? vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath : vscode.workspace.rootPath;
+		let root = vscode.window.activeTextEditor ? (vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) || vscode.window.activeTextEditor.document).uri.fsPath : vscode.workspace.rootPath;
 
 		// not only if it was configured, but if it was successful.
 		if (wasInfered && root.indexOf(gopath) === 0) {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -168,7 +168,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.workspace', (args) => {
-		let goConfig = vscode.workspace.getConfiguration('go');
+		let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
 		testWorkspace(goConfig, args);
 	}));
 
@@ -197,7 +197,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	}));
 
 	ctx.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {
-		let updatedGoConfig = vscode.workspace.getConfiguration('go');
+		let updatedGoConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
 		sendTelemetryEventForConfig(updatedGoConfig);
 		updateGoPathGoRootFromConfig();
 

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -101,7 +101,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		}
 
 		if (vscode.window.activeTextEditor && isGoPathSet()) {
-			runBuilds(vscode.window.activeTextEditor.document, vscode.workspace.getConfiguration('go'));
+			runBuilds(vscode.window.activeTextEditor.document, vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor.document.uri));
 		}
 	});
 
@@ -128,11 +128,14 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.gopath', () => {
 		let gopath = getCurrentGoPath();
-		let wasInfered = vscode.workspace.getConfiguration('go')['inferGopath'];
+
+		let wasInfered = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null)['inferGopath'];
+		let root = vscode.window.activeTextEditor ? vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath : vscode.workspace.rootPath;
 
 		// not only if it was configured, but if it was successful.
-		if (wasInfered && vscode.workspace.rootPath.indexOf(gopath) === 0) {
-			vscode.window.showInformationMessage('Current GOPATH is inferred from workspace root: ' + gopath);
+		if (wasInfered && root.indexOf(gopath) === 0) {
+			const inferredFrom = vscode.window.activeTextEditor ? 'current folder': 'workspace root';
+			vscode.window.showInformationMessage(`Current GOPATH is inferred from ${inferredFrom}: ${gopath}`);
 		} else {
 			vscode.window.showInformationMessage('Current GOPATH: ' + gopath);
 		}
@@ -151,17 +154,17 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.cursor', (args) => {
-		let goConfig = vscode.workspace.getConfiguration('go');
+		let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
 		testAtCursor(goConfig, args);
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.package', (args) => {
-		let goConfig = vscode.workspace.getConfiguration('go');
+		let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
 		testCurrentPackage(goConfig, args);
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.file', (args) => {
-		let goConfig = vscode.workspace.getConfiguration('go');
+		let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
 		testCurrentFile(goConfig, args);
 	}));
 
@@ -273,7 +276,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
 	});
 
-	sendTelemetryEventForConfig(vscode.workspace.getConfiguration('go'));
+	sendTelemetryEventForConfig(vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri: null));
 }
 
 function deactivate() {
@@ -294,7 +297,7 @@ function runBuilds(document: vscode.TextDocument, goConfig: vscode.WorkspaceConf
 	}
 
 	let uri = document.uri;
-	check(uri.fsPath, goConfig).then(errors => {
+	check(uri, goConfig).then(errors => {
 		errorDiagnosticCollection.clear();
 		warningDiagnosticCollection.clear();
 
@@ -344,7 +347,7 @@ function startBuildOnSaveWatcher(subscriptions: vscode.Disposable[]) {
 		if (document.languageId !== 'go' || ignoreNextSave.has(document)) {
 			return;
 		}
-		let goConfig = vscode.workspace.getConfiguration('go');
+		let goConfig = vscode.workspace.getConfiguration('go', document.uri);
 		let textEditor = vscode.window.activeTextEditor;
 		let formatPromise: PromiseLike<void> = Promise.resolve();
 		if (goConfig['formatOnSave'] && textEditor.document === document) {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -127,10 +127,13 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		let gopath = getCurrentGoPath();
 
 		let wasInfered = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null)['inferGopath'];
-		let root = vscode.window.activeTextEditor ? (vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) || vscode.window.activeTextEditor.document).uri.fsPath : vscode.workspace.rootPath;
+		let root = vscode.workspace.rootPath;
+		if (vscode.window.activeTextEditor && vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)) {
+			root = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath;
+		}
 
 		// not only if it was configured, but if it was successful.
-		if (wasInfered && root.indexOf(gopath) === 0) {
+		if (wasInfered && root && root.indexOf(gopath) === 0) {
 			const inferredFrom = vscode.window.activeTextEditor ? 'current folder' : 'workspace root';
 			vscode.window.showInformationMessage(`Current GOPATH is inferred from ${inferredFrom}: ${gopath}`);
 		} else {

--- a/src/goModifytags.ts
+++ b/src/goModifytags.ts
@@ -30,7 +30,7 @@ export function addTags(commandArgs: GoTagsConfig) {
 		return;
 	}
 
-	getTagsAndOptions(<GoTagsConfig>vscode.workspace.getConfiguration('go')['addTags'], commandArgs).then(([tags, options, transformValue]) => {
+	getTagsAndOptions(<GoTagsConfig>vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor.document.uri)['addTags'], commandArgs).then(([tags, options, transformValue]) => {
 		if (!tags && !options) {
 			return;
 		}
@@ -57,7 +57,7 @@ export function removeTags(commandArgs: GoTagsConfig) {
 		return;
 	}
 
-	getTagsAndOptions(<GoTagsConfig>vscode.workspace.getConfiguration('go')['removeTags'], commandArgs).then(([tags, options]) => {
+	getTagsAndOptions(<GoTagsConfig>vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor.document.uri)['removeTags'], commandArgs).then(([tags, options]) => {
 		if (!tags && !options) {
 			args.push('--clear-tags');
 			args.push('--clear-options');

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -100,7 +100,7 @@ export class GoDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 	};
 
 	private convertToCodeSymbols(document: vscode.TextDocument, decls: GoOutlineDeclaration[], symbols: vscode.SymbolInformation[], containerName: string): void {
-		let gotoSymbolConfig = vscode.workspace.getConfiguration('go')['gotoSymbol'];
+		let gotoSymbolConfig = vscode.workspace.getConfiguration('go', document.uri)['gotoSymbol'];
 		let includeImports = gotoSymbolConfig ? gotoSymbolConfig['includeImports'] : false;
 		decls.forEach(decl => {
 			if (!includeImports && decl.type === 'import') return;

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -148,6 +148,10 @@ export function parseEnvFile(path: string): { [key: string]: string } {
 
 // Walks up given folder path to return the closest ancestor that has `src` as a child
 export function getInferredGopath(folderPath: string): string {
+	if (!folderPath) {
+		return;
+	}
+
 	let dirs = folderPath.toLowerCase().split(path.sep);
 
 	// find src directory closest to given folder path

--- a/src/goReferences.ts
+++ b/src/goReferences.ts
@@ -31,7 +31,7 @@ export class GoReferenceProvider implements vscode.ReferenceProvider {
 			let offset = byteOffsetAt(document, position);
 			let env = getToolsEnvVars();
 			let goGuru = getBinPath('guru');
-			let buildTags = '"' + vscode.workspace.getConfiguration('go')['buildTags'] + '"';
+			let buildTags = '"' + vscode.workspace.getConfiguration('go', document.uri)['buildTags'] + '"';
 
 			let process = cp.execFile(goGuru, ['-modified', '-tags', buildTags, 'referrers', `${filename}:#${offset.toString()}`], {env}, (err, stdout, stderr) => {
 				try {

--- a/src/goRename.ts
+++ b/src/goRename.ts
@@ -27,7 +27,7 @@ export class GoRenameProvider implements vscode.RenameProvider {
 			let offset = byteOffsetAt(document, pos);
 			let env = getToolsEnvVars();
 			let gorename = getBinPath('gorename');
-			let buildTags = '"' + vscode.workspace.getConfiguration('go')['buildTags'] + '"';
+			let buildTags = '"' + vscode.workspace.getConfiguration('go', document.uri)['buildTags'] + '"';
 			let gorenameArgs = ['-offset', filename + ':#' + offset, '-to', newName, '-tags', buildTags];
 			let canRenameToolUseDiff = isDiffToolAvailable();
 			if (canRenameToolUseDiff) {

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -24,7 +24,7 @@ export class GoRunTestCodeLensProvider implements CodeLensProvider {
 			};
 
 	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
-		let config = vscode.workspace.getConfiguration('go');
+		let config = vscode.workspace.getConfiguration('go', document.uri);
 		let codeLensConfig = config.get('enableCodeLens');
 		let codelensEnabled = codeLensConfig ? codeLensConfig['runtest'] : false;
 		if (!codelensEnabled || !document.fileName.endsWith('_test.go')) {

--- a/src/goSignature.ts
+++ b/src/goSignature.ts
@@ -19,7 +19,6 @@ export class GoSignatureHelpProvider implements SignatureHelpProvider {
 	}
 
 	public provideSignatureHelp(document: TextDocument, position: Position, token: CancellationToken): Promise<SignatureHelp> {
-		let goConfig = this.goConfig;
 		if (!this.goConfig) {
 			this.goConfig = vscode.workspace.getConfiguration('go', document.uri);
 		}
@@ -30,6 +29,7 @@ export class GoSignatureHelpProvider implements SignatureHelpProvider {
 		}
 		let callerPos = this.previousTokenPosition(document, theCall.openParen);
 		// Temporary fix to fall back to godoc if guru is the set docsTool
+		let goConfig = this.goConfig;
 		if (goConfig['docsTool'] === 'guru') {
 			goConfig = Object.assign({}, goConfig, { 'docsTool': 'godoc' });
 		}

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -41,7 +41,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 	private pkgsList = new Map<string, string>();
 
 	public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.CompletionItem[]> {
-		return this.provideCompletionItemsInternal(document, position, token, vscode.workspace.getConfiguration('go'));
+		return this.provideCompletionItemsInternal(document, position, token, vscode.workspace.getConfiguration('go', document.uri));
 	}
 
 	public provideCompletionItemsInternal(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, config: vscode.WorkspaceConfiguration): Thenable<vscode.CompletionItem[]> {
@@ -180,7 +180,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 									suggest.name
 								);
 							}
-							let conf = vscode.workspace.getConfiguration('go');
+							let conf = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
 							if (conf.get('useCodeSnippetsOnFunctionSuggest') && suggest.class === 'func') {
 								let params = parameters(suggest.type.substring(4));
 								let paramSnippets = [];
@@ -226,7 +226,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				return resolve();
 			}
 			let gocode = getBinPath('gocode');
-			let autobuild = vscode.workspace.getConfiguration('go')['gocodeAutoBuild'];
+			let autobuild = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null)['gocodeAutoBuild'];
 			let env = getToolsEnvVars();
 			cp.execFile(gocode, ['set', 'propose-builtins', 'true'], { env }, (err, stdout, stderr) => {
 				cp.execFile(gocode, ['set', 'autobuild', autobuild], {}, (err, stdout, stderr) => {

--- a/src/goSymbol.ts
+++ b/src/goSymbol.ts
@@ -47,7 +47,7 @@ export class GoWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider
 				symbols.push(symbolInfo);
 			});
 		};
-		let root = vscode.window.activeTextEditor ? vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath : vscode.workspace.rootPath;
+		let root = vscode.window.activeTextEditor ? (vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) || vscode.window.activeTextEditor.document).uri.fsPath : vscode.workspace.rootPath;
 
 		return getWorkspaceSymbols(root, query).then(results => {
 			let symbols: vscode.SymbolInformation[] = [];

--- a/src/goSymbol.ts
+++ b/src/goSymbol.ts
@@ -47,7 +47,14 @@ export class GoWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider
 				symbols.push(symbolInfo);
 			});
 		};
-		let root = vscode.window.activeTextEditor ? (vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) || vscode.window.activeTextEditor.document).uri.fsPath : vscode.workspace.rootPath;
+		let root = vscode.workspace.rootPath;
+		if (vscode.window.activeTextEditor && vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)) {
+			root = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath;
+		}
+		if (!root) {
+			vscode.window.showInformationMessage('No workspace is open to find symbols.');
+			return;
+		}
 
 		return getWorkspaceSymbols(root, query).then(results => {
 			let symbols: vscode.SymbolInformation[] = [];

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -115,9 +115,17 @@ export function testCurrentPackage(goConfig: vscode.WorkspaceConfiguration, args
  * @param goConfig Configuration for the Go extension.
  */
 export function testWorkspace(goConfig: vscode.WorkspaceConfiguration, args: any) {
+	let dir = vscode.workspace.rootPath;
+	if (vscode.window.activeTextEditor && vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)) {
+		dir = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath;
+	}
+	if (!dir) {
+		vscode.window.showInformationMessage('No workspace is open to run tests.');
+		return;
+	}
 	const testConfig = {
 		goConfig: goConfig,
-		dir: vscode.window.activeTextEditor ? (vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) || vscode.window.activeTextEditor.document).uri.fsPath : vscode.workspace.rootPath,
+		dir: dir,
 		flags: getTestFlags(goConfig, args),
 		includeSubDirectories: true
 	};

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -117,7 +117,7 @@ export function testCurrentPackage(goConfig: vscode.WorkspaceConfiguration, args
 export function testWorkspace(goConfig: vscode.WorkspaceConfiguration, args: any) {
 	const testConfig = {
 		goConfig: goConfig,
-		dir: vscode.window.activeTextEditor ? vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath : vscode.workspace.rootPath,
+		dir: vscode.window.activeTextEditor ? (vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) || vscode.window.activeTextEditor.document).uri.fsPath : vscode.workspace.rootPath,
 		flags: getTestFlags(goConfig, args),
 		includeSubDirectories: true
 	};

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -117,7 +117,7 @@ export function testCurrentPackage(goConfig: vscode.WorkspaceConfiguration, args
 export function testWorkspace(goConfig: vscode.WorkspaceConfiguration, args: any) {
 	const testConfig = {
 		goConfig: goConfig,
-		dir: vscode.workspace.rootPath,
+		dir: vscode.window.activeTextEditor ? vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath : vscode.workspace.rootPath,
 		flags: getTestFlags(goConfig, args),
 		includeSubDirectories: true
 	};

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -202,7 +202,7 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 			if (ver && (ver.major > 1 || (ver.major === 1 && ver.minor >= 9))) {
 				return ['./...'];
 			}
-			return getNonVendorPackages(vscode.workspace.rootPath);
+			return getNonVendorPackages(testconfig.dir);
 		});
 	}
 	return Promise.resolve([]);

--- a/src/util.ts
+++ b/src/util.ts
@@ -309,8 +309,8 @@ export function getToolsEnvVars(): any {
 }
 
 export function getCurrentGoPath(workspaceUri?: vscode.Uri): string {
-	if (!workspaceUri && vscode.window.activeTextEditor && vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)) {
-		workspaceUri = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri;
+	if (!workspaceUri && vscode.window.activeTextEditor) {
+		workspaceUri = (vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) || vscode.window.activeTextEditor.document).uri;
 	}
 	const config = vscode.workspace.getConfiguration('go', workspaceUri);
 	const currentRoot = workspaceUri ? workspaceUri.fsPath : vscode.workspace.rootPath;

--- a/src/util.ts
+++ b/src/util.ts
@@ -379,10 +379,15 @@ export function timeout(millis): Promise<void> {
  */
 export function resolvePath(inputPath: string, workspaceRoot?: string): string {
 	if (!inputPath || !inputPath.trim()) return inputPath;
-	if (!workspaceRoot && vscode.window.activeTextEditor && vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)) {
-		workspaceRoot = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath;
+
+	if (!workspaceRoot && vscode.workspace.workspaceFolders) {
+		if (vscode.workspace.workspaceFolders.length === 1) {
+			workspaceRoot = vscode.workspace.rootPath;
+		} else if (vscode.window.activeTextEditor && vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)) {
+			workspaceRoot = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath;
+		}
 	}
-	workspaceRoot = workspaceRoot || vscode.workspace.rootPath;
+
 	if (workspaceRoot) {
 		inputPath = inputPath.replace(/\${workspaceRoot}/g, vscode.workspace.rootPath);
 	}

--- a/src/util.ts
+++ b/src/util.ts
@@ -309,8 +309,8 @@ export function getToolsEnvVars(): any {
 }
 
 export function getCurrentGoPath(workspaceUri?: vscode.Uri): string {
-	if (!workspaceUri && vscode.window.activeTextEditor) {
-		workspaceUri = (vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) || vscode.window.activeTextEditor.document).uri;
+	if (!workspaceUri && vscode.window.activeTextEditor && vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)) {
+		workspaceUri = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri;
 	}
 	const config = vscode.workspace.getConfiguration('go', workspaceUri);
 	const currentRoot = workspaceUri ? workspaceUri.fsPath : vscode.workspace.rootPath;
@@ -389,7 +389,7 @@ export function resolvePath(inputPath: string, workspaceRoot?: string): string {
 	}
 
 	if (workspaceRoot) {
-		inputPath = inputPath.replace(/\${workspaceRoot}/g, vscode.workspace.rootPath);
+		inputPath = inputPath.replace(/\${workspaceRoot}/g, workspaceRoot);
 	}
 	return resolveHomeDir(inputPath);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -262,7 +262,7 @@ function resolveToolsGopath(): string {
 	let toolsGopathForWorkspace = vscode.workspace.getConfiguration('go')['toolsGopath'] || '';
 
 	// In case of single root, use resolvePath to resolve ~ and ${workspaceRoot}
-	if (vscode.workspace.workspaceFolders.length === 1) {
+	if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length <= 1) {
 		return resolvePath(toolsGopathForWorkspace);
 	}
 
@@ -307,10 +307,12 @@ export function getToolsEnvVars(): any {
 	return Object.assign(envVars, toolsEnvVars);
 }
 
-export function getCurrentGoPath(): string {
-	const config = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
-	const currentWorkpace = vscode.window.activeTextEditor ? vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) : null;
-	const currentRoot = currentWorkpace ? currentWorkpace.uri.fsPath : vscode.workspace.rootPath;
+export function getCurrentGoPath(workspaceUri?: vscode.Uri): string {
+	if (!workspaceUri && vscode.window.activeTextEditor && vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)) {
+		workspaceUri = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri;
+	}
+	const config = vscode.workspace.getConfiguration('go', workspaceUri);
+	const currentRoot = workspaceUri ? workspaceUri.fsPath : vscode.workspace.rootPath;
 	const configGopath = config['gopath'] ? resolvePath(config['gopath'], currentRoot) : '';
 	const inferredGopath = config['inferGopath'] === true ? getInferredGopath(currentRoot) : '';
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -309,7 +309,8 @@ export function getToolsEnvVars(): any {
 
 export function getCurrentGoPath(): string {
 	const config = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
-	const currentRoot = vscode.window.activeTextEditor ? vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath : vscode.workspace.rootPath;
+	const currentWorkpace = vscode.window.activeTextEditor ? vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri) : null;
+	const currentRoot = currentWorkpace ? currentWorkpace.uri.fsPath : vscode.workspace.rootPath;
 	const configGopath = config['gopath'] ? resolvePath(config['gopath'], currentRoot) : '';
 	const inferredGopath = config['inferGopath'] === true ? getInferredGopath(currentRoot) : '';
 

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -243,7 +243,7 @@ It returns the number of bytes written and any write error encountered.
 				// golint is not supported in Go 1.5, so skip the test
 				return Promise.resolve();
 			}
-			return check(path.join(fixturePath, 'errorsTest', 'errors.go'), config).then(diagnostics => {
+			return check(vscode.Uri.file(path.join(fixturePath, 'errorsTest', 'errors.go')), config).then(diagnostics => {
 				let sortedDiagnostics = diagnostics.sort((a, b) => a.line - b.line);
 				assert.equal(sortedDiagnostics.length, expected.length, `too many errors ${JSON.stringify(sortedDiagnostics)}`);
 				for (let i in expected) {
@@ -356,7 +356,7 @@ It returns the number of bytes written and any write error encountered.
 				{ line: 12, severity: 'warning', msg: 'error return value not checked (undeclared name: prin) (errcheck)' },
 				{ line: 12, severity: 'warning', msg: 'unused variable or constant undeclared name: prin (varcheck)' },
 			];
-			return check(path.join(fixturePath, 'errorsTest', 'errors.go'), config).then(diagnostics => {
+			return check(vscode.Uri.file(path.join(fixturePath, 'errorsTest', 'errors.go')), config).then(diagnostics => {
 				let sortedDiagnostics = diagnostics.sort((a, b) => {
 					if (a.msg < b.msg)
 						return -1;


### PR DESCRIPTION
#1142 In multi root mode
- All settings except the 2 related to language server can be set at folder level
- toolsGopath set at Workspace level will be used for all folders. If none is set at workpsace level, then the one set at any of the folder level will be used
- Language server (if enabled) will not be used when folders have different GOPATHs
- All commands and features that currently work at workspace level will work at folder level
     - Build/lint/vet/test workspace
     - Go to symbol in workpsace