### PR TITLE
Cancel currently running processes when spawning new ones

### DIFF
--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -24,216 +24,230 @@ export interface GoDefinitionInformation {
 	toolUsed: string;
 }
 
-export function definitionLocation(document: vscode.TextDocument, position: vscode.Position, goConfig: vscode.WorkspaceConfiguration, includeDocs = true): Promise<GoDefinitionInformation> {
-	let wordRange = document.getWordRangeAtPosition(position);
-	let lineText = document.lineAt(position.line).text;
-	let word = wordRange ? document.getText(wordRange) : '';
-	if (!wordRange || lineText.startsWith('//') || isPositionInString(document, position) || word.match(/^\d+.?\d+$/) || goKeywords.indexOf(word) > 0) {
-		return Promise.resolve(null);
-	}
-	if (!goConfig) {
-		goConfig = vscode.workspace.getConfiguration('go', document.uri);
-	}
-	let toolForDocs = goConfig['docsTool'] || 'godoc';
-	let offset = byteOffsetAt(document, position);
-	let env = getToolsEnvVars();
-	return getGoVersion().then((ver: SemVersion) => {
-		// If no Go version can be parsed, it means it's a non-tagged one.
-		// Assume it's > Go 1.5
-		if (toolForDocs === 'godoc' || (ver && (ver.major < 1 || (ver.major === 1 && ver.minor < 6)))) {
-			return definitionLocation_godef(document, position, offset, includeDocs, env);
-		} else if (toolForDocs === 'guru') {
-			return definitionLocation_guru(document, position, offset, env);
+export class DefinitionHelper {
+	private currentRunningProcess: cp.ChildProcess;
+
+	private isPositionValid(document: vscode.TextDocument, position: vscode.Position): boolean {
+		let wordRange = document.getWordRangeAtPosition(position);
+		let lineText = document.lineAt(position.line).text;
+		let word = wordRange ? document.getText(wordRange) : '';
+		if (!wordRange || lineText.startsWith('//') || isPositionInString(document, position) || word.match(/^\d+.?\d+$/) || goKeywords.indexOf(word) > 0) {
+			return false;
 		}
-		return definitionLocation_gogetdoc(document, position, offset, env);
-	});
-}
-
-function definitionLocation_godef(document: vscode.TextDocument, position: vscode.Position, offset: number, includeDocs: boolean, env: any): Promise<GoDefinitionInformation> {
-	let godef = getBinPath('godef');
-	if (!path.isAbsolute(godef)) {
-		return Promise.reject(missingToolMsg + 'godef');
+		return true;
 	}
 
-	return new Promise<GoDefinitionInformation>((resolve, reject) => {
-		// Spawn `godef` process
-		let p = cp.execFile(godef, ['-t', '-i', '-f', document.fileName, '-o', offset.toString()], { env }, (err, stdout, stderr) => {
-			try {
-				if (err && (<any>err).code === 'ENOENT') {
-					return reject(missingToolMsg + 'godef');
-				}
-				if (err) {
-					return reject(err);
-				};
-				let result = stdout.toString();
-				let lines = result.split('\n');
-				let match = /(.*):(\d+):(\d+)/.exec(lines[0]);
-				if (!match) {
-					// TODO: Gotodef on pkg name:
-					// /usr/local/go/src/html/template\n
-					return resolve(null);
-				}
-				let [_, file, line, col] = match;
-				let signature = lines[1];
-				let godoc = getBinPath('godoc');
-				let pkgPath = path.dirname(file);
-				let definitionInformation: GoDefinitionInformation = {
-					file: file,
-					line: +line - 1,
-					column: + col - 1,
-					declarationlines: lines.splice(1),
-					toolUsed: 'godef',
-					doc: null,
-					name: null
-				};
-				if (!includeDocs) {
-					return resolve(definitionInformation);
-				}
-				cp.execFile(godoc, [pkgPath], { env }, (err, stdout, stderr) => {
-					if (err && (<any>err).code === 'ENOENT') {
-						vscode.window.showInformationMessage('The "godoc" command is not available.');
+	private getDefinitionTool(goConfig: vscode.WorkspaceConfiguration) {
+		let toolForDocs = goConfig['docsTool'] || 'godoc';
+		return getGoVersion().then((ver: SemVersion) => {
+			// If no Go version can be parsed, it means it's a non-tagged one.
+			// Assume it's > Go 1.5
+			if (toolForDocs === 'godoc' || (ver && (ver.major < 1 || (ver.major === 1 && ver.minor < 6)))) {
+				return 'godef';
+			}
+			return toolForDocs === 'guru' ? 'guru' : 'gogetdoc';
+		});
+	}
+
+	public cancelCurrentRunningProcess() {
+		if (this.currentRunningProcess) {
+			this.currentRunningProcess.kill();
+		}
+	}
+
+	public definitionLocation(document: vscode.TextDocument, position: vscode.Position, goConfig: vscode.WorkspaceConfiguration, includeDocs = true): Promise<GoDefinitionInformation> {
+		if (!this.isPositionValid(document, position)) {
+			return Promise.resolve(null);
+		}
+
+		goConfig = goConfig || vscode.workspace.getConfiguration('go', document.uri);
+		return this.getDefinitionTool(goConfig).then(tool => {
+			const binaryPath = getBinPath(tool);
+			if (!path.isAbsolute(binaryPath)) {
+				return Promise.reject(missingToolMsg + tool);
+			}
+
+			let buildTags = goConfig['buildTags'];
+			let offset = byteOffsetAt(document, position);
+			let env = getToolsEnvVars();
+			let args: string[];
+			let callback: (stdout: string) => GoDefinitionInformation;
+
+			switch (tool) {
+				case 'godef':
+					args = ['-t', '-i', '-f', document.fileName, '-o', offset.toString()];
+					callback = this.godefCallback;
+					break;
+				case 'guru':
+					args = ['-json', '-modified', 'definition', document.fileName + ':#' + offset.toString()];
+					callback = this.guruCallback;
+					break;
+				case 'gogetdoc':
+					args = ['-u', '-json', '-modified', '-pos', document.fileName + ':#' + offset.toString()];
+					if (buildTags) {
+						args.push('-tags', '"' + buildTags + '"');
 					}
-					let godocLines = stdout.toString().split('\n');
-					let doc = '';
-					let sigName = signature.substring(0, signature.indexOf(' '));
-					let sigParams = signature.substring(signature.indexOf(' func') + 5);
-					let searchSignature = 'func ' + sigName + sigParams;
-					for (let i = 0; i < godocLines.length; i++) {
-						if (godocLines[i] === searchSignature) {
-							while (godocLines[++i].startsWith('    ')) {
-								doc += godocLines[i].substring(4) + '\n';
-							}
-							break;
+					callback = this.gogetdocCallback;
+					break;
+				default:
+					break;
+			}
+
+			if (!args || !callback) {
+				return Promise.resolve(null);
+			}
+
+			this.cancelCurrentRunningProcess();
+			return new Promise<GoDefinitionInformation>((resolve, reject) => {
+				this.currentRunningProcess = cp.execFile(binaryPath, args, { env }, (err, stdout, stderr) => {
+					if (err) {
+						return reject(err);
+					}
+
+					let definitionInformation: GoDefinitionInformation;
+					try {
+						definitionInformation = callback(stdout);
+					} catch (e) {
+						return reject(e);
+					}
+
+					if (tool !== 'godef' || !includeDocs || !definitionInformation.declarationlines || !definitionInformation.declarationlines.length) {
+						return resolve(definitionInformation);
+					}
+
+					// godef doesnt provide docs, so we call godoc
+					let pkgPath = path.dirname(definitionInformation.file);
+					let signature = definitionInformation.declarationlines[0];
+					let godoc = getBinPath('godoc');
+					this.currentRunningProcess = cp.execFile(godoc, [pkgPath], { env }, (err, stdout, stderr) => {
+						if (err && (<any>err).code === 'ENOENT') {
+							vscode.window.showInformationMessage('The "godoc" command is not available.');
+							return resolve(definitionInformation);
 						}
-					}
-					if (doc !== '') {
-						definitionInformation.doc = doc;
-					}
-					return resolve(definitionInformation);
+						try {
+							let godocLines = stdout.toString().split('\n');
+							let doc = '';
+							let sigName = signature.substring(0, signature.indexOf(' '));
+							let sigParams = signature.substring(signature.indexOf(' func') + 5);
+							let searchSignature = 'func ' + sigName + sigParams;
+							for (let i = 0; i < godocLines.length; i++) {
+								if (godocLines[i] === searchSignature) {
+									while (godocLines[++i].startsWith('    ')) {
+										doc += godocLines[i].substring(4) + '\n';
+									}
+									break;
+								}
+							}
+							if (doc !== '') {
+								definitionInformation.doc = doc;
+							}
+						} catch (e) {
+							return reject(e);
+						}
+						return resolve(definitionInformation);
+					});
+					this.currentRunningProcess.on('close', () => { this.currentRunningProcess = null; });
 				});
-			} catch (e) {
-				reject(e);
-			}
+				this.currentRunningProcess.stdin.end(tool === 'godef' ? document.getText() : getFileArchive(document));
+				this.currentRunningProcess.on('close', () => { this.currentRunningProcess = null; });
+			});
 		});
-		p.stdin.end(document.getText());
-	});
-}
-
-function definitionLocation_gogetdoc(document: vscode.TextDocument, position: vscode.Position, offset: number, env: any, useTags: boolean = true): Promise<GoDefinitionInformation> {
-	let gogetdoc = getBinPath('gogetdoc');
-	if (!path.isAbsolute(gogetdoc)) {
-		return Promise.reject(missingToolMsg + 'gogetdoc');
 	}
 
-	return new Promise<GoDefinitionInformation>((resolve, reject) => {
 
-		let gogetdocFlagsWithoutTags = ['-u', '-json', '-modified', '-pos', document.fileName + ':#' + offset.toString()];
-		let buildTags = vscode.workspace.getConfiguration('go', document.uri)['buildTags'];
-		let gogetdocFlags = (buildTags && useTags) ? [...gogetdocFlagsWithoutTags, '-tags', '"' + buildTags + '"'] : gogetdocFlagsWithoutTags;
-		let p = cp.execFile(gogetdoc, gogetdocFlags, { env }, (err, stdout, stderr) => {
-			try {
-				if (err && (<any>err).code === 'ENOENT') {
-					return reject(missingToolMsg + 'gogetdoc');
-				}
-				if (stderr && stderr.startsWith('flag provided but not defined: -tags')) {
-					return definitionLocation_gogetdoc(document, position, offset, env, false);
-				}
-				if (err) {
-					return reject(err);
-				};
-				let goGetDocOutput = <GoGetDocOuput>JSON.parse(stdout.toString());
-				let match = /(.*):(\d+):(\d+)/.exec(goGetDocOutput.pos);
-				let definitionInfo = {
-					file: null,
-					line: 0,
-					column: 0,
-					toolUsed: 'gogetdoc',
-					declarationlines: goGetDocOutput.decl.split('\n'),
-					doc: goGetDocOutput.doc,
-					name: goGetDocOutput.name
-				};
-				if (!match) {
-					return resolve(definitionInfo);
-				}
-				let [_, file, line, col] = match;
-				definitionInfo.file = match[1];
-				definitionInfo.line = +match[2] - 1;
-				definitionInfo.column = +match[3] - 1;
-				return resolve(definitionInfo);
 
-			} catch (e) {
-				reject(e);
-			}
-		});
-		p.stdin.end(getFileArchive(document));
-	});
-}
-
-function definitionLocation_guru(document: vscode.TextDocument, position: vscode.Position, offset: number, env: any): Promise<GoDefinitionInformation> {
-	let guru = getBinPath('guru');
-	if (!path.isAbsolute(guru)) {
-		return Promise.reject(missingToolMsg + 'guru');
+	private godefCallback(stdout: string): GoDefinitionInformation {
+		let result = stdout.toString();
+		let lines = result.split('\n');
+		let match = /(.*):(\d+):(\d+)/.exec(lines[0]);
+		if (!match) {
+			// TODO: Gotodef on pkg name:
+			// /usr/local/go/src/html/template\n
+			return null;
+		}
+		let [_, file, line, col] = match;
+		let signature = lines[1];
+		let godoc = getBinPath('godoc');
+		let pkgPath = path.dirname(file);
+		let definitionInformation: GoDefinitionInformation = {
+			file: file,
+			line: +line - 1,
+			column: + col - 1,
+			declarationlines: lines.splice(1),
+			toolUsed: 'godef',
+			doc: null,
+			name: null
+		};
+		return definitionInformation;
 	}
 
-	return new Promise<GoDefinitionInformation>((resolve, reject) => {
-		let p = cp.execFile(guru, ['-json', '-modified', 'definition', document.fileName + ':#' + offset.toString()], { env }, (err, stdout, stderr) => {
-			try {
-				if (err && (<any>err).code === 'ENOENT') {
-					return reject(missingToolMsg + 'guru');
-				}
-				if (err) {
-					return reject(err);
-				};
-				let guruOutput = <GuruDefinitionOuput>JSON.parse(stdout.toString());
-				let match = /(.*):(\d+):(\d+)/.exec(guruOutput.objpos);
-				let definitionInfo = {
-					file: null,
-					line: 0,
-					column: 0,
-					toolUsed: 'guru',
-					declarationlines: [guruOutput.desc],
-					doc: null,
-					name: null,
-				};
-				if (!match) {
-					return resolve(definitionInfo);
-				}
-				let [_, file, line, col] = match;
-				definitionInfo.file = match[1];
-				definitionInfo.line = +match[2] - 1;
-				definitionInfo.column = +match[3] - 1;
-				return resolve(definitionInfo);
-			} catch (e) {
-				reject(e);
-			}
-		});
-		p.stdin.end(getFileArchive(document));
-	});
-}
+	private guruCallback(stdout: string): GoDefinitionInformation {
+		let guruOutput = <GuruDefinitionOuput>JSON.parse(stdout.toString());
+		let match = /(.*):(\d+):(\d+)/.exec(guruOutput.objpos);
+		let definitionInfo = {
+			file: null,
+			line: 0,
+			column: 0,
+			toolUsed: 'guru',
+			declarationlines: [guruOutput.desc],
+			doc: null,
+			name: null,
+		};
+		if (!match) {
+			return definitionInfo;
+		}
+		let [_, file, line, col] = match;
+		definitionInfo.file = match[1];
+		definitionInfo.line = +match[2] - 1;
+		definitionInfo.column = +match[3] - 1;
+		return definitionInfo;
+	}
 
+	private gogetdocCallback(stdout: string): GoDefinitionInformation {
+		let goGetDocOutput = <GoGetDocOuput>JSON.parse(stdout.toString());
+		let match = /(.*):(\d+):(\d+)/.exec(goGetDocOutput.pos);
+		let definitionInfo = {
+			file: null,
+			line: 0,
+			column: 0,
+			toolUsed: 'gogetdoc',
+			declarationlines: goGetDocOutput.decl.split('\n'),
+			doc: goGetDocOutput.doc,
+			name: goGetDocOutput.name
+		};
+		if (!match) {
+			return definitionInfo;
+		}
+		let [_, file, line, col] = match;
+		definitionInfo.file = match[1];
+		definitionInfo.line = +match[2] - 1;
+		definitionInfo.column = +match[3] - 1;
+		return definitionInfo;
+	}
+}
 
 export class GoDefinitionProvider implements vscode.DefinitionProvider {
 	private goConfig = null;
+	private helper: DefinitionHelper;
 
 	constructor(goConfig?: vscode.WorkspaceConfiguration) {
 		this.goConfig = goConfig;
+		this.helper = new DefinitionHelper();
 	}
 
 	public provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Location> {
-		return definitionLocation(document, position, this.goConfig, false).then(definitionInfo => {
+		token.onCancellationRequested(this.helper.cancelCurrentRunningProcess);
+
+		return this.helper.definitionLocation(document, position, this.goConfig, false).then(definitionInfo => {
 			if (definitionInfo == null || definitionInfo.file == null) return null;
 			let definitionResource = vscode.Uri.file(definitionInfo.file);
 			let pos = new vscode.Position(definitionInfo.line, definitionInfo.column);
 			return new vscode.Location(definitionResource, pos);
 		}, err => {
-			if (err) {
-				// Prompt for missing tool is located here so that the
-				// prompts dont show up on hover or signature help
-				if (typeof err === 'string' && err.startsWith(missingToolMsg)) {
-					promptForMissingTool(err.substr(missingToolMsg.length));
-				} else {
-					console.log(err);
-				}
+			// Prompt for missing tool is located here so that the
+			// prompts dont show up on hover or signature help
+			if (err && typeof err === 'string' && err.startsWith(missingToolMsg)) {
+				promptForMissingTool(err.substr(missingToolMsg.length));
 			}
 			return Promise.resolve(null);
 		});

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -50,8 +50,13 @@ export class DefinitionHelper {
 	}
 
 	public cancelCurrentRunningProcess() {
-		if (this.currentRunningProcess) {
-			this.currentRunningProcess.kill();
+		try {
+			if (this.currentRunningProcess) {
+				this.currentRunningProcess.kill();
+				this.currentRunningProcess = null;
+			}
+		} catch (e) {
+			console.log(e)
 		}
 	}
 
@@ -146,10 +151,8 @@ export class DefinitionHelper {
 						}
 						return resolve(definitionInformation);
 					});
-					this.currentRunningProcess.on('close', () => { this.currentRunningProcess = null; });
 				});
 				this.currentRunningProcess.stdin.end(tool === 'godef' ? document.getText() : getFileArchive(document));
-				this.currentRunningProcess.on('close', () => { this.currentRunningProcess = null; });
 			});
 		});
 	}

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -252,6 +252,7 @@ export class GoDefinitionProvider implements vscode.DefinitionProvider {
 			if (err && typeof err === 'string' && err.startsWith(missingToolMsg)) {
 				promptForMissingTool(err.substr(missingToolMsg.length));
 			}
+			console.log(err);
 			return Promise.resolve(null);
 		});
 	}


### PR DESCRIPTION
Related to #1265

The `DefinitionProvider`, `SignatureProvider` and `HoverProvider` all use the same tools behind the scenes. 
These tools are configured using the `go.docsTool` setting and can be `gogetdoc`, `godef` + `godoc` or `guru`

This PR includes the below features
- When cancellation is requested by VSCode via the `cancellationToken`, kill the currently running process
- Before creating a new process, kill the existing one. But these should not criss-cross among the 3 features, eg: A request for hover should not kill the process that was created for signature help request
- Major refactorings to accomodate the above