### PR TITLE
Fixed tests "Error checking" and "Gometalinter error checking"

### DIFF
--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -230,6 +230,7 @@ It returns the number of bytes written and any write error encountered.
 		let config = Object.create(vscode.workspace.getConfiguration('go'), {
 			'vetOnSave': { value: 'package' },
 			'vetFlags': { value: ['-all'] },
+			'lintOnSave': { value: 'package' },
 			'lintTool': { value: 'golint' },
 			'lintFlags': { value: [] }
 		});
@@ -347,6 +348,7 @@ It returns the number of bytes written and any write error encountered.
 			}
 
 			let config = Object.create(vscode.workspace.getConfiguration('go'), {
+				'lintOnSave': { value: 'package' },
 				'lintTool': { value: 'gometalinter' },
 				'lintFlags': { value: ['--disable-all', '--enable=varcheck', '--enable=errcheck'] },
 				'vetOnSave': { value: 'off' },


### PR DESCRIPTION
If user set "go.lintOnSave" to false in User settings, then tests "Error checking" and "Gometalinter error checking" are failed