### PR TITLE
📚 Fix misspelling on snippets/go.json

### DIFF
--- a/snippets/go.json
+++ b/snippets/go.json
@@ -83,7 +83,7 @@
 		"if statement": {
 			"prefix": "if",
 			"body": "if ${1:condition} {\n\t$0\n}",
-			"description": "Snippet for if statment"
+			"description": "Snippet for if statement"
 		},
 		"else branch": {
 			"prefix": "el",


### PR DESCRIPTION
statement is misspelled as "statment" at "if statement" snippet in the snippets/go.json file.