### PR TITLE
Switch to testfile if already open/visible instead of reopening

### DIFF
--- a/src/goGenerateTests.ts
+++ b/src/goGenerateTests.ts
@@ -58,7 +58,7 @@ export function toggleTestFile(): void {
 	for (let doc of vscode.window.visibleTextEditors) {
 		if (doc.document.fileName === targetFilePath) {
 			vscode.commands.executeCommand('vscode.open', vscode.Uri.file(targetFilePath), doc.viewColumn);
-			return
+			return;
 		}
 	}
 	vscode.commands.executeCommand('vscode.open', vscode.Uri.file(targetFilePath));

--- a/src/goGenerateTests.ts
+++ b/src/goGenerateTests.ts
@@ -55,6 +55,12 @@ export function toggleTestFile(): void {
 	} else {
 		targetFilePath = currentFilePath.substr(0, currentFilePath.lastIndexOf('.go')) + '_test.go';
 	}
+	for (let doc of vscode.window.visibleTextEditors) {
+		if (doc.document.fileName === targetFilePath) {
+			vscode.commands.executeCommand('vscode.open', vscode.Uri.file(targetFilePath), doc.viewColumn);
+			return
+		}
+	}
 	vscode.commands.executeCommand('vscode.open', vscode.Uri.file(targetFilePath));
 }
 


### PR DESCRIPTION
Implementing the first feature mentioned in #610.
This PR prevents vscode from overriding the currently open file if the test is already open in another visible editor.
To improve this even further, this could benefit from https://github.com/Microsoft/vscode/issues/15178 to even open the file if it is not visible in the other open editors.

First PR here (even first contribution to vscode) so if something is not ok, please tell me :-)
