### PR TITLE
Make tools re-compiling warnings scoped by toolsGopath

### DIFF
--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -68,8 +68,16 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	updateGoPathGoRootFromConfig().then(() => {
 		const updateToolsCmdText = 'Update tools';
-		const prevGoroot = ctx.globalState.get('goroot');
-		const currentGoroot = process.env['GOROOT'];
+		interface goInfo {
+			goroot: string;
+			version: string;
+		}
+		const toolsGopath = getToolsGopath() || getCurrentGoPath();
+		let toolsGoInfo: { [id: string]: goInfo; } = ctx.globalState.get('toolsGoInfo') || {};
+		if (!toolsGoInfo[toolsGopath]) toolsGoInfo[toolsGopath] = { goroot: null, version: null };
+		const prevGoroot = toolsGoInfo[toolsGopath].goroot;
+		const currentGoroot: string = process.env['GOROOT'];
+		vscode.window.showInformationMessage(currentGoroot);
 		if (prevGoroot !== currentGoroot && prevGoroot) {
 			vscode.window.showInformationMessage('Your goroot is different than before, a few Go tools may need recompiling', updateToolsCmdText).then(selected => {
 				if (selected === updateToolsCmdText) {
@@ -79,7 +87,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		} else {
 			getGoVersion().then(currentVersion => {
 				if (currentVersion) {
-					const prevVersion = ctx.globalState.get('goVersion');
+					const prevVersion = toolsGoInfo[toolsGopath].version;
 					const currVersionString = `${currentVersion.major}.${currentVersion.minor}`;
 
 					if (prevVersion !== currVersionString) {
@@ -90,12 +98,13 @@ export function activate(ctx: vscode.ExtensionContext): void {
 								}
 							});
 						}
-						ctx.globalState.update('goVersion', currVersionString);
+						toolsGoInfo[toolsGopath].version = currVersionString;
 					}
 				}
 			});
 		}
-		ctx.globalState.update('goroot', currentGoroot);
+		toolsGoInfo[toolsGopath].goroot = currentGoroot;
+		ctx.globalState.update('toolsGoroot', toolsGoInfo);
 
 		offerToInstallTools();
 		if (checkLanguageServer()) {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -68,12 +68,12 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	updateGoPathGoRootFromConfig().then(() => {
 		const updateToolsCmdText = 'Update tools';
-		interface goInfo {
+		interface GoInfo {
 			goroot: string;
 			version: string;
 		}
 		const toolsGopath = getToolsGopath() || getCurrentGoPath();
-		let toolsGoInfo: { [id: string]: goInfo; } = ctx.globalState.get('toolsGoInfo') || {};
+		let toolsGoInfo: { [id: string]: GoInfo; } = ctx.globalState.get('toolsGoInfo') || {};
 		if (!toolsGoInfo[toolsGopath]) toolsGoInfo[toolsGopath] = { goroot: null, version: null };
 		const prevGoroot = toolsGoInfo[toolsGopath].goroot;
 		const currentGoroot: string = process.env['GOROOT'];


### PR DESCRIPTION
When switching between workspaces with different goroot and toolsGopath
settings, the editor is suggesting that re-compiling tools is required
because the GOROOT state is global and not toolsGopath-aware.

This makes the global context a map keyed on toolsGopath.