### PR TITLE
Copy formatFlags before modifications

### DIFF
--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -20,7 +20,7 @@ export class Formatter {
 			let goConfig = vscode.workspace.getConfiguration('go', document.uri);
 			let formatTool = goConfig['formatTool'] || 'goreturns';
 			let formatCommandBinPath = getBinPath(formatTool);
-			let formatFlags = goConfig['formatFlags'] || [];
+			let formatFlags = goConfig['formatFlags'].slice() || [];
 			let canFormatToolUseDiff = goConfig['useDiffForFormatting'] && isDiffToolAvailable();
 			if (canFormatToolUseDiff && formatFlags.indexOf('-d') === -1) {
 				formatFlags.push('-d');


### PR DESCRIPTION
On the latest insiders build it looks like the workspace config objects are now frozen (which makes sense). I don't know if there's a "more correct" way to fix this but this seemed reasonable.

Fixes #1333