### PR TITLE
When gotoSymbol.includeGoroot is set, also show symbols from GOROOT

### DIFF
--- a/package.json
+++ b/package.json
@@ -689,6 +689,12 @@
           "description": "If false, the import statements will be excluded while using the Go to Symbol in File feature",
           "scope": "resource"
         },
+        "go.gotoSymbol.includeGoroot": {
+          "type": "boolean",
+          "default": false,
+          "description": "If false, the standard library located at $GOROOT will be excluded while using the Go to Symbol in File feature",
+          "scope": "resource"
+        },
         "go.enableCodeLens": {
           "type": "object",
           "properties": {

--- a/src/goSymbol.ts
+++ b/src/goSymbol.ts
@@ -60,19 +60,66 @@ export class GoWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider
 			return;
 		}
 
-		let workspaceSymbols = getSymbols(root, query, token, goConfig);
-		let gorootSymbols = goConfig.gotoSymbol.includeGoroot
-			? getGoroot().then(goroot => getSymbols(goroot, query, token, goConfig))
-			: <GoSymbolDeclaration[]>[];
-
-		return Promise.all([workspaceSymbols, gorootSymbols])
-			.then(([...results]) => <GoSymbolDeclaration[]>[].concat(...results))
-			.then(results => {
-				let symbols: vscode.SymbolInformation[] = [];
-				convertToCodeSymbols(results, symbols);
-				return symbols;
-			});
+		return getWorkspaceSymbols(root, query, token, goConfig).then(results => {
+			let symbols: vscode.SymbolInformation[] = [];
+			convertToCodeSymbols(results, symbols);
+			return symbols;
+		});
 	}
+}
+
+export function getWorkspaceSymbols(workspacePath: string, query: string, token: vscode.CancellationToken, goConfig?: vscode.WorkspaceConfiguration, ignoreFolderFeatureOn: boolean = true): Thenable<GoSymbolDeclaration[]> {
+	if (!goConfig) {
+		goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
+	}
+	let gotoSymbolConfig = goConfig['gotoSymbol'];
+	let calls: Promise<GoSymbolDeclaration[]>[] = [];
+
+	let ignoreFolders: string[] = gotoSymbolConfig ? gotoSymbolConfig['ignoreFolders'] : [];
+	let baseArgs = (ignoreFolderFeatureOn && ignoreFolders && ignoreFolders.length > 0) ? ['-ignore', ignoreFolders.join(',')] : [];
+
+	calls.push(callGoSymbols([...baseArgs, workspacePath, query], token));
+
+	if (gotoSymbolConfig.includeGoroot) {
+		let gorootCall = getGoroot()
+			.then(goRoot => callGoSymbols([...baseArgs, goRoot, query], token));
+		calls.push(gorootCall);
+	}
+
+	return Promise.all(calls)
+		.then(([...results]) => <GoSymbolDeclaration[]>[].concat(...results))
+		.catch((err: Error) => {
+			if (err && (<any>err).code === 'ENOENT') {
+				promptForMissingTool('go-symbols');
+			}
+			if (err.message.startsWith('flag provided but not defined: -ignore')) {
+				promptForUpdatingTool('go-symbols');
+				return getWorkspaceSymbols(workspacePath, query, token, goConfig, false);
+			}
+		});
+}
+
+function callGoSymbols(args: string[], token: vscode.CancellationToken): Promise<GoSymbolDeclaration[]> {
+	let gosyms = getBinPath('go-symbols');
+	let env = getToolsEnvVars();
+	let p: cp.ChildProcess;
+
+	if (token) {
+		token.onCancellationRequested(() => killProcess(p));
+	}
+
+	return new Promise((resolve, reject) => {
+		p = cp.execFile(gosyms, args, { maxBuffer: 1024 * 1024, env }, (err, stdout, stderr) => {
+			if (err && stderr && stderr.startsWith('flag provided but not defined: -ignore')) {
+				return reject(new Error(stderr));
+			} else if (err) {
+				return reject(err);
+			}
+			let result = stdout.toString();
+			let decls = <GoSymbolDeclaration[]>JSON.parse(result);
+			return resolve(decls);
+		});
+	});
 }
 
 function getGoroot(): Promise<string> {
@@ -92,42 +139,3 @@ function getGoroot(): Promise<string> {
 	});
 }
 
