### PR TITLE
Add the output option for the delve

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,6 +412,11 @@
                   "lldb"
                 ],
                 "description": "Backend used by delve. Only available in delve version 0.12.2 and above."
+              },
+              "output": {
+                "type": "string",
+                "description": "Output path for the bynary of delve",
+                "default": "debug"
               }
             }
           }

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -140,6 +140,7 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	/** Optional path to .env file. */
 	envFile?: string;
 	backend?: string;
+	output?: string;
 }
 
 process.on('uncaughtException', (err: any) => {
@@ -300,6 +301,9 @@ class Delve {
 			}
 			if (launchArgs.backend) {
 				dlvArgs = dlvArgs.concat(['--backend=' + launchArgs.backend]);
+			}
+			if (launchArgs.output && mode === 'debug') {
+				dlvArgs = dlvArgs.concat(['--output=' + launchArgs.output]);
 			}
 			if (launchArgs.args) {
 				dlvArgs = dlvArgs.concat(['--', ...launchArgs.args]);


### PR DESCRIPTION
Hi

I added the output option for delve. 
You would be able to use delve, even if there has been `debug` directory already.

Thank you