### PR TITLE
prompt user to update go.buildTags if file has the build tags

### DIFF
--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -51,17 +51,20 @@ export function checksOnFileEdit(e: vscode.TextDocumentChangeEvent) {
 	const openSettings = {title: 'Open settings'};
 
 	for (let i = 0; i < e.document.lineCount; i++) {
-		if (e.document.lineAt(i).text.match(/^\/\/ \+build [\w\s]+$/)) {
-			fileBuildTags.push(...e.document.lineAt(i).text.split(' '));
+		if (e.document.lineAt(i).isEmptyOrWhitespace) {
+			break;
+		}
+		let foundBuildTags = e.document.lineAt(i).text.match(/^\/\/\s*\+build\s+(.+)$/)[1].split(' ');
+		if (foundBuildTags) {
+			foundBuildTags = foundBuildTags.filter(item => item !== '');
+			fileBuildTags.push(...foundBuildTags);
 		}
 	}
-
-	fileBuildTags = fileBuildTags.filter(tag => tag !== '+build' && tag !== '//' && tag !== '' && tag !== '//+build');
 
 	if (fileBuildTags) {
 		for (let i = 0; i < fileBuildTags.length; i++) {
 			if (settingsBuildTags === null || settingsBuildTags.indexOf(fileBuildTags[i]) === -1) {
-				vscode.window.showInformationMessage('Build tags mentioned in the file don not match with "go.buildTags"', neverAgain, openSettings).then(result => {
+				vscode.window.showInformationMessage('Build tags mentioned in the file don not match with "go.buildTags"'+fileBuildTags, neverAgain, openSettings).then(result => {
 					if (result === neverAgain) {
 						ctx.globalState.update('ignoreGeneratedCodeWarning', true);
 					}

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -18,7 +18,7 @@ import { GoRunTestCodeLensProvider } from './goRunTestCodelens';
 import { GoSignatureHelpProvider } from './goSignature';
 import { GoWorkspaceSymbolProvider } from './goSymbol';
 import { GoCodeActionProvider } from './goCodeAction';
-import { check, removeTestStatus, notifyIfGeneratedFile } from './goCheck';
+import { check, removeTestStatus, checksOnFileEdit } from './goCheck';
 import { updateGoPathGoRootFromConfig, offerToInstallTools } from './goInstallTools';
 import { GO_MODE } from './goMode';
 import { showHideStatus } from './goStatus';
@@ -148,7 +148,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	vscode.window.onDidChangeActiveTextEditor(showHideStatus, null, ctx.subscriptions);
 	vscode.window.onDidChangeActiveTextEditor(getCodeCoverage, null, ctx.subscriptions);
 	vscode.workspace.onDidChangeTextDocument(parseLiveFile, null, ctx.subscriptions);
-	vscode.workspace.onDidChangeTextDocument(notifyIfGeneratedFile, ctx, ctx.subscriptions);
+	vscode.workspace.onDidChangeTextDocument(checksOnFileEdit, ctx, ctx.subscriptions);
 
 	startBuildOnSaveWatcher(ctx.subscriptions);
 


### PR DESCRIPTION
This one is for #1497, I have added check to prompt the user to update "go.buildTags" settings if the file has build tags that are not specified in "go.buildTags". The prompt has two options, "Don't show again" and "Open settings".  