### PR TITLE
Fix buildFlags type in 'debug test' Codelens

### DIFF
--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -81,8 +81,7 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 				const envFile = vsConfig['testEnvFile'];
 				let buildFlags = getTestFlags(vsConfig, null);
 				if (vsConfig['buildTags'] && buildFlags.indexOf('-tags') === -1) {
-					buildFlags.push('-tags');
-					buildFlags.push(`"${vsConfig['buildTags']}"`);
+					buildFlags.push(`-tags '${vsConfig['buildTags']}'`);
 				}
 
 				let config = Object.assign({}, this.debugConfig, { args, program, env, envFile, buildFlags });

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -81,10 +81,11 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 				const envFile = vsConfig['testEnvFile'];
 				let buildFlags = getTestFlags(vsConfig, null);
 				if (vsConfig['buildTags'] && buildFlags.indexOf('-tags') === -1) {
-					buildFlags.push(`-tags '${vsConfig['buildTags']}'`);
+					buildFlags.push('-tags');
+					buildFlags.push(`${vsConfig['buildTags']}`);
 				}
 
-				let config = Object.assign({}, this.debugConfig, { args, program, env, envFile, buildFlags });
+				let config = Object.assign({}, this.debugConfig, { args, program, env, envFile, buildFlags: buildFlags.map(x => `'${x}'`).join(' ') });
 				let debugTestCmd: Command = {
 					title: 'debug test',
 					command: 'vscode.startDebug',


### PR DESCRIPTION
Make the type of buildArgs executed by Codelens consistent with LaunchRequestArguments.
This fix the problem that `go.buildTags` is ignored by `debug test`.