### PR TITLE
Allow travis failures on tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ go:
   - 1.10.x
   - tip
 
+matrix:
+  allow_failures:
+    - go: tip
+
 sudo: false
 
 os:


### PR DESCRIPTION
When running tests in CI, the extension is also tested against unstable
`tip`, which is supposed to show upcoming breakages. At the same time lots
of contributors are confused and deterred by builds that break for reasons
unrelated to the changeset. To mitigate this, keep testing on `tip`, but
allow failures, so it can still be used as a canary.