### PR TITLE
When using go-languageserver, also use code completion feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The Go extension is ready to use on the get go. If you want to customize the fea
 
 The Go extension uses a host of Go tools to provide the various language features. An alternative is to use a single language server that provides the same feature.  
 
-Set `go.useLanguageServer` to `true` to use the Go language server from [Sourcegraph](https://github.com/sourcegraph/go-langserver) for features like Hover, Definition, Find All References, Signature Help, Go to Symbol in File and Workspace.
+Set `go.useLanguageServer` to `true` to use the Go language server from [Sourcegraph](https://github.com/sourcegraph/go-langserver) for features like Code completion, Hover, Definition, Find All References, Signature Help, Go to Symbol in File and Workspace.
 * This is an experimental feature and is not available in Windows yet.
 * If set to true, you will be prompted to install the Go language server. Once installed, you will have to reload VS Code window. The language server will then be run by the Go extension in the background to provide services needed for the above mentioned features.
 * Everytime you change the value of the setting `go.useLanguageServer`, you need to reload the VS Code window for it to take effect.

--- a/package.json
+++ b/package.json
@@ -702,10 +702,16 @@
               "type": "boolean",
               "default": false,
               "description": "If true, gofmt is used by the language server to format files."
+            },
+            "autoComplete": {
+              "type": "boolean",
+              "default": false,
+              "description": "If true, the language server will provide code completion results."
             }
           },
           "default": {
-            "format": false
+            "format": false,
+            "autoComplete": false
           },
           "description": "Use this setting to enable/disable experimental features from the language server."
         },

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -264,7 +264,7 @@ function installTools(goVersion: SemVersion, missing?: string[]) {
 		outputChannel.appendLine(''); // Blank line for spacing
 		let failures = res.filter(x => x != null);
 		if (failures.length === 0) {
-			if (missing.indexOf('langserver-go') > -1) {
+			if (missing.indexOf('go-langserver') > -1) {
 				outputChannel.appendLine('Reload VS Code window to use the Go language server');
 			}
 			outputChannel.appendLine('All tools successfully installed. You\'re ready to Go :).');
@@ -388,13 +388,13 @@ export function checkLanguageServer(): boolean {
 
 	// we execute the languageserver using -help so that it will fail and
 	// print all the available flags
-	let langserverSupportsCompletion = true;
+	let helpText = '';
 	try {
-		cp.execFileSync(getBinPath('go-langserver'), ['-help']);
+		helpText = cp.execFileSync(getBinPath('go-langserver'), ['-help']).toString();
 	} catch (err) {
-		let stderr: string = err.stderr.toString();
-		langserverSupportsCompletion = stderr.includes('-gocodecompletion');
+		helpText = (<cp.SpawnSyncReturns<Buffer>>err).stderr.toString();
 	}
+	let langserverSupportsCompletion = helpText.includes('-gocodecompletion');
 
 	if (!langserverSupportsCompletion) {
 		promptForUpdatingTool('go-langserver');
@@ -412,8 +412,3 @@ function allFoldersHaveSameGopath(): boolean {
 	let tempGopath = getCurrentGoPath(vscode.workspace.workspaceFolders[0].uri);
 	return vscode.workspace.workspaceFolders.find(x => tempGopath !== getCurrentGoPath(x.uri)) ? false : true;
 }
-
-
-
-
-

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -383,8 +383,25 @@ export function checkLanguageServer(): boolean {
 	if (!langServerAvailable) {
 		promptForMissingTool('go-langserver');
 		vscode.window.showInformationMessage('Reload VS Code window after installing the Go language server');
+		return langServerAvailable;
 	}
-	return langServerAvailable;
+
+	// we execute the languageserver using -help so that it will fail and
+	// print all the available flags
+	let langserverSupportsCompletion = true;
+	try {
+		cp.execFileSync(getBinPath('go-langserver'), ['-help']);
+	} catch (err) {
+		let stderr: string = err.stderr.toString();
+		langserverSupportsCompletion = stderr.includes('-gocodecompletion');
+	}
+
+	if (!langserverSupportsCompletion) {
+		promptForUpdatingTool('go-langserver');
+		vscode.window.showInformationMessage('Reload VS Code window after updating the Go language server');
+	}
+
+	return langserverSupportsCompletion;
 }
 
 function allFoldersHaveSameGopath(): boolean {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -380,42 +380,27 @@ function getMissingTools(goVersion: SemVersion): Promise<string[]> {
 }
 
 // If langserver needs to be used, but is not installed, this will prompt user to install and Reload
-// If langserver needs to be used, and is installed, this will return the list of supported flags
-// Returns null in all other cases
-export function checkLanguageServer(): string[] {
+// If langserver needs to be used, and is installed, this will return true
+// Returns false in all other cases
+export function checkLanguageServer(): boolean {
 	let latestGoConfig = vscode.workspace.getConfiguration('go');
-	if (!latestGoConfig['useLanguageServer']) return null;
+	if (!latestGoConfig['useLanguageServer']) return false;
 
 	if (process.platform === 'win32') {
 		vscode.window.showInformationMessage('The Go language server is not supported on Windows yet.');
-		return null;
+		return false;
 	}
 	if (!allFoldersHaveSameGopath()) {
 		vscode.window.showInformationMessage('The Go language server is not supported in a multi root set up with different GOPATHs.');
-		return null;
+		return false;
 	}
 
 	let langServerAvailable = getBinPath('go-langserver') !== 'go-langserver';
 	if (!langServerAvailable) {
 		promptForMissingTool('go-langserver');
 		vscode.window.showInformationMessage('Reload VS Code window after installing the Go language server');
-		return null;
 	}
-
-	// we execute the languageserver using -help so that it will fail and
-	// print all the available flags
-	let helpText = '';
-	try {
-		helpText = cp.execFileSync(getBinPath('go-langserver'), ['-help']).toString();
-	} catch (err) {
-		helpText = (<cp.SpawnSyncReturns<Buffer>>err).stderr.toString();
-	}
-
-	// return the list of supported flags so consumers know what features
-	// can be supported
-	return helpText.split('\n')
-		.filter(line => line.trim().startsWith('-'))
-		.map(flag => flag.split(' ')[0]);
+	return langServerAvailable;
 }
 
 function allFoldersHaveSameGopath(): boolean {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -96,7 +96,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 				'go-langserver',
 				{
 					command: getBinPath('go-langserver'),
-					args: ['-mode=stdio', ...langServerFlags],
+					args: ['-mode=stdio', '-gocodecompletion', ...langServerFlags],
 				},
 				{
 					documentSelector: ['go'],
@@ -110,6 +110,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 			ctx.subscriptions.push(c.start());
 		} else {
+			ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(GO_MODE, new GoCompletionItemProvider(), '.', '\"'));
 			ctx.subscriptions.push(vscode.languages.registerHoverProvider(GO_MODE, new GoHoverProvider()));
 			ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(GO_MODE, new GoDefinitionProvider()));
 			ctx.subscriptions.push(vscode.languages.registerReferenceProvider(GO_MODE, new GoReferenceProvider()));
@@ -130,7 +131,6 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	let testCodeLensProvider = new GoRunTestCodeLensProvider();
 	let referencesCodeLensProvider = new GoReferencesCodeLensProvider();
 
-	ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(GO_MODE, new GoCompletionItemProvider(), '.', '\"'));
 	ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(GO_MODE, new GoDocumentFormattingEditProvider()));
 	ctx.subscriptions.push(vscode.languages.registerRenameProvider(GO_MODE, new GoRenameProvider()));
 	ctx.subscriptions.push(vscode.languages.registerCodeActionsProvider(GO_MODE, new GoCodeActionProvider()));

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -135,14 +135,14 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 				const outdatedMsg = `Your installed version of "go-langserver" is out of date and does not support {0}. Falling back to default behavior.`;
 
-				if (!languageServerExperimentalFeatures['autoComplete'] || !capabilities.completionProvider) {
+				if (languageServerExperimentalFeatures['autoComplete'] !== true || !capabilities.completionProvider) {
 					ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(GO_MODE, new GoCompletionItemProvider(), '.', '\"'));
 					if (languageServerExperimentalFeatures['autoComplete'] === true) {
 						vscode.window.showInformationMessage(outdatedMsg.replace('{0}', 'code completion'));
 					}
 				}
 
-				if (!languageServerExperimentalFeatures['format'] || !capabilities.documentFormattingProvider) {
+				if (languageServerExperimentalFeatures['format'] !== true || !capabilities.documentFormattingProvider) {
 					ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(GO_MODE, new GoDocumentFormattingEditProvider()));
 					if (languageServerExperimentalFeatures['format'] === true) {
 						vscode.window.showInformationMessage(outdatedMsg.replace('{0}', 'code formatting'));


### PR DESCRIPTION
Instead of using go-code, use go-languageserver for providing
code completion results when enabled. Solves #1593