### PR TITLE
Support sourceDirectories in launch config

### DIFF
--- a/package.json
+++ b/package.json
@@ -382,6 +382,11 @@
                 "description": "The host name of the machine the delve debugger will be listening on.",
                 "default": "127.0.0.1"
               },
+              "sourceDirectories": {
+                "type": "array",
+                "description": "List of source directories to search when the debug symbols only have relative paths.",
+                "default": []
+              },
               "trace": {
                 "type": [
                   "boolean",


### PR DESCRIPTION
When debugging a prebuilt binary, the debug symbols may only contain
relative paths.  This is the case, for example, when building go
binaries with bazel using github.com/bazelbuild/rules_go.  To make
it possible to debug such binaries, support "sourceDirectories"
attribute in launch config.

When translating from relative delve path to absolute vscode path
during backtrace decode, we try prepending each entry from
sourceDirectory array to the relative path reported by delve.  We take
the first one that produces a valid filename.

When translating from absolute vscode path to relative delve path
when setting breakpoints, we try stripping each entry from
sourceDirectory array from the absolute path to form a relative path.
We then ask delve to set a breakpoint to that relative path, and if
that succeeds, we move to the next breakpoint.