### PR TITLE
bugfix: Ensure 'debug test' codelens only tests the selected test.

### DIFF
--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -82,7 +82,7 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 					arguments: [{ functionName: func.name }]
 				};
 
-				const args = ['-test.run', func.name];
+				const args = ['-test.run', '^' + func.name + '$'];
 				const program = path.dirname(document.fileName);
 				const env = Object.assign({}, this.debugConfig.env, vsConfig['testEnvVars']);
 				const envFile = vsConfig['testEnvFile'];


### PR DESCRIPTION
If you have two functions `TestFoo` and `TestFooTwo`, and select
'debug test' on `TestFoo`, both tests will be executed. This happens
because `go test -test.run` expects a regular expression, but we were
only passing it a function name, causing both tests to pass the regex check.

Fixed by wrapping the function name in start/end markers.

This is similar to what we do when running the tests e.g.
https://github.com/Microsoft/vscode-go/blob/3d35f45653506e14d4e98689eb22dd7fe4654478/src/testUtils.ts#L222