### PR TITLE
add auto save to tests on test run or debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -565,12 +565,6 @@
           "description": "Flags to pass to `go test`. If null, then buildFlags will be used.",
           "scope": "resource"
         },
-        "go.saveTestFileOnRunOrDebug": {
-          "type": "boolean",
-          "default": true,
-          "description": "Automatically test files when 'Run Test' or 'Debug Test' is run.",
-          "scope": "resource"
-        },
         "go.toolsEnvVars": {
           "type": "object",
           "default": {},

--- a/package.json
+++ b/package.json
@@ -565,6 +565,12 @@
           "description": "Flags to pass to `go test`. If null, then buildFlags will be used.",
           "scope": "resource"
         },
+        "go.saveTestFileOnRunOrDebug": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically test files when 'Run Test' or 'Debug Test' is run.",
+          "scope": "resource"
+        },
         "go.toolsEnvVars": {
           "type": "object",
           "default": {},

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -151,6 +151,7 @@ export function testCurrentFile(goConfig: vscode.WorkspaceConfiguration, args: s
 		return;
 	}
 
+	editor.document.save().then(() => {
 	return getTestFunctions(editor.document).then(testFunctions => {
 		const testConfig = {
 			goConfig: goConfig,
@@ -162,6 +163,7 @@ export function testCurrentFile(goConfig: vscode.WorkspaceConfiguration, args: s
 		lastTestConfig = testConfig;
 
 		return goTest(testConfig);
+		});
 	}).then(null, err => {
 		console.error(err);
 		return Promise.resolve(false);

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -31,15 +31,8 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, args: any)
 		vscode.window.showInformationMessage('No tests found. Current file is not a test file.');
 		return;
 	}
-	if (editor.document.isDirty) {
-		if (goConfig['saveTestFileOnRunOrDebug'] === true) {
-			editor.document.save();
-		} else {
-			vscode.window.showInformationMessage('File has unsaved changes. Save and try again.');
-			return;
-		}
-	}
-	getTestFunctions(editor.document).then(testFunctions => {
+	editor.document.save().then(() => {
+		return getTestFunctions(editor.document).then(testFunctions => {
 		let testFunctionName: string;
 
 		// We use functionName if it was provided as argument
@@ -71,6 +64,7 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, args: any)
 		lastTestConfig = testConfig;
 
 		return goTest(testConfig);
+		});
 	}).then(null, err => {
 		console.error(err);
 	});

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -152,17 +152,17 @@ export function testCurrentFile(goConfig: vscode.WorkspaceConfiguration, args: s
 	}
 
 	editor.document.save().then(() => {
-	return getTestFunctions(editor.document).then(testFunctions => {
-		const testConfig = {
-			goConfig: goConfig,
-			dir: path.dirname(editor.document.fileName),
-			flags: getTestFlags(goConfig, args),
-			functions: testFunctions.map(func => { return func.name; })
-		};
-		// Remember this config as the last executed test.
-		lastTestConfig = testConfig;
+		return getTestFunctions(editor.document).then(testFunctions => {
+			const testConfig = {
+				goConfig: goConfig,
+				dir: path.dirname(editor.document.fileName),
+				flags: getTestFlags(goConfig, args),
+				functions: testFunctions.map(func => { return func.name; })
+			};
+			// Remember this config as the last executed test.
+			lastTestConfig = testConfig;
 
-		return goTest(testConfig);
+			return goTest(testConfig);
 		});
 	}).then(null, err => {
 		console.error(err);

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -32,8 +32,12 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, args: any)
 		return;
 	}
 	if (editor.document.isDirty) {
-		vscode.window.showInformationMessage('File has unsaved changes. Save and try again.');
-		return;
+		if (goConfig['saveTestFileOnRunOrDebug'] === true) {
+			editor.document.save();
+		} else {
+			vscode.window.showInformationMessage('File has unsaved changes. Save and try again.');
+			return;
+		}
 	}
 	getTestFunctions(editor.document).then(testFunctions => {
 		let testFunctionName: string;

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -151,7 +151,7 @@ export function testCurrentFile(goConfig: vscode.WorkspaceConfiguration, args: s
 		return;
 	}
 
-	editor.document.save().then(() => {
+	return editor.document.save().then(() => {
 		return getTestFunctions(editor.document).then(testFunctions => {
 			const testConfig = {
 				goConfig: goConfig,


### PR DESCRIPTION
Fixes #1225 by adding `editor.document.save()` if the document state is dirty. Also adds a `go.saveTestFileOnRunOrDebug` (defaults to `true`) to disable auto save in the case that someone wants to disable this feature.