### PR TITLE
toolsEnvVars: Fix setting of previously unset env variables

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -347,7 +347,7 @@ export function getToolsEnvVars(): any {
 	const envVars = Object.assign({}, process.env, gopath ? { GOPATH: gopath } : {});
 
 	if (toolsEnvVars && typeof toolsEnvVars === 'object') {
-		Object.keys(toolsEnvVars).forEach(key => envVars[key] = typeof envVars[key] === 'string' ? resolvePath(toolsEnvVars[key]) : envVars[key]);
+		Object.keys(toolsEnvVars).forEach(key => envVars[key] = typeof toolsEnvVars[key] === 'string' ? resolvePath(toolsEnvVars[key]) : toolsEnvVars[key]);
 	}
 
 	// cgo expects go to be in the path


### PR DESCRIPTION
Was broken in https://github.com/Microsoft/vscode-go/commit/be30dfc597d94194b96ae5a03ca7731a90795e8a (only for toolsEnvVars, testEnvConfig and fileEnv don't suffer from the same issue).