### PR TITLE
Added configuration to use legacy Find All References

### DIFF
--- a/package.json
+++ b/package.json
@@ -417,6 +417,11 @@
       "type": "object",
       "title": "Go configuration",
       "properties": {
+        "go.legacyReference": {
+          "typ": "boolean",
+          "default": false,
+          "description": "Use legacy Find All References."
+        },
         "go.buildOnSave": {
           "type": "string",
           "enum": [

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -38,7 +38,8 @@ const allTools: { [key: string]: string } = {
 	'gometalinter': 'github.com/alecthomas/gometalinter',
 	'megacheck': 'honnef.co/go/tools/...',
 	'go-langserver': 'github.com/sourcegraph/go-langserver',
-	'dlv': 'github.com/derekparker/delve/cmd/dlv'
+	'dlv': 'github.com/derekparker/delve/cmd/dlv',
+	'go-find-references': 'github.com/lukehoban/go-find-references'
 };
 
 // Tools used explicitly by the basic features of the extension
@@ -57,7 +58,8 @@ const importantTools = [
 	'golint',
 	'gometalinter',
 	'megacheck',
-	'dlv'
+	'dlv',
+	'go-find-references'
 ];
 
 function getTools(goVersion: SemVersion): string[] {
@@ -71,7 +73,8 @@ function getTools(goVersion: SemVersion): string[] {
 		'gorename',
 		'gomodifytags',
 		'goplay',
-		'impl'
+		'impl',
+		'go-find-references'
 	];
 
 	if (goLiveErrorsEnabled()) {

--- a/src/goReferences.ts
+++ b/src/goReferences.ts
@@ -10,6 +10,7 @@ import cp = require('child_process');
 import path = require('path');
 import { getBinPath, byteOffsetAt, canonicalizeGOPATHPrefix, getFileArchive, getToolsEnvVars } from './util';
 import { promptForMissingTool } from './goInstallTools';
+import { ChildProcess } from 'child_process';
 
 export class GoReferenceProvider implements vscode.ReferenceProvider {
 
@@ -17,66 +18,113 @@ export class GoReferenceProvider implements vscode.ReferenceProvider {
 		return this.doFindReferences(document, position, options, token);
 	}
 
+	private runGoReference(document: vscode.TextDocument, position: vscode.Position, filename: string, cwd: string, options: { includeDeclaration: boolean }, resolve: any, reject: any): ChildProcess {
+		// get current word
+		let wordRange = document.getWordRangeAtPosition(position);
+		if (!wordRange) {
+			return null;
+		}
+		let textAtPosition = document.getText(wordRange);
+		let wordLength = textAtPosition.length;
+		let start = wordRange.start;
+		let possibleDot = '';
+		if (start.character > 0) {
+			possibleDot = document.getText(new vscode.Range(start.line, start.character - 1, start.line, start.character));
+		}
+		if (possibleDot === '.') {
+			let previousWordRange = document.getWordRangeAtPosition(new vscode.Position(start.line, start.character - 1));
+			let textAtPreviousPosition = document.getText(previousWordRange);
+			wordLength += textAtPreviousPosition.length + 1;
+		}
+
+		let offset = byteOffsetAt(document, position);
+
+		let gofindreferences = getBinPath('go-find-references');
+		let env = getToolsEnvVars();
+		return cp.execFile(gofindreferences, ['-file', filename, '-offset', offset.toString(), '-root', vscode.workspace.rootPath], { env }, (err, stdout, stderr) => {
+			try {
+				if (err && (<any>err).code === 'ENOENT') {
+					vscode.window.showInformationMessage('The "go-find-references" command is not available.  Use "go get -v github.com/lukehoban/go-find-references" to install.');
+					return resolve(null);
+				}
+				let lines = stdout.toString().split('\n');
+				const results: vscode.Location[] = lines.map((line) => {
+					const match = /(.*):(\d+):(\d+)/.exec(line);
+					if (!match) return;
+					let [_, file, lineStr, colStr] = match;
+					let referenceResource = vscode.Uri.file(path.resolve(cwd, file));
+					let range = new vscode.Range(
+						+lineStr - 1, +colStr - 1, +lineStr - 1, +colStr + wordLength - 1
+					);
+					return new vscode.Location(referenceResource, range);
+				})
+				.filter((result) => result !== undefined);
+				resolve(results);
+			} catch (e) {
+				reject(e);
+			}
+		});
+	}
+
+	private runGuru(document: vscode.TextDocument, position: vscode.Position, filename: string, cwd: string, options: { includeDeclaration: boolean }, resolve: any, reject: any): ChildProcess {
+		let goGuru = getBinPath('guru');
+		if (!path.isAbsolute(goGuru)) {
+			promptForMissingTool('guru');
+			return null;
+		}
+		let offset = byteOffsetAt(document, position);
+		let env = getToolsEnvVars();
+		let buildTags = vscode.workspace.getConfiguration('go', document.uri)['buildTags'];
+		let args = buildTags ? ['-tags', buildTags] : [];
+		args.push('-modified', 'referrers', `${filename}:#${offset.toString()}`);
+		return cp.execFile(goGuru, args, { env }, (err, stdout, stderr) => {
+			try {
+				if (err && (<any>err).code === 'ENOENT') {
+					promptForMissingTool('guru');
+					return reject('Cannot find tool "guru" to find references.');
+				}
+
+				if (err && (<any>err).killed !== true) {
+					return reject(`Error running guru: ${err.message || stderr}`);
+				}
+
+				let lines = stdout.toString().split('\n');
+				let results: vscode.Location[] = [];
+				for (let i = 0; i < lines.length; i++) {
+					let match = /^(.*):(\d+)\.(\d+)-(\d+)\.(\d+):/.exec(lines[i]);
+					if (!match) continue;
+					let [_, file, lineStartStr, colStartStr, lineEndStr, colEndStr] = match;
+					let referenceResource = vscode.Uri.file(path.resolve(cwd, file));
+
+					if (!options.includeDeclaration) {
+						if (document.uri.fsPath === referenceResource.fsPath &&
+							position.line === Number(lineStartStr) - 1) {
+							continue;
+						}
+					}
+
+					let range = new vscode.Range(
+						+lineStartStr - 1, +colStartStr - 1, +lineEndStr - 1, +colEndStr
+					);
+					results.push(new vscode.Location(referenceResource, range));
+				}
+				resolve(results);
+			} catch (e) {
+				reject(e);
+			}
+		});
+	}
+
 	private doFindReferences(document: vscode.TextDocument, position: vscode.Position, options: { includeDeclaration: boolean }, token: vscode.CancellationToken): Thenable<vscode.Location[]> {
 		return new Promise<vscode.Location[]>((resolve, reject) => {
-			// get current word
-			let wordRange = document.getWordRangeAtPosition(position);
-			if (!wordRange) {
-				return resolve([]);
-			}
-
-			let goGuru = getBinPath('guru');
-			if (!path.isAbsolute(goGuru)) {
-				promptForMissingTool('guru');
-				return reject('Cannot find tool "guru" to find references.');
-			}
-
 			let filename = canonicalizeGOPATHPrefix(document.fileName);
 			let cwd = path.dirname(filename);
-			let offset = byteOffsetAt(document, position);
-			let env = getToolsEnvVars();
-			let buildTags = vscode.workspace.getConfiguration('go', document.uri)['buildTags'];
-			let args = buildTags ? ['-tags', buildTags] : [];
-			args.push('-modified', 'referrers', `${filename}:#${offset.toString()}`);
-
-			let process = cp.execFile(goGuru, args, { env }, (err, stdout, stderr) => {
-				try {
-					if (err && (<any>err).code === 'ENOENT') {
-						promptForMissingTool('guru');
-						return reject('Cannot find tool "guru" to find references.');
-					}
-
-					if (err && (<any>err).killed !== true) {
-						return reject(`Error running guru: ${err.message || stderr}`);
-					}
-
-					let lines = stdout.toString().split('\n');
-					let results: vscode.Location[] = [];
-					for (let i = 0; i < lines.length; i++) {
-						let match = /^(.*):(\d+)\.(\d+)-(\d+)\.(\d+):/.exec(lines[i]);
-						if (!match) continue;
-						let [_, file, lineStartStr, colStartStr, lineEndStr, colEndStr] = match;
-						let referenceResource = vscode.Uri.file(path.resolve(cwd, file));
-
-						if (!options.includeDeclaration) {
-							if (document.uri.fsPath === referenceResource.fsPath &&
-								position.line === Number(lineStartStr) - 1) {
-								continue;
-							}
-						}
-
-						let range = new vscode.Range(
-							+lineStartStr - 1, +colStartStr - 1, +lineEndStr - 1, +colEndStr
-						);
-						results.push(new vscode.Location(referenceResource, range));
-					}
-					resolve(results);
-				} catch (e) {
-					reject(e);
-				}
-			});
+			let f = vscode.workspace.getConfiguration('go', document.uri)['legacyReference'] ? this.runGoReference : this.runGuru;
+			let process = f(document, position, filename, cwd, options, resolve, reject);
+			if (!process) {
+				return reject('Cannot find tool to find references.');
+			}
 			process.stdin.end(getFileArchive(document));
-
 			token.onCancellationRequested(() =>
 				process.kill()
 			);


### PR DESCRIPTION
This is in response to #1491 .

So there are a couple things here that I am still not sure about, having never written a VSC plugin before and not being super fluent in TS/JS:

There is still one issue that I can't figure out though. Maybe someone else has an idea:

When sideloaded, while there doesn't seem to be a regression when ```go.legacyReference``` is _disabled_ (the default)--that is, it still works as usual without issue, however when ```go.legacyReference``` is _enabled_, it seems to find _some_ references, but most symbols that it should find are missing, and sometimes no symbols are found at all. This legacy code was taken directly from commit history, so Im not sure what I am missing here. Furthermore, I ran the ```go-find-references``` command externally and even it only finds a subset of the expected symbols. I'm not sure if go-find-references is just broken or if I am using it incorrectly.