### PR TITLE
Changed single quotes to escaped double quotes in descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -444,7 +444,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Flags to `go build`/`go test` used during build-on-save or running tests. (e.g. ['-ldflags=\"-s\"'])",
+          "description": "Flags to `go build`/`go test` used during build-on-save or running tests. (e.g. [\"-ldflags=\\\"-s\\\"\"])",
           "scope": "resource"
         },
         "go.buildTags": {
@@ -501,7 +501,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Flags to pass to `go tool vet` (e.g. ['-all', '-shadow'])",
+          "description": "Flags to pass to `go tool vet` (e.g. [\"-all\", \"-shadow\"])",
           "scope": "resource"
         },
         "go.formatTool": {
@@ -521,7 +521,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Flags to pass to format tool (e.g. ['-s'])",
+          "description": "Flags to pass to format tool (e.g. [\"-s\"])",
           "scope": "resource"
         },
         "go.inferGopath": {


### PR DESCRIPTION
examples given in the description are wrong as having array with elements surrounded with single quotes will cause error.