### PR TITLE
Cyclometric complexity code lens

### DIFF
--- a/package.json
+++ b/package.json
@@ -697,6 +697,11 @@
               "type": "boolean",
               "default": true,
               "description": "If true, enables code lens for running and debugging tests"
+            },
+            "complexity": {
+              "type": "boolean",
+              "default": false,
+              "description": "If true, enables a code lens showing cyclometric complexity. Uses gocyclo."
             }
           },
           "default": {

--- a/src/goComplexityCodelens.ts
+++ b/src/goComplexityCodelens.ts
@@ -111,7 +111,7 @@ export class GoComplexityCodeLensProvider extends GoBaseCodeLensProvider {
 					const range = func.location.range;
 					codelens.push(new CodeLens(
 						range,
-						{ title: `Complexity is ${result.complexity}`, command: null}));
+						{ title: `Cyclomatic complexity: ${result.complexity}`, command: null}));
 				});
 			});
 
@@ -122,7 +122,7 @@ export class GoComplexityCodeLensProvider extends GoBaseCodeLensProvider {
 					let packageResults = toolResults.filter((val) => { return val.package === pkg.name });
 					let topComplexity = Math.max(...packageResults.map(o => o.complexity));
 					const range = pkg.location.range;
-					codelens.push(new CodeLens(range, { title: `Complexity is ${topComplexity}`, command: null }));
+					codelens.push(new CodeLens(range, { title: `Cyclomatic complexity: ${topComplexity}`, command: null }));
 				}
 			});
 		

--- a/src/goComplexityCodelens.ts
+++ b/src/goComplexityCodelens.ts
@@ -88,7 +88,7 @@ export class GoComplexityCodeLensProvider extends GoBaseCodeLensProvider {
 					if (!match) { return undefined; }
 					
 					return new ComplexityResult(+match[1], match[2], match[3]);
-				}).filter(a => { a !== undefined });
+				}).filter(a => { return a !== undefined });
 
 				resolve(res);
 			});

--- a/src/goComplexityCodelens.ts
+++ b/src/goComplexityCodelens.ts
@@ -73,6 +73,7 @@ export class GoComplexityCodeLensProvider extends GoBaseCodeLensProvider {
 				}
 
 				let lines = stdout.split('\n');
