### PR TITLE
Update goDebug.js to enable the removal of the debug binary

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -369,7 +369,7 @@ class Delve {
 	}
 
 	close() {
-		if (!this.debugProcess) {
+		if (this.debugProcess) {
 			this.call<DebuggerState>('Command', [{ name: 'halt' }], (err, state) => {
 				if (err) return logError('Failed to halt.');
 				this.call<DebuggerState>('Restart', [], (err, state) => {


### PR DESCRIPTION
This modification works with PR #1379, RE #1345, to enable the removal of the debug binary when pressing the stop button.