### PR TITLE
Add option to hide test command arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -628,6 +628,12 @@
           "description": "Environment variables that will passed to the processes that run the Go tools (e.g. CGO_CFLAGS)",
           "scope": "resource"
         },
+        "go.hideTestCommandArguments": {
+          "type": "boolean",
+          "default": false,
+          "description": "Hide `go test` command arguments when running tests.",
+          "scope": "resource"
+        },
         "go.gocodeAutoBuild": {
           "type": "boolean",
           "default": false,

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -157,7 +157,14 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 			} else {
 				outTargets.push(...targets);
 			}
-			outputChannel.appendLine(['Running tool:', goRuntimePath, ...outTargets].join(' '));
+
+			// Hide or show test command arguments; useful for user when there are many argumentsC
+			if (testconfig.goConfig['hideTestCommandArguments']) {
+				outputChannel.appendLine(['Running tool:', goRuntimePath, '[arguments hidden]'].join(' '));
+			} else {
+				outputChannel.appendLine(['Running tool:', goRuntimePath, ...outTargets].join(' '));
+			}
+
 			outputChannel.appendLine('');
 
 			args.push(...targets);


### PR DESCRIPTION
### Description

Adds configuration option to hide test command arguments.

### Examples

File used in examples: https://golang.org/src/database/sql/sql_test.go

**Output with `hideTestCommandArguments: false` (default):**

> Running tool: /usr/local/Cellar/go/1.10.1/libexec/bin/go test -timeout 30s -run Running tool: /usr/local/Cellar/go/1.10.1/libexec/bin/go test -timeout 30s -run ^TestOpenDB|TestDriverPanic|TestQuery|TestQueryContext|TestQueryContextWait|TestTxContextWait|TestUnsupportedOptions|TestMultiResultSetQuery|TestQueryNamedArg|TestPoolExhaustOnCancel|TestRowsColumns|TestRowsColumnTypes|TestQueryRow|TestTxRollbackCommitErr|TestStatementErrorAfterClose|TestStatementQueryRow|TestStatementClose|TestStatementQueryRowConcurrent|TestBogusPreboundParameters|TestExec|TestTxPrepare|TestTxStmt|TestTxStmtPreparedOnce|TestTxStmtClosedRePrepares|TestParentStmtOutlivesTxStmt|TestTxStmtFromTxStmtRePrepares|TestTxQuery|TestTxQueryInvalid|TestTxErrBadConn|TestConnQuery|TestConnTx|TestIssue2542Deadlock|TestCloseStmtBeforeRows|TestNullByteSlice|TestPointerParamsAndScans|TestQueryRowClosingStmt|TestIssue6651|TestNullStringParam|TestNullInt64Param|TestNullFloat64Param|TestNullBoolParam|TestQueryRowNilScanDest|TestIssue4902|TestSimultaneousQueries|TestMaxIdleConns|TestMaxOpenConns|TestMaxOpenConnsOnBusy|TestPendingConnsAfterErr|TestSingleOpenConn|TestStats|TestConnMaxLifetime|TestStmtCloseDeps|TestCloseConnBeforeStmts|TestRowsCloseOrder|TestRowsImplicitClose|TestStmtCloseOrder|TestManyErrBadConn|TestIssue20575|TestIssue20622|TestErrBadConnReconnect|TestTxEndBadConn|TestIssue6081|TestIssue18429|TestIssue20160|TestIssue18719|TestIssue20647|TestConcurrency|TestConnectionLeak|TestNamedValueChecker|TestNamedValueCheckerSkip|TestOpenConnector|TestQueryExecContextOnly|TestBadDriver|TestPing|TestTypedString$
>
> PASS
> ok  	database/sql	1.265s
> Success: Tests passed.

**Example output with `hideTestCommandArguments: true`:**
> Running tool: /usr/local/Cellar/go/1.10.1/libexec/bin/go [arguments hidden]
>
> PASS
> ok  	database/sql	1.313s
> Success: Tests passed.

### Screenshots

I found it especially useful when output tab was on the right side of the window.

`hideTestCommandArguments: false`  /  `hideTestCommandArguments: true`
![screenshot 2018-04-26 09 07 01](https://user-images.githubusercontent.com/3007862/39288643-7f2ca6a8-4931-11e8-97ef-24349455804a.png) ![screenshot 2018-04-26 09 06 41](https://user-images.githubusercontent.com/3007862/39288648-8463fa0e-4931-11e8-9ea2-13e76cf507c7.png)