+				const rex  = /^([0-9]+)\s([a-z_]+)\s(.+)\s(.+):([0-9]+):([0-9]+)$/;
 				let res = lines.map((line) => {
 					// Output line example from gocyclo:
 					// 142 somepackage parseFrame path\to\file.go:2741:1
@@ -84,7 +85,7 @@ export class GoComplexityCodeLensProvider extends GoBaseCodeLensProvider {
 					// 4: file path (path\to\file.go)
 					// 5: line number (2741)
 					// 6: Col (1)
-					let match = /^([0-9]+)\s([a-z_]+)\s(.+)\s(.+):([0-9]+):([0-9]+)$/.exec(line);
+					let match = rex.exec(line);
 					if (!match) { return undefined; }
 					
 					return new ComplexityResult(+match[1], match[2], match[3]);
@@ -102,8 +103,7 @@ export class GoComplexityCodeLensProvider extends GoBaseCodeLensProvider {
 
 		let functionResults = documentSymbolProvider.provideDocumentSymbols(document, token)
 			.then(symbols => {
-				return symbols.filter(sym => sym.kind === vscode.SymbolKind.Function
-					|| sym.kind == vscode.SymbolKind.Constructor)
+				return symbols.filter(sym => sym.kind === vscode.SymbolKind.Function)
 			})
 			.then(fns => {
 				fns.forEach(func => {
@@ -126,6 +126,6 @@ export class GoComplexityCodeLensProvider extends GoBaseCodeLensProvider {
 				}
 			});
 		
-		return Promise.all([functionResults, packageResult]).then(() => codelens);
+		return Promise.all([functionResults,packageResult]).then(() => codelens);
 	}
 }

--- a/src/goComplexityCodelens.ts
+++ b/src/goComplexityCodelens.ts
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------*/
+
+'use strict';
+
+import vscode = require('vscode');
+import path = require('path');
+import { TextDocument, CancellationToken, CodeLens, Command } from 'vscode';
+import { GoDocumentSymbolProvider } from './goOutline';
+import { getBinPath, getCurrentGoPath, canonicalizeGOPATHPrefix } from './util';
+// import { , byteOffsetAt, canonicalizeGOPATHPrefix, getFileArchive, getToolsEnvVars } from './util';
+import { GoBaseCodeLensProvider } from './goBaseCodelens';
+import { promptForMissingTool } from './goInstallTools';
+import cp = require('child_process');
+
+class ComplexityResult {
+	complexity: number;
+
+	package: string;
+
+	function: string;
+
+	constructor(complexity: number, pkg: string, functionName: string) {
+		this.complexity = complexity;
+		this.package = pkg;
+		this.function = functionName;
+	}
+}
+
+export class GoComplexityCodeLensProvider extends GoBaseCodeLensProvider {
+	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
+		if (!this.enabled) {
+			return [];
+		}
+		let config = vscode.workspace.getConfiguration('go', document.uri);
+
+		let codeLensConfig = config.get('enableCodeLens');
+		let codelensEnabled = codeLensConfig
+			? codeLensConfig['complexity']
+			: false;
+
+		let goCyclo = getBinPath('gocyclo');
+		if (!path.isAbsolute(goCyclo)) {
+			promptForMissingTool('gocyclo');
+			codelensEnabled = false;
+		}
+
+		if (!codelensEnabled) {
+			return [];
+		}
+
+		return this.runComplexityTool(goCyclo, document)
+			.then((res) => this.getComplexity(res, document, token));
+	}
+
+	private runComplexityTool(goCyclo: string, document: TextDocument) {
+		return new Promise<ComplexityResult[]>((resolve, reject) => {
+			const result: ComplexityResult[] = [];
+
+			let filename = canonicalizeGOPATHPrefix(document.fileName);
+			let args = [filename];
+			cp.execFile(goCyclo, args, (err, stdout, stderr) => {
+				if (err) {
+					if ((<any>err).code === 'ENOENT')
+					{
+						promptForMissingTool('gocyclo');
+						return reject('Cannot find tool "gocyclo" to find references.');
+					}
+					if ((<any>err).killed !== true) {
+						return reject(`Error running gocyclo: ${err.message || stderr}`);	
+					}
+				}
+
+				let lines = stdout.split('\n');
+				let res = lines.map((line) => {
+					let cols = line.split(' ');
+					return new ComplexityResult(+cols[0], cols[1], cols[2]);
+				});
+
+				resolve(res);
+			});
+		});
+	}
+	
+	private getComplexity(toolResults: ComplexityResult[], document: TextDocument, token: CancellationToken): Thenable<CodeLens[]> {
+		const codelens: CodeLens[] = [];
+
+		let documentSymbolProvider = new GoDocumentSymbolProvider();
+				
+		let functionResults = documentSymbolProvider.provideDocumentSymbols(document, token)
+			.then(symbols => {
+				return symbols.filter(sym => sym.kind === vscode.SymbolKind.Function
+					|| sym.kind == vscode.SymbolKind.Constructor)
+			})
+			.then(fns => {
+				fns.forEach(func => {
+					let result = toolResults.find(o => o.function === func.name);
+					const range = func.location.range;
+					codelens.push(new CodeLens(
+						range,
+						{ title: `Complexity is ${result.complexity}`, command: null}));
+				});
+			});
+
+			let packageResult = documentSymbolProvider.provideDocumentSymbols(document, token)
+			.then(symbols => { return symbols.find(sym => sym.kind === vscode.SymbolKind.Package && !!sym.name); })
+			.then(pkg => {
+				if (pkg) {
+					let packageResults = toolResults.filter((val) => { return val.package === pkg.name });
+					let topComplexity = Math.max(...packageResults.map(o => o.complexity));
+					const range = pkg.location.range;
+					codelens.push(new CodeLens(range, { title: `Complexity is ${topComplexity}`, command: null }));
+				}
+			});
+		
+		return Promise.all([functionResults, packageResult]).then(() => codelens);
+	}
+}

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -38,7 +38,8 @@ const allTools: { [key: string]: string } = {
 	'gometalinter': 'github.com/alecthomas/gometalinter',
 	'megacheck': 'honnef.co/go/tools/...',
 	'go-langserver': 'github.com/sourcegraph/go-langserver',
-	'dlv': 'github.com/derekparker/delve/cmd/dlv'
+	'dlv': 'github.com/derekparker/delve/cmd/dlv',
+	'gocyclo': 'github.com/fzipp/gocyclo',
 };
 
 // Tools used explicitly by the basic features of the extension

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -15,6 +15,7 @@ import { GoDocumentFormattingEditProvider, Formatter } from './goFormat';
 import { GoRenameProvider } from './goRename';
 import { GoDocumentSymbolProvider } from './goOutline';
 import { GoRunTestCodeLensProvider } from './goRunTestCodelens';
+import { GoComplexityCodeLensProvider } from './goComplexityCodelens';
 import { GoSignatureHelpProvider } from './goSignature';
 import { GoWorkspaceSymbolProvider } from './goSymbol';
 import { GoCodeActionProvider } from './goCodeAction';
@@ -135,6 +136,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	let testCodeLensProvider = new GoRunTestCodeLensProvider();
 	let referencesCodeLensProvider = new GoReferencesCodeLensProvider();
+	let complexityCodeLensProvider = new GoComplexityCodeLensProvider();
 
 	ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(GO_MODE, new GoCompletionItemProvider(), '.', '\"'));
 	ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(GO_MODE, new GoDocumentFormattingEditProvider()));
@@ -142,6 +144,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.languages.registerCodeActionsProvider(GO_MODE, new GoCodeActionProvider()));
 	ctx.subscriptions.push(vscode.languages.registerCodeLensProvider(GO_MODE, testCodeLensProvider));
 	ctx.subscriptions.push(vscode.languages.registerCodeLensProvider(GO_MODE, referencesCodeLensProvider));
+	ctx.subscriptions.push(vscode.languages.registerCodeLensProvider(GO_MODE, complexityCodeLensProvider));
 	ctx.subscriptions.push(vscode.languages.registerImplementationProvider(GO_MODE, new GoImplementationProvider()));
 	ctx.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('go', new GoDebugConfigurationProvider()));
 


### PR DESCRIPTION
This PR add a new (optional) code lens to show the complexity of functions in a given go source file, using the gocyclo package (https://github.com/fzipp/gocyclo).

The cyclomatic complexity score of a function can be a useful indicator for when a given function has too many branches of logic and needs to be broken apart. 

![image](https://user-images.githubusercontent.com/2563682/34528256-3aad54d0-f0a0-11e7-8627-df0a81b5825b.png)

At the present moment the complexity is merely shown to the user, but it could be easily enhanced to include configurable thresholds and associated messages.