### PR TITLE
Runnable golang scratch pad

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
   "activationEvents": [
     "onLanguage:go",
     "onCommand:go.gopath",
+    "onCommand:go.newscratch",
+    "onCommand:go.runscratch",
     "onCommand:go.tools.install",
     "onDebug"
   ],
@@ -172,6 +174,16 @@
         "command": "go.show.commands",
         "title": "Go: Show All Commands...",
         "description": "Shows all commands from the Go extension in the wuick pick"
+      },
+      {
+        "command": "go.newscratch",
+        "title": "Go: New Scratch Pad",
+        "description": "Create a dummy main in a new window"
+      },
+      {
+        "command": "go.runscratch",
+        "title": "Go: Run Scratch Pad",
+        "description": "Compile and run scratch pad"
       },
       {
         "command": "go.browse.packages",

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -18,6 +18,7 @@ import { GoRunTestCodeLensProvider } from './goRunTestCodelens';
 import { GoSignatureHelpProvider } from './goSignature';
 import { GoWorkspaceSymbolProvider } from './goSymbol';
 import { GoCodeActionProvider } from './goCodeAction';
+import { createScratch, runScratch } from './goScratch';
 import { check, removeTestStatus } from './goCheck';
 import { updateGoPathGoRootFromConfig, offerToInstallTools } from './goInstallTools';
 import { GO_MODE } from './goMode';
@@ -208,6 +209,14 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.coverage', () => {
 		toggleCoverageCurrentPackage();
+	}));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.newscratch', () => {
+		createScratch();
+	}));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.runscratch', () => {
+		runScratch();
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.showOutput', () => {

--- a/src/goScratch.ts
+++ b/src/goScratch.ts
@@ -1,0 +1,48 @@
+'use strict';
+
+import vscode = require('vscode');
+import cp = require('child_process');
+import os = require('os');
+import path = require('path');
+import { getGoRuntimePath } from './goPath';
+import { outputChannel } from './goStatus';
+
+const tmpPath = path.normalize(path.join(os.tmpdir(), 'go-scratch', 'scratch.go'));
+let template = `package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("Hello World!")
+}`;
+
+export function createScratch(): void {
+	vscode.workspace.openTextDocument(tmpPath)
+		.then(doc => createExisting(doc), () => createNew(vscode.Uri.parse('untitled:' + tmpPath)));
+}
+
+function createExisting(doc: vscode.TextDocument) {
+	vscode.window.showTextDocument(doc)
+		.then(editor => editor.edit(builder => builder.replace(rangeAll(doc), template)))
+		.then(() => doc.save());
+}
+
+function createNew(newfile: vscode.Uri) {
+	vscode.workspace.openTextDocument(newfile)
+		.then(doc => createExisting(doc));
+}
+
+function rangeAll(doc: vscode.TextDocument): vscode.Range {
+	return new vscode.Range(new vscode.Position(0, 0), doc.positionAt(doc.getText().length));
+}
+
+export function runScratch(): void {
+	outputChannel.clear();
+	outputChannel.show(2);
+	let proc = cp.spawn(getGoRuntimePath(), ['run', tmpPath], { env: process.env });
+	proc.stdout.on('data', chunk => outputChannel.append(chunk.toString()));
+	proc.stderr.on('data', chunk => outputChannel.append(chunk.toString()));
+	proc.on('close', code => outputChannel.append('\n[Exited with code ' + code + ']'));
+}


### PR DESCRIPTION
Provide a way to quickly prototype and test golang concepts.
Adds two new commands:
![2017-11-28_11_31_18](https://user-images.githubusercontent.com/2963806/33312200-d7d87c04-d42f-11e7-9992-596c84cba40e.png)


**Go: New Scratch Pad**
Creates or resets an existing scratch pad with a minimalistic "Hello World" main package.
The scratch file is kept in a temporary directory and its persistency should not to be relied upon.

**Go: Run Scratch Pad**
Compiles and runs the scratch file, outputting its STDOUT and STDERR to the "Go" output pane.
Upon termination, the process return value is also printed.

![2017-11-28_11_32_21](https://user-images.githubusercontent.com/2963806/33312207-df97f00a-d42f-11e7-9748-07b905729d25.png)

