### PR TITLE
Fix file path expansion for subpackages in go test output.

### DIFF
--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -8,7 +8,7 @@ import path = require('path');
 import vscode = require('vscode');
 import util = require('util');
 import { parseEnvFile, getGoRuntimePath, getCurrentGoWorkspaceFromGOPATH } from './goPath';
-import { getToolsEnvVars, getGoVersion, LineBuffer, SemVersion, resolvePath, getCurrentGoPath } from './util';
+import { getToolsEnvVars, getGoVersion, LineBuffer, SemVersion, resolvePath, getCurrentGoPath, getWorkspaceFolderPath } from './util';
 import { GoDocumentSymbolProvider } from './goOutline';
 import { getNonVendorPackages } from './goPackages';
 
@@ -150,6 +150,8 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 			args.push(testconfig.dir.substr(currentGoWorkspace.length + 1));
 		}
 
+		const workspaceRoot = getWorkspaceFolderPath(vscode.Uri.file(testconfig.dir));
+
 		targetArgs(testconfig).then(targets => {
 			let outTargets = args.slice(0);
 			if (targets.length > 2) {
@@ -166,9 +168,25 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 			const outBuf = new LineBuffer();
 			const errBuf = new LineBuffer();
 
-			outBuf.onLine(line => outputChannel.appendLine(expandFilePathInOutput(line, testconfig.dir)));
-			outBuf.onDone(last => last && outputChannel.appendLine(expandFilePathInOutput(last, testconfig.dir)));
+			const packageResultLineRE = /^(ok|FAIL)[ \t]+(.+?)[ \t]+([0-9\.]+s|\(cached\))/; // 1=ok/FAIL, 2=package, 3=time/(cached)
+			const testResultLines: string[] = [];
 
+			const processTestResultLine = (line: string) => {
+				testResultLines.push(line);
+				const result = line.match(packageResultLineRE);
+				if (result) {
+					const packageNameArr = result[2].split('/');
+					const baseDir = path.join(workspaceRoot, ...packageNameArr.slice(1));
+					testResultLines.forEach(line => outputChannel.appendLine(expandFilePathInOutput(line, baseDir)));
+					testResultLines.splice(0);
+				}
+			};
+
+			// go test emits test results on stdout, which contain file names relative to the package under test
+			outBuf.onLine(line => processTestResultLine(line));
+			outBuf.onDone(last => last && processTestResultLine(last));
+
+			// go test emits build errors on stderr, which contain paths relative to the cwd
 			errBuf.onLine(line => outputChannel.appendLine(expandFilePathInOutput(line, testconfig.dir)));
 			errBuf.onDone(last => last && outputChannel.appendLine(expandFilePathInOutput(last, testconfig.dir)));
 
@@ -230,4 +248,3 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 	}
 	return Promise.resolve([]);
 }
-


### PR DESCRIPTION
This fixes #1626 by using the package name from the go test output combined with the workspace root folder path to expand filenames to their correct path. go test itself buffers all test output in a package until all the tests in a package have completed, so adding our own per-package buffering does not have a visible effect on the latency of test reporting.