### PR TITLE
Update terminateProcess.sh to delete debug binary.

### DIFF
--- a/scripts/terminateProcess.sh
+++ b/scripts/terminateProcess.sh
@@ -3,8 +3,8 @@
 terminateTree() {
 	for cpid in $(/usr/bin/pgrep -P $1); do
 		terminateTree $cpid
-	done
-	kill -9 $1 > /dev/null 2>&1
+		kill -9 $1 > /dev/null 2>&1
+done
 }
 
 for pid in $*; do


### PR DESCRIPTION
RE: #1345 As simple as this fix is, it is working for me. On OS X, normally the debug binary does not get deleted, ever. With this modification, the binary debug file gets deleted as long as there are no pending breakpoints or you have continued past them. Which is appropriate, because if there are existing breakpoints and debug information, Delve can can continue to use the binary until your done.