-export function getSymbols(lookupPath: string, query: string, token: vscode.CancellationToken, goConfig?: vscode.WorkspaceConfiguration, ignoreFolderFeatureOn: boolean = true): Thenable<GoSymbolDeclaration[]> {
-	if (!goConfig) {
-		goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
-	}
-	let gotoSymbolConfig = goConfig['gotoSymbol'];
-	let ignoreFolders: string[] = gotoSymbolConfig ? gotoSymbolConfig['ignoreFolders'] : [];
-	let args = (ignoreFolderFeatureOn && ignoreFolders && ignoreFolders.length > 0) ? ['-ignore', ignoreFolders.join(',')] : [];
-	args.push(lookupPath);
-	args.push(query);
-	let gosyms = getBinPath('go-symbols');
-	let env = getToolsEnvVars();
-	let p: cp.ChildProcess;
-	if (token) {
-		token.onCancellationRequested(() => killProcess(p));
-	}
-
-	return new Promise((resolve, reject) => {
-		p = cp.execFile(gosyms, args, { maxBuffer: 1024 * 1024, env }, (err, stdout, stderr) => {
-			try {
-				if (err && (<any>err).code === 'ENOENT') {
-					promptForMissingTool('go-symbols');
-				}
-				if (err && stderr && stderr.startsWith('flag provided but not defined: -ignore')) {
-					promptForUpdatingTool('go-symbols');
-					p = null;
-					return getSymbols(lookupPath, query, token, goConfig, false).then(results => {
-						return resolve(results);
-					});
-				}
-				if (err) return resolve(null);
-				let result = stdout.toString();
-				let decls = <GoSymbolDeclaration[]>JSON.parse(result);
-				return resolve(decls);
-			} catch (e) {
-				reject(e);
-			}
-		});
-	});
-}

--- a/src/goSymbol.ts
+++ b/src/goSymbol.ts
@@ -62,10 +62,10 @@ export class GoWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider
 		let workspaceSymbols = getSymbols(root, query, token, goConfig);
 		let gorootSymbols = goConfig.gotoSymbol.includeGoroot && process.env.GOROOT
 			? getSymbols(process.env.GOROOT, query, token, goConfig)
-			: [];
+			: <GoSymbolDeclaration[]>[];
 
 		return Promise.all([workspaceSymbols, gorootSymbols])
-			.then(([...results]) => [].concat(...results))
+			.then(([...results]) => <GoSymbolDeclaration[]>[].concat(...results))
 			.then(results => {
 				let symbols: vscode.SymbolInformation[] = [];
 				convertToCodeSymbols(results, symbols);

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -11,7 +11,7 @@ import { GoHoverProvider } from '../src/goExtraInfo';
 import { GoCompletionItemProvider } from '../src/goSuggest';
 import { GoSignatureHelpProvider } from '../src/goSignature';
 import { GoDefinitionProvider } from '../src/goDeclaration';
-import { getWorkspaceSymbols } from '../src/goSymbol';
+import { getSymbols } from '../src/goSymbol';
 import { check } from '../src/goCheck';
 import cp = require('child_process');
 import { getEditsFromUnifiedDiffStr, getEdits } from '../src/diffUtils';
@@ -703,11 +703,11 @@ It returns the number of bytes written and any write error encountered.
 				}
 			}
 		});
-		let withoutIgnoringFolders = getWorkspaceSymbols(workspacePath, 'WinInfo', null, configWithoutIgnoringFolders).then(results => {
+		let withoutIgnoringFolders = getSymbols(workspacePath, 'WinInfo', null, configWithoutIgnoringFolders).then(results => {
 			assert.equal(results[0].name, 'WinInfo');
 			assert.equal(results[0].path, path.join(workspacePath, 'vendor/9fans.net/go/acme/acme.go'));
 		});
-		let withIgnoringFolders = getWorkspaceSymbols(workspacePath, 'WinInfo', null, configWithIgnoringFolders).then(results => {
+		let withIgnoringFolders = getSymbols(workspacePath, 'WinInfo', null, configWithIgnoringFolders).then(results => {
 			assert.equal(results.length, 0);
 		});
 		Promise.all([withIgnoringFolders, withoutIgnoringFolders]).then(() => done(), done);

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -703,6 +703,20 @@ It returns the number of bytes written and any write error encountered.
 				}
 			}
 		});
+		let configWithIncludeGoroot = Object.create(vscode.workspace.getConfiguration('go'), {
+			'gotoSymbol': {
+				value: {
+					'includeGoroot': true
+				}
+			}
+		});
+		let configWithoutIncludeGoroot = Object.create(vscode.workspace.getConfiguration('go'), {
+			'gotoSymbol': {
+				value: {
+					'includeGoroot': false
+				}
+			}
+		});
 		let withoutIgnoringFolders = getSymbols(workspacePath, 'WinInfo', null, configWithoutIgnoringFolders).then(results => {
 			assert.equal(results[0].name, 'WinInfo');
 			assert.equal(results[0].path, path.join(workspacePath, 'vendor/9fans.net/go/acme/acme.go'));
@@ -710,6 +724,13 @@ It returns the number of bytes written and any write error encountered.
 		let withIgnoringFolders = getSymbols(workspacePath, 'WinInfo', null, configWithIgnoringFolders).then(results => {
 			assert.equal(results.length, 0);
 		});
+		let withoutIncludingGoroot = getSymbols(workspacePath, 'printf', null, configWithoutIncludeGoroot).then(results => {
+			assert.equal(results.length, 0);
+		});
+		let withIncludingGoroot = getSymbols(workspacePath, 'WinInfo', null, configWithIncludeGoroot).then(results => {
+			assert.equal(results[0].name, 'printf');
+		});
+		
 		Promise.all([withIgnoringFolders, withoutIgnoringFolders]).then(() => done(), done);
 	});
 


### PR DESCRIPTION
Setting the option to true enables the user to include the standard
library located at GOROOT to be included in the results shown on
"Go To Symbol" - resolves #1567