### PR TITLE
Fix broken tests

### DIFF
--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -380,7 +380,7 @@ It returns the number of bytes written and any write error encountered.
 				{ line: 11, severity: 'warning', msg: 'error return value not checked (undeclared name: prin) (errcheck)' },
 				{ line: 11, severity: 'warning', msg: 'unused variable or constant undeclared name: prin (varcheck)' },
 			];
-			let errorsTestPath = path.join(fixtureSourcePath, 'errorsTest', 'errors.go') || '';
+			let errorsTestPath = path.join(fixtureSourcePath, 'errorsTest', 'errors.go');
 			return check(vscode.Uri.file(errorsTestPath), config).then(diagnostics => {
 				let sortedDiagnostics = diagnostics.sort((a, b) => {
 					if (a.msg < b.msg)

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -380,7 +380,7 @@ It returns the number of bytes written and any write error encountered.
 				{ line: 11, severity: 'warning', msg: 'error return value not checked (undeclared name: prin) (errcheck)' },
 				{ line: 11, severity: 'warning', msg: 'unused variable or constant undeclared name: prin (varcheck)' },
 			];
-			let errorsTestPath = path.join(fixturePath, 'errorsTest', 'errors.go');
+			let errorsTestPath = path.join(fixtureSourcePath, 'errorsTest', 'errors.go');
 			return check(vscode.Uri.file(errorsTestPath), config).then(diagnostics => {
 				let sortedDiagnostics = diagnostics.sort((a, b) => {
 					if (a.msg < b.msg)

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -853,7 +853,7 @@ It returns the number of bytes written and any write error encountered.
 				'lintTool': { value: 'gometalinter' },
 				'lintFlags': { value: ['--json', '--disable-all', '--enable=golint', '--enable=errcheck'] },
 			});
-			let linterTestPath = path.join(fixtureSourcePath, 'linterTest');
+			let linterTestPath = path.join(fixturePath, 'linterTest');
 			let expected = [
 				{ file: path.join(linterTestPath, 'linter_1.go'), line: 8, severity: 'warning', msg: 'error return value not checked (a declared but not used) (errcheck' },
 				{ file: path.join(linterTestPath, 'linter_2.go'), line: 5, severity: 'warning', msg: 'error return value not checked (missing return) (errcheck)' },

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -380,7 +380,8 @@ It returns the number of bytes written and any write error encountered.
 				{ line: 11, severity: 'warning', msg: 'error return value not checked (undeclared name: prin) (errcheck)' },
 				{ line: 11, severity: 'warning', msg: 'unused variable or constant undeclared name: prin (varcheck)' },
 			];
-			return check(vscode.Uri.file(path.join(fixturePath, 'errorsTest', 'errors.go')), config).then(diagnostics => {
+			let errorsTestPath = path.join(fixtureSourcePath, 'errorsTest', 'errors.go') || '';
+			return check(vscode.Uri.file(errorsTestPath), config).then(diagnostics => {
 				let sortedDiagnostics = diagnostics.sort((a, b) => {
 					if (a.msg < b.msg)
 						return -1;
@@ -388,6 +389,9 @@ It returns the number of bytes written and any write error encountered.
 						return 1;
 					return 0;
 				});
+
+				assert.equal(sortedDiagnostics.length, expected.length, 'Actual error count does not match the expected one');
+
 				for (let i in expected) {
 					assert.equal(sortedDiagnostics[i].line, expected[i].line, `Failed to match expected error #${i}: ${JSON.stringify(sortedDiagnostics)}`);
 					assert.equal(sortedDiagnostics[i].severity, expected[i].severity, `Failed to match expected error #${i}: ${JSON.stringify(sortedDiagnostics)}`);
@@ -849,13 +853,14 @@ It returns the number of bytes written and any write error encountered.
 				'lintTool': { value: 'gometalinter' },
 				'lintFlags': { value: ['--json', '--disable-all', '--enable=golint', '--enable=errcheck'] },
 			});
-			let linterTestPath = path.join(fixturePath, 'linterTest');
+			let linterTestPath = path.join(fixtureSourcePath, 'linterTest');
 			let expected = [
 				{ file: path.join(linterTestPath, 'linter_1.go'), line: 8, severity: 'warning', msg: 'error return value not checked (a declared but not used) (errcheck' },
 				{ file: path.join(linterTestPath, 'linter_2.go'), line: 5, severity: 'warning', msg: 'error return value not checked (missing return) (errcheck)' },
 				{ file: path.join(linterTestPath, 'linter_1.go'), line: 5, severity: 'warning', msg: 'exported function ExportedFunc should have comment or be unexported (golint)' },
 			];
-			return goLint(vscode.Uri.file(path.join(linterTestPath, 'linter_1.go')), config).then(diagnostics => {
+			let linterFilePath = path.join(linterTestPath, 'linter_1.go');
+			return goLint(vscode.Uri.file(linterFilePath), config).then(diagnostics => {
 				let sortedDiagnostics = diagnostics.sort((a, b) => {
 					if (a.msg < b.msg)
 						return -1;
@@ -863,6 +868,9 @@ It returns the number of bytes written and any write error encountered.
 						return 1;
 					return 0;
 				});
+
+				assert.equal(sortedDiagnostics.length, expected.length, 'Actual error count does not match the expected one');
+
 				for (let i in expected) {
 					let errorMsg = `Failed to match expected error #${i}: ${JSON.stringify(sortedDiagnostics)}`;
 					assert(sortedDiagnostics[i].msg.startsWith(expected[i].msg), errorMsg);

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -380,7 +380,7 @@ It returns the number of bytes written and any write error encountered.
 				{ line: 11, severity: 'warning', msg: 'error return value not checked (undeclared name: prin) (errcheck)' },
 				{ line: 11, severity: 'warning', msg: 'unused variable or constant undeclared name: prin (varcheck)' },
 			];
-			let errorsTestPath = path.join(fixtureSourcePath, 'errorsTest', 'errors.go');
+			let errorsTestPath = path.join(fixturePath, 'errorsTest', 'errors.go');
 			return check(vscode.Uri.file(errorsTestPath), config).then(diagnostics => {
 				let sortedDiagnostics = diagnostics.sort((a, b) => {
 					if (a.msg < b.msg)
@@ -390,14 +390,14 @@ It returns the number of bytes written and any write error encountered.
 					return 0;
 				});
 
-				assert.equal(sortedDiagnostics.length, expected.length, 'Actual diagnostics count does not match the expected one');
+				assert.equal(sortedDiagnostics.length, expected.length, `too many errors ${JSON.stringify(sortedDiagnostics)}`);
 
 				for (let i in expected) {
 					assert.equal(sortedDiagnostics[i].line, expected[i].line, `Failed to match expected error #${i}: ${JSON.stringify(sortedDiagnostics)}`);
 					assert.equal(sortedDiagnostics[i].severity, expected[i].severity, `Failed to match expected error #${i}: ${JSON.stringify(sortedDiagnostics)}`);
 					assert.equal(sortedDiagnostics[i].msg, expected[i].msg, `Failed to match expected error #${i}: ${JSON.stringify(sortedDiagnostics)}`);
 				}
-				assert.equal(sortedDiagnostics.length, expected.length, `too many errors ${JSON.stringify(sortedDiagnostics)}`);
+
 				return Promise.resolve();
 			});
 		}).then(() => done(), done);
@@ -869,7 +869,7 @@ It returns the number of bytes written and any write error encountered.
 					return 0;
 				});
 
-				assert.equal(sortedDiagnostics.length, expected.length, 'Actual diagnostics count does not match the expected one');
+				assert.equal(sortedDiagnostics.length, expected.length, `too many errors ${JSON.stringify(sortedDiagnostics)}`);
 
 				for (let i in expected) {
 					let errorMsg = `Failed to match expected error #${i}: ${JSON.stringify(sortedDiagnostics)}`;
@@ -878,7 +878,7 @@ It returns the number of bytes written and any write error encountered.
 					assert.equal(sortedDiagnostics[i].line, expected[i].line, errorMsg);
 					assert.equal(sortedDiagnostics[i].severity, expected[i].severity, errorMsg);
 				}
-				assert.equal(sortedDiagnostics.length, expected.length, `too many errors ${JSON.stringify(sortedDiagnostics)}`);
+
 				return Promise.resolve();
 			});
 		}).then(() => done(), done);

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -390,7 +390,7 @@ It returns the number of bytes written and any write error encountered.
 					return 0;
 				});
 
-				assert.equal(sortedDiagnostics.length, expected.length, 'Actual error count does not match the expected one');
+				assert.equal(sortedDiagnostics.length, expected.length, 'Actual diagnostics count does not match the expected one');
 
 				for (let i in expected) {
 					assert.equal(sortedDiagnostics[i].line, expected[i].line, `Failed to match expected error #${i}: ${JSON.stringify(sortedDiagnostics)}`);
@@ -869,7 +869,7 @@ It returns the number of bytes written and any write error encountered.
 					return 0;
 				});
 
-				assert.equal(sortedDiagnostics.length, expected.length, 'Actual error count does not match the expected one');
+				assert.equal(sortedDiagnostics.length, expected.length, 'Actual diagnostics count does not match the expected one');
 
 				for (let i in expected) {
 					let errorMsg = `Failed to match expected error #${i}: ${JSON.stringify(sortedDiagnostics)}`;


### PR DESCRIPTION
Fix the broken source paths so the failing [tests](https://travis-ci.org/Microsoft/vscode-go/builds/345395708) (Gometalinter error checking and Test Linter for Package) pass. Also add an extra assert before traversing the expected errors in order to prevent an uncaught exception if no result is brought by gometalinter

@ramya-rao-a PTAL

PS: on a side note, gometalinter is not listed as a dependency for running tests locally. After I fixed the test code I realized I didn't have gometalinter installed, nor all of the required linters. I can add this info to the [wiki](https://github.com/Microsoft/vscode-go/wiki/Building,-Debugging-and-Sideloading-the-extension-in-Visual-Studio-Code) if it is ok with you