### PR TITLE
Add snippet for Example functions

### DIFF
--- a/snippets/go.json
+++ b/snippets/go.json
@@ -172,6 +172,10 @@
 			"prefix": "bf",
 			"body": "func Benchmark$1(b *testing.B) {\n\tfor ${2:i} := 0; ${2:i} < b.N; ${2:i}++ {\n\t\t$0\n\t}\n}"
 		},
+		"example function": {
+			"prefix": "ef",
+			"body": "func Example$1() {\n\t$2\n\t//Output:\n\t$3\n}"
+		},
 		"table driven test": {
 			"prefix": "tdt",
 			"body": "func Test$1(t *testing.T) {\n\ttestCases := []struct {\n\t\tdesc\tstring\n\t\t$2\n\t}{\n\t\t{\n\t\t\tdesc: \"$3\",\n\t\t\t$4\n\t\t},\n\t}\n\tfor _, tC := range testCases {\n\t\tt.Run(tC.desc, func(t *testing.T) {\n\t\t\t$0\n\t\t})\n\t}\n}"


### PR DESCRIPTION
This allows VSCode users to create testable Example functions using a short snippet. It's represented by `ef` since we already have `tf` for tests and `bf` for benchmarks.

More on Example functions: https://blog.golang.org/examples.