### PR TITLE
Kill existing vet/lint processes before starting new ones

### DIFF
--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -71,12 +71,27 @@ export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurat
 		args.push('./...');
 	}
 
-	return runTool(
+	if (running) {
+		tokenSource.cancel();
+	}
+
+	running = true;
+	const lintPromise = runTool(
 		args,
 		(lintWorkspace && currentWorkspace) ? currentWorkspace : path.dirname(fileUri.fsPath),
 		'warning',
 		false,
 		lintTool,
-		lintEnv
-	);
+		lintEnv,
+		false,
+		tokenSource.token
+	).then((result) => {
+		running = false;
+		return result;
+	});
+
+	return lintPromise;
 }
+
+let tokenSource = new vscode.CancellationTokenSource();
+let running = false;


### PR DESCRIPTION
When we spawn a process to either run `go vet` or the linters, they are known to spqwn child processes of their own. Since these are on save features, multiple saves on a large project can slow things down.

This PR introduces a cancellation token that is used to kill existing vet/lint processes and their children before starting new ones