### PR TITLE
Support resolving symlinks when navigating to symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -679,6 +679,11 @@
           "description": "If false, the import statements will be excluded while using the Go to Symbol in File feature",
           "scope": "resource"
         },
+        "go.gotoSymbol.resolveSymlinks": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, symlinks will be resolved when using the Go to Symbol feature"
+        },
         "go.enableCodeLens": {
           "type": "object",
           "properties": {

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -8,7 +8,7 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import path = require('path');
-import { byteOffsetAt, getBinPath } from './util';
+import { byteOffsetAt, getBinPath, resolveSymlinksMaybe } from './util';
 import { promptForMissingTool } from './goInstallTools';
 import { getGoVersion, SemVersion, goKeywords, isPositionInString, getToolsEnvVars, getFileArchive, killProcess } from './util';
 
@@ -78,6 +78,7 @@ function definitionLocation_godef(document: vscode.TextDocument, position: vscod
 					return resolve(null);
 				}
 				let [_, file, line, col] = match;
+				file = resolveSymlinksMaybe(file);
 				let signature = lines[1];
 				let godoc = getBinPath('godoc');
 				let pkgPath = path.dirname(file);
@@ -164,9 +165,10 @@ function definitionLocation_gogetdoc(document: vscode.TextDocument, position: vs
 					return resolve(definitionInfo);
 				}
 				let [_, file, line, col] = match;
-				definitionInfo.file = match[1];
-				definitionInfo.line = +match[2] - 1;
-				definitionInfo.column = +match[3] - 1;
+				file = resolveSymlinksMaybe(file);
+				definitionInfo.file = file;
+				definitionInfo.line = +line - 1;
+				definitionInfo.column = +col - 1;
 				return resolve(definitionInfo);
 
 			} catch (e) {
@@ -210,9 +212,10 @@ function definitionLocation_guru(document: vscode.TextDocument, position: vscode
 					return resolve(definitionInfo);
 				}
 				let [_, file, line, col] = match;
-				definitionInfo.file = match[1];
-				definitionInfo.line = +match[2] - 1;
-				definitionInfo.column = +match[3] - 1;
+				file = resolveSymlinksMaybe(file);
+				definitionInfo.file = file;
+				definitionInfo.line = +line - 1;
+				definitionInfo.column = +col - 1;
 				return resolve(definitionInfo);
 			} catch (e) {
 				reject(e);

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -26,6 +26,7 @@ import { toggleCoverageCurrentPackage, getCodeCoverage, removeCodeCoverage } fro
 import { initGoCover } from './goCover';
 import { testAtCursor, testCurrentPackage, testCurrentFile, testPrevious, testWorkspace } from './goTest';
 import { showTestOutput } from './testUtils';
+import { resolveSymlinksMaybe } from './util';
 import * as goGenerateTests from './goGenerateTests';
 import { addImport } from './goImport';
 import { getAllPackages } from './goPackages';
@@ -109,7 +110,10 @@ export function activate(ctx: vscode.ExtensionContext): void {
 					uriConverters: {
 						// Apply file:/// scheme to all file paths.
 						code2Protocol: (uri: vscode.Uri): string => (uri.scheme ? uri : uri.with({ scheme: 'file' })).toString(),
-						protocol2Code: (uri: string) => vscode.Uri.parse(uri),
+						protocol2Code: (uri: string): vscode.Uri => {
+							let u = vscode.Uri.parse(uri);
+							return u.with({ path: resolveSymlinksMaybe(u.path) });
+						},
 					},
 				}
 			);

--- a/src/util.ts
+++ b/src/util.ts
@@ -470,6 +470,18 @@ export function resolvePath(inputPath: string, workspaceRoot?: string): string {
 }
 
 /**
+ * Resolves symlinks from a file path, if user has enabled that feature.
+ */
+export function resolveSymlinksMaybe(path: string): string {
+	let gotoSymbolConfig = vscode.workspace.getConfiguration('go')['gotoSymbol'];
+	if (gotoSymbolConfig && gotoSymbolConfig['resolveSymlinks']) {
+		return fs.realpathSync(path);
+	} else {
+		return path;
+	}
+}
+
+/**
  * Returns the import path in a passed in string.
  * @param text The string to search for an import path
  */


### PR DESCRIPTION
When building go apps outside of a GOPATH environment (e.g. using
bazel), users may want to construct an artificial GOPATH directory
structure using symlinks, in order to keep using standard go
productivity tools.  In particular, pointing vscode to such an
artificial GOPATH directory allows features like "go to symbol" work
without further configuration.

However, when navigating around a GOPATH that consists of symlinks, we
would like to open the real files, not the symlinks, within vscode.  To
support this, add support for a new "go.gotoSymbol.resolveSymlinks"
configuration setting.