### PR TITLE
Fix prevention of completion popup in line comments. (fixes #1659)

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -54,7 +54,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 
 				// prevent completion when typing in a line comment
 				const commentIndex = lineText.indexOf('//');
-				if (commentIndex > 0 && position.character > commentIndex) {
+				if (commentIndex >= 0 && position.character > commentIndex) {
 					return resolve([]);
 				}
 

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -53,8 +53,8 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				let autocompleteUnimportedPackages = config['autocompleteUnimportedPackages'] === true && !lineText.match(/^(\s)*(import|package)(\s)+/);
 
 				// prevent completion when typing in a line comment
-				const commentMatch = lineText.match(/\/\/.*$/);
-				if (commentMatch && position.character > commentMatch.index) {
+				const commentIndex = lineText.indexOf('//');
+				if (commentIndex > 0 && position.character > commentIndex) {
 					return resolve([]);
 				}
 

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -52,7 +52,9 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				let lineTillCurrentPosition = lineText.substr(0, position.character);
 				let autocompleteUnimportedPackages = config['autocompleteUnimportedPackages'] === true && !lineText.match(/^(\s)*(import|package)(\s)+/);
 
-				if (lineText.match(/^\s*\/\//)) {
+				// prevent completion when typing in a line comment
+				const commentMatch = lineText.match(/\/\/.*$/);
+				if (commentMatch && position.character > commentMatch.index) {
 					return resolve([]);
 				}
 
@@ -327,4 +329,3 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 		}
 	}
 }
-


### PR DESCRIPTION
Fixes #1659 by checking for a line comment at the _end_ of the current line and also checking that the cursor position is within the line comment.