### PR TITLE
Fix smart package completion

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -531,14 +531,15 @@ export function guessPackageNameFromFile(filePath): Promise<string[]> {
 
 		const proposedPkgName = segments[segments.length - 1];
 
-		if (goFilename.endsWith('_test.go')) {
-			return resolve([proposedPkgName, proposedPkgName + '_test']);
-		}
-
 		fs.stat(path.join(directoryPath, 'main.go'), (err, stats) => {
 			if (stats && stats.isFile()) {
 				return resolve(['main']);
 			}
+
+			if (goFilename.endsWith('_test.go')) {
+				return resolve([proposedPkgName, proposedPkgName + '_test']);
+			}
+
 			return resolve([proposedPkgName]);
 		});
 	});


### PR DESCRIPTION
Some people might want to test the `main` package with the existence of `main.go`.
On the `_test.go` file, it will suggest `main` as package name instead of `publisher_test` or `publisher`.

Dir structure example:
```
pubsub
- cmd
   - subscriber
      - main.go
   - publisher
      - main.go
      - main_test.go <-- package main
- doc.go
- pubsub.go
```

Q: Why not suggest `main_test`?
A:  Main package are not going to be reused by others, all function  might going to be non-exported. So the test package not will use the non `_test` pattern.