### PR TITLE
Enable setting test arguments with '-args' 

### DIFF
--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -125,11 +125,11 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 
 		let buildTags: string = testconfig.goConfig['buildTags'];
 		let args: Array<string> = ['test', ...testconfig.flags];
-		
+
 		// command-line arguments after '-args' are for the test being run, not for 'go test'
-		let testArgsIx = args.indexOf("-args");
+		let testArgsIx = args.indexOf('-args');
 		let testArgs = [];
-		if(testArgsIx > 0) {
+		if (testArgsIx > 0) {
 			testArgs = args.splice(testArgsIx);
 		}
 		let testType: string = testconfig.isBenchmark ? 'Benchmarks' : 'Tests';
@@ -169,7 +169,7 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 
 			// args given after '-args' terminate argument processing for 'go test' and thus need to go last
 			args.push(...targets, ...testArgs);
-			
+
 			let proc = cp.spawn(goRuntimePath, args, { env: testEnvVars, cwd: testconfig.dir });
 			const outBuf = new LineBuffer();
 			const errBuf = new LineBuffer();

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -125,6 +125,13 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 
 		let buildTags: string = testconfig.goConfig['buildTags'];
 		let args: Array<string> = ['test', ...testconfig.flags];
+		
+		// command-line arguments after '-args' are for the test being run, not for 'go test'
+		let testArgsIx = args.indexOf("-args");
+		let testArgs = [];
+		if(testArgsIx > 0) {
+			testArgs = args.splice(testArgsIx);
+		}
 		let testType: string = testconfig.isBenchmark ? 'Benchmarks' : 'Tests';
 
 		if (testconfig.isBenchmark) {
@@ -160,8 +167,9 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 			outputChannel.appendLine(['Running tool:', goRuntimePath, ...outTargets].join(' '));
 			outputChannel.appendLine('');
 
-			args.push(...targets);
-
+			// args given after '-args' terminate argument processing for 'go test' and thus need to go last
+			args.push(...targets, ...testArgs);
+			
 			let proc = cp.spawn(goRuntimePath, args, { env: testEnvVars, cwd: testconfig.dir });
 			const outBuf = new LineBuffer();
 			const errBuf = new LineBuffer();

--- a/test/fixtures/testArgsTest/args_test.go
+++ b/test/fixtures/testArgsTest/args_test.go
@@ -1,0 +1,24 @@
+package testargstest
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+
+	// test that we can pass test-specific arguments with '-args'
+
+	fmt.Fprintf(os.Stderr, "args: %#v", os.Args)
+
+	foo := flag.String("foo", "", "test foo arg")
+	flag.Parse()
+
+	if *foo != "testval" {
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -74,6 +74,7 @@ suite('Go Extension Tests', () => {
 		fs.copySync(path.join(fixtureSourcePath, 'fillStruct', 'input_2.go'), path.join(fixturePath, 'fillStruct', 'input_2.go'));
 		fs.copySync(path.join(fixtureSourcePath, 'fillStruct', 'golden_2.go'), path.join(fixturePath, 'fillStruct', 'golden_2.go'));
 		fs.copySync(path.join(fixtureSourcePath, 'fillStruct', 'input_2.go'), path.join(fixturePath, 'fillStruct', 'input_3.go'));
+		fs.copySync(path.join(fixtureSourcePath, 'testArgsTest', 'args_test.go'), path.join(fixturePath, 'testArgsTest', 'args_test.go'));
 	});
 
 	suiteTeardown(() => {
@@ -517,6 +518,25 @@ It returns the number of bytes written and any write error encountered.
 				});
 			});
 		}).then(() => done(), done);
+	});
+
+	test("Test '-args' are correctly passed to tests", (done) => {
+		let config = Object.create(vscode.workspace.getConfiguration('go'), {
+			'testFlags': { value: ["-v", "-args", "-foo", "testval"]}
+		});
+		
+
+		let uri = vscode.Uri.file(path.join(fixturePath, 'testArgsTest', 'args_test.go'));
+		vscode.workspace.openTextDocument(uri).then(document => {
+			return vscode.window.showTextDocument(document).then(editor => {
+				return testCurrentFile(config, []).then((result: boolean) => {
+					assert.equal(result, true);
+					return Promise.resolve();
+				});
+			});
+		}).then(() => done(), done);
+
+
 	});
 
 	test('Test Outline', (done) => {

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -279,9 +279,9 @@ It returns the number of bytes written and any write error encountered.
 				for (let i in expected) {
 					for (let j in sortedDiagnostics) {
 						if (expected[i].line
-						&& (expected[i].line === sortedDiagnostics[j].line)
-						&& (expected[i].severity === sortedDiagnostics[j].severity)
-						&& (expected[i].msg === sortedDiagnostics[j].msg)) {
+							&& (expected[i].line === sortedDiagnostics[j].line)
+							&& (expected[i].severity === sortedDiagnostics[j].severity)
+							&& (expected[i].msg === sortedDiagnostics[j].msg)) {
 							matchCount++;
 						}
 					}
@@ -405,8 +405,8 @@ It returns the number of bytes written and any write error encountered.
 				for (let i in expected) {
 					for (let j in sortedDiagnostics) {
 						if ((expected[i].line === sortedDiagnostics[j].line)
-						&& (expected[i].severity === sortedDiagnostics[j].severity)
-						&& (expected[i].msg === sortedDiagnostics[j].msg)) {
+							&& (expected[i].severity === sortedDiagnostics[j].severity)
+							&& (expected[i].msg === sortedDiagnostics[j].msg)) {
 							matchCount++;
 						}
 					}
@@ -520,11 +520,11 @@ It returns the number of bytes written and any write error encountered.
 		}).then(() => done(), done);
 	});
 
-	test("Test '-args' are correctly passed to tests", (done) => {
+	test('Test "-args" are correctly passed to tests', (done) => {
 		let config = Object.create(vscode.workspace.getConfiguration('go'), {
-			'testFlags': { value: ["-v", "-args", "-foo", "testval"]}
+			'testFlags': { value: ['-v', '-args', '-foo', 'testval'] }
 		});
-		
+
 
 		let uri = vscode.Uri.file(path.join(fixturePath, 'testArgsTest', 'args_test.go'));
 		vscode.workspace.openTextDocument(uri).then(document => {


### PR DESCRIPTION
Test arguments are now correctly passed in. Users have to set their `go.buildFlags`, e.g.:

```go
"go.buildFlags": [
        "-args",
        "-foo",
        "i_am_foo",
        "-bar",
        "i_am_bar"
    ]
```
