### PR TITLE
Add remote debugging debug configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -286,6 +286,22 @@
                 "${2:MyTestFunction}"
               ]
             }
+          },
+          {
+            "label": "Go: Connect to server",
+            "description": "Connect to a remote headless debug server",
+            "body": {
+              "name": "${3:Connect to server}",
+              "type": "go",
+              "request": "launch",
+              "mode": "remote",
+              "remotePath": "^\"\\${workspaceRoot}${1:}\"",
+              "port": 2345,
+              "host": "127.0.0.1",
+              "program": "^\"\\${workspaceRoot}${1:}\"",
+              "env": {},
+              "args": []
+            }
           }
         ],
         "configurationAttributes": {


### PR DESCRIPTION
It appears the template for generating a remote debugging configuration is missing.
Somewhat related to https://github.com/Microsoft/vscode-go/pull/254