### PR TITLE
Show build/vet/lint status in Status bar. Fix #1456

### DIFF
--- a/src/goBuild.ts
+++ b/src/goBuild.ts
@@ -26,6 +26,7 @@ export function buildCode(buildWorkspace?: boolean) {
 	let documentUri = editor ? editor.document.uri : null;
 	let goConfig = vscode.workspace.getConfiguration('go', documentUri);
 
+	outputChannel.clear(); // Ensures stale output from build on save is cleared
 	diagnosticsStatusBarItem.show();
 	diagnosticsStatusBarItem.text = 'Building...';
 
@@ -33,7 +34,6 @@ export function buildCode(buildWorkspace?: boolean) {
 		.then(errors => {
 			handleDiagnosticErrors(editor ? editor.document : null, errors, vscode.DiagnosticSeverity.Error);
 			diagnosticsStatusBarItem.hide();
-			outputChannel.clear();
 		})
 		.catch(err => {
 			vscode.window.showInformationMessage('Error: ' + err);

--- a/src/goBuild.ts
+++ b/src/goBuild.ts
@@ -28,10 +28,12 @@ export function buildCode(buildWorkspace?: boolean) {
 
 	diagnosticsStatusBarItem.show();
 	diagnosticsStatusBarItem.text = 'Building...';
+
 	goBuild(documentUri, goConfig, buildWorkspace)
 		.then(errors => {
 			handleDiagnosticErrors(editor ? editor.document : null, errors, vscode.DiagnosticSeverity.Error);
 			diagnosticsStatusBarItem.hide();
+			outputChannel.clear();
 		})
 		.catch(err => {
 			vscode.window.showInformationMessage('Error: ' + err);

--- a/src/goBuild.ts
+++ b/src/goBuild.ts
@@ -6,7 +6,7 @@ import os = require('os');
 import { getNonVendorPackages } from './goPackages';
 import { getTestFlags } from './testUtils';
 import { getCurrentGoWorkspaceFromGOPATH } from './goPath';
-
+import { diagnosticsStatusBarItem } from './goStatus';
 /**
  * Builds current package or workspace.
  */
@@ -25,13 +25,17 @@ export function buildCode(buildWorkspace?: boolean) {
 
 	let documentUri = editor ? editor.document.uri : null;
 	let goConfig = vscode.workspace.getConfiguration('go', documentUri);
-	outputChannel.clear();
-	outputChannel.show();
-	outputChannel.appendLine('Building in progress...');
+
+	diagnosticsStatusBarItem.show();
+	diagnosticsStatusBarItem.text = 'Building...';
 	goBuild(documentUri, goConfig, buildWorkspace)
-		.then(errors => handleDiagnosticErrors(editor ? editor.document : null, errors, vscode.DiagnosticSeverity.Error))
+		.then(errors => {
+			handleDiagnosticErrors(editor ? editor.document : null, errors, vscode.DiagnosticSeverity.Error);
+			diagnosticsStatusBarItem.hide();
+		})
 		.catch(err => {
 			vscode.window.showInformationMessage('Error: ' + err);
+			diagnosticsStatusBarItem.text = 'Build Failed';
 		});
 }
 

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -10,7 +10,7 @@ import path = require('path');
 import os = require('os');
 import { getGoRuntimePath } from './goPath';
 import { getCoverage } from './goCover';
-import { outputChannel } from './goStatus';
+import { outputChannel, diagnosticsStatusBarItem } from './goStatus';
 import { goTest } from './testUtils';
 import { ICheckResult } from './util';
 import { goLint } from './goLint';
@@ -39,6 +39,7 @@ export function notifyIfGeneratedFile(e: vscode.TextDocumentChangeEvent) {
 }
 
 export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfiguration): Promise<ICheckResult[]> {
+	diagnosticsStatusBarItem.hide();
 	outputChannel.clear();
 	let runningToolsPromises = [];
 	let cwd = path.dirname(fileUri.fsPath);

--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -27,6 +27,7 @@ export function lintCode(lintWorkspace?: boolean) {
 		.then(warnings => {
 			handleDiagnosticErrors(editor ? editor.document : null, warnings, vscode.DiagnosticSeverity.Warning);
 			diagnosticsStatusBarItem.hide();
+			outputChannel.clear();
 		})
 		.catch(err => {
 			vscode.window.showInformationMessage('Error: ' + err);

--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -2,7 +2,7 @@ import path = require('path');
 import vscode = require('vscode');
 import { getToolsEnvVars, resolvePath, runTool, ICheckResult, handleDiagnosticErrors, getWorkspaceFolderPath } from './util';
 import { outputChannel } from './goStatus';
-
+import { diagnosticsStatusBarItem } from './goStatus';
 /**
  * Runs linter in the current package or workspace.
  */
@@ -19,13 +19,18 @@ export function lintCode(lintWorkspace?: boolean) {
 
 	let documentUri = editor ? editor.document.uri : null;
 	let goConfig = vscode.workspace.getConfiguration('go', documentUri);
-	outputChannel.clear();
-	outputChannel.show();
-	outputChannel.appendLine('Linting in progress...');
+
+	diagnosticsStatusBarItem.show();
+	diagnosticsStatusBarItem.text = 'Linting...';
+
 	goLint(documentUri, goConfig, lintWorkspace)
-		.then(warnings => handleDiagnosticErrors(editor ? editor.document : null, warnings, vscode.DiagnosticSeverity.Warning))
+		.then(warnings => {
+			handleDiagnosticErrors(editor ? editor.document : null, warnings, vscode.DiagnosticSeverity.Warning);
+			diagnosticsStatusBarItem.hide();
+		})
 		.catch(err => {
 			vscode.window.showInformationMessage('Error: ' + err);
+			diagnosticsStatusBarItem.text = 'Linting Failed';
 		});
 }
 

--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -20,6 +20,7 @@ export function lintCode(lintWorkspace?: boolean) {
 	let documentUri = editor ? editor.document.uri : null;
 	let goConfig = vscode.workspace.getConfiguration('go', documentUri);
 
+	outputChannel.clear(); // Ensures stale output from lint on save is cleared
 	diagnosticsStatusBarItem.show();
 	diagnosticsStatusBarItem.text = 'Linting...';
 
@@ -27,7 +28,6 @@ export function lintCode(lintWorkspace?: boolean) {
 		.then(warnings => {
 			handleDiagnosticErrors(editor ? editor.document : null, warnings, vscode.DiagnosticSeverity.Warning);
 			diagnosticsStatusBarItem.hide();
-			outputChannel.clear();
 		})
 		.catch(err => {
 			vscode.window.showInformationMessage('Error: ' + err);

--- a/src/goStatus.ts
+++ b/src/goStatus.ts
@@ -10,6 +10,8 @@ import vscode = require('vscode');
 
 export let outputChannel = vscode.window.createOutputChannel('Go');
 
+export let diagnosticsStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+
 let statusBarEntry: vscode.StatusBarItem;
 
 export function showHideStatus() {

--- a/src/goVet.ts
+++ b/src/goVet.ts
@@ -21,6 +21,7 @@ export function vetCode(vetWorkspace?: boolean) {
 	let documentUri = editor ? editor.document.uri : null;
 	let goConfig = vscode.workspace.getConfiguration('go', documentUri);
 
+	outputChannel.clear(); // Ensures stale output from vet on save is cleared
 	diagnosticsStatusBarItem.show();
 	diagnosticsStatusBarItem.text = 'Vetting...';
 
@@ -28,7 +29,6 @@ export function vetCode(vetWorkspace?: boolean) {
 		.then(warnings => {
 			handleDiagnosticErrors(editor ? editor.document : null, warnings, vscode.DiagnosticSeverity.Warning);
 			diagnosticsStatusBarItem.hide();
-			outputChannel.clear();
 		})
 		.catch(err => {
 			vscode.window.showInformationMessage('Error: ' + err);

--- a/src/goVet.ts
+++ b/src/goVet.ts
@@ -2,6 +2,7 @@ import path = require('path');
 import vscode = require('vscode');
 import { getToolsEnvVars, runTool, ICheckResult, handleDiagnosticErrors, getWorkspaceFolderPath } from './util';
 import { outputChannel } from './goStatus';
+import { diagnosticsStatusBarItem } from './goStatus';
 
 /**
  * Runs go vet in the current package or workspace.
@@ -19,13 +20,18 @@ export function vetCode(vetWorkspace?: boolean) {
 
 	let documentUri = editor ? editor.document.uri : null;
 	let goConfig = vscode.workspace.getConfiguration('go', documentUri);
-	outputChannel.clear();
-	outputChannel.show();
-	outputChannel.appendLine('Vetting in progress...');
+
+	diagnosticsStatusBarItem.show();
+	diagnosticsStatusBarItem.text = 'Vetting...';
+
 	goVet(documentUri, goConfig, vetWorkspace)
-		.then(warnings => handleDiagnosticErrors(editor ? editor.document : null, warnings, vscode.DiagnosticSeverity.Warning))
+		.then(warnings => {
+			handleDiagnosticErrors(editor ? editor.document : null, warnings, vscode.DiagnosticSeverity.Warning);
+			diagnosticsStatusBarItem.hide();
+		})
 		.catch(err => {
 			vscode.window.showInformationMessage('Error: ' + err);
+			diagnosticsStatusBarItem.text = 'Vetting Failed';
 		});
 }
 

--- a/src/goVet.ts
+++ b/src/goVet.ts
@@ -28,6 +28,7 @@ export function vetCode(vetWorkspace?: boolean) {
 		.then(warnings => {
 			handleDiagnosticErrors(editor ? editor.document : null, warnings, vscode.DiagnosticSeverity.Warning);
 			diagnosticsStatusBarItem.hide();
+			outputChannel.clear();
 		})
 		.catch(err => {
 			vscode.window.showInformationMessage('Error: ' + err);


### PR DESCRIPTION
I am also maintaining the state in the `outputChannel` which is revealed with the registered command `go.show.outputPanel` when the user clicks on the `statusBarItem` (in case the user wants debug info). Hope it is fine?