### PR TITLE
Do not filter comment lines when hovering on structures

### DIFF
--- a/src/goExtraInfo.ts
+++ b/src/goExtraInfo.ts
@@ -29,7 +29,7 @@ export class GoHoverProvider implements HoverProvider {
 		return definitionLocation(document, position, goConfig, true, token).then(definitionInfo => {
 			if (definitionInfo == null) return null;
 			let lines = definitionInfo.declarationlines
-				.filter(line => !line.startsWith('\t//') && line !== '')
+				.filter(line => line !== '')
 				.map(line => line.replace(/\t/g, '    '));
 			let text;
 			text = lines.join('\n').replace(/\n+$/, '');


### PR DESCRIPTION
remove filter of lines starting with "\t//"

Fixes: https://github.com/Microsoft/vscode-go/issues/1550
Signed-off-by: Dan Mick <dan.mick@redhat.com>