### PR TITLE
Triggering autocompletion in comments if the next item is an exported member #1005

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -59,12 +59,11 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				if (lineCommentRegex.test(lineTillCurrentPosition) && position.line + 1 < document.lineCount) {
 					let nextLine = document.lineAt(position.line + 1).text.trim();
 					let memberType = nextLine.match(exportedMemberRegex);
+					let suggestionItem: vscode.CompletionItem;
 					if (memberType && memberType.length === 3) {
-						let suggestionItem = new vscode.CompletionItem(memberType[2]);
-						suggestionItem.kind = vscodeKindFromGoCodeClass(memberType[1]);
-						return resolve([suggestionItem]);
+						suggestionItem = new vscode.CompletionItem(memberType[2], vscodeKindFromGoCodeClass(memberType[1]));
 					}
-					return resolve([]);
+					return resolve(suggestionItem ? [suggestionItem] : []);
 				}
 				// prevent completion when typing in a line comment that doesnt start from the beginning of the line
 				const commentIndex = lineText.indexOf('//');

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -56,7 +56,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 					let nextLine = document.lineAt(position.line + 1).text;
 					let memberName = nextLine.replace(/\s+/g, ' ').trim().split(" ");
 					if (!nextLine.startsWith("\t")) {
-						// check for exported qmembers declared in block
+						// check for exported members declared in block
 						memberName.shift()
 					}
 					if (!memberName[0].match(/^[A-Z]/)) {

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -53,13 +53,18 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				let autocompleteUnimportedPackages = config['autocompleteUnimportedPackages'] === true && !lineText.match(/^(\s)*(import|package)(\s)+/);
 
 				if (lineText.match(/^\s*\/\//)) {
-					let nextLine = document.lineAt(position.line + 1).text;
-					let memberName = nextLine.replace(/\s+/g, ' ').trim().split(' ');
-					if (!nextLine.startsWith('\t')) {
-						// check for exported members declared in block
-						memberName.shift();
+					if (position.line + 1 < document.lineCount) {
+						let nextLine = document.lineAt(position.line + 1).text;
+						let memberName = nextLine.replace(/\s+/g, ' ').trim().split(' ');
+						if ((!nextLine.startsWith('\t'))) {
+							// check for exported members declared in block
+							memberName.shift();
+						}
+						if (!memberName[0].match(/^[A-Z]/)) {
+							return resolve([]);
+						}
 					}
-					if (!memberName[0].match(/^[A-Z]/)) {
+					else {
 						return resolve([]);
 					}
 				}

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -54,10 +54,10 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 
 				if (lineText.match(/^\s*\/\//)) {
 					let nextLine = document.lineAt(position.line + 1).text;
-					let memberName = nextLine.replace(/\s+/g, ' ').trim().split(" ");
-					if (!nextLine.startsWith("\t")) {
+					let memberName = nextLine.replace(/\s+/g, ' ').trim().split(' ');
+					if (!nextLine.startsWith('\t')) {
 						// check for exported members declared in block
-						memberName.shift()
+						memberName.shift();
 					}
 					if (!memberName[0].match(/^[A-Z]/)) {
 						return resolve([]);

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -71,7 +71,6 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 							return resolve([suggestionItem]);
 						}
 					}
-
 				}
 
 				let inString = isPositionInString(document, position);

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -170,7 +170,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 								);
 							}
 							if ((config['useCodeSnippetsOnFunctionSuggest'] || config['useCodeSnippetsOnFunctionSuggestWithoutType'])
-									&& (suggest.class === 'func' || suggest.class === 'var' && suggest.type.startsWith('func('))) {
+								&& (suggest.class === 'func' || suggest.class === 'var' && suggest.type.startsWith('func('))) {
 								let params = parameters(suggest.type.substring(4));
 								let paramSnippets = [];
 								for (let i = 0; i < params.length; i++) {

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -54,8 +54,12 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 
 				if (lineText.match(/^\s*\/\//)) {
 					let nextLine = document.lineAt(position.line + 1).text;
-					let part0 = nextLine.split(" ");
-					if (!part0[1].match(/^[A-Z]/)) {
+					let memberName = nextLine.replace(/\s+/g, ' ').trim().split(" ");
+					if (!nextLine.startsWith("\t")) {
+						// check for exported qmembers declared in block
+						memberName.shift()
+					}
+					if (!memberName[0].match(/^[A-Z]/)) {
 						return resolve([]);
 					}
 				}

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -53,7 +53,11 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				let autocompleteUnimportedPackages = config['autocompleteUnimportedPackages'] === true && !lineText.match(/^(\s)*(import|package)(\s)+/);
 
 				if (lineText.match(/^\s*\/\//)) {
-					return resolve([]);
+					let nextLine = document.lineAt(position.line + 1).text;
+					let part0 = nextLine.split(" ");
+					if (!part0[1].match(/^[A-Z]/)) {
+						return resolve([]);
+					}
 				}
 
 				let inString = isPositionInString(document, position);

--- a/test/fixtures/completions/exportedMemberDocs.go
+++ b/test/fixtures/completions/exportedMemberDocs.go
@@ -20,3 +20,8 @@ func SayHello() {
 type HelloParams struct {
 	language string
 }
+
+type (
+	// 
+	Point struct{ x, y float64 }
+)

--- a/test/fixtures/completions/exportedMemberDocs.go
+++ b/test/fixtures/completions/exportedMemberDocs.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 )
 
+//
+var Language = "english"
+
 const (
 	//
 	HelloStatus = 0
@@ -22,6 +25,6 @@ type HelloParams struct {
 }
 
 type (
-	// 
+	//
 	Point struct{ x, y float64 }
 )

--- a/test/fixtures/completions/exportedMemberDocs.go
+++ b/test/fixtures/completions/exportedMemberDocs.go
@@ -7,6 +7,13 @@ import (
 //
 var Language = "english"
 
+var (
+	//
+	Greeting = "Hello"
+	// 
+	GreetingText = "Hello World!"
+)
+
 const (
 	//
 	HelloStatus = 0

--- a/test/fixtures/completions/exportedMemberDocs.go
+++ b/test/fixtures/completions/exportedMemberDocs.go
@@ -4,24 +4,13 @@ import (
 	"fmt"
 )
 
-//
+// L
 var Language = "english" // should not invoke completion since this is line comment
 
-var (
-	//
-	Greeting = "Hello"
-	//
-	GreetingText = "Hello World!"
-)
+// G
+const GreetingText = "Hello"
 
-const (
-	//
-	HelloStatus = 0
-	//
-	GreetingStatus = 1
-)
-
-//
+// S
 func SayHello() {
 	fmt.Println("Says hello!")
 }
@@ -30,8 +19,3 @@ func SayHello() {
 type HelloParams struct {
 	language string
 }
-
-type (
-	//
-	Point struct{ x, y float64 }
-)

--- a/test/fixtures/completions/exportedMemberDocs.go
+++ b/test/fixtures/completions/exportedMemberDocs.go
@@ -5,12 +5,12 @@ import (
 )
 
 //
-var Language = "english"
+var Language = "english" // should not invoke completion since this is line comment
 
 var (
 	//
 	Greeting = "Hello"
-	// 
+	//
 	GreetingText = "Hello World!"
 )
 

--- a/test/fixtures/completions/exportedMemberDocs.go
+++ b/test/fixtures/completions/exportedMemberDocs.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+)
+
+const (
+	//
+	HelloStatus = 0
+	//
+	GreetingStatus = 1
+)
+
+//
+func SayHello() {
+	fmt.Println("Says hello!")
+}
+
+// HelloParams
+type HelloParams struct {
+	language string
+}

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -864,7 +864,8 @@ It returns the number of bytes written and any write error encountered.
 		let provider = new GoCompletionItemProvider();
 		let testCases: [vscode.Position, string[]][] = [
 			[new vscode.Position(6, 3), ['Language']],
-			[new vscode.Position(10, 8), ['Greeting']],
+			[new vscode.Position(7, 29), []],
+			[new vscode.Position(10, 9), ['Greeting']],
 			[new vscode.Position(12, 8), ['GreetingText']],
 			[new vscode.Position(17, 8), ['HelloStatus']],
 			[new vscode.Position(19, 8), ['GreetingStatus']],

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -777,45 +777,45 @@ It returns the number of bytes written and any write error encountered.
 		vscode.workspace.openTextDocument(uri).then((textDocument) => {
 			return vscode.window.showTextDocument(textDocument).then(editor => {
 
-				let noFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: false } })).then(items => {
+			let noFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: false }})).then(items => {
 					let item = items.find(x => x.label === 'Print');
 					assert.equal(!item.insertText, true);
 				});
 
-				let withFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: true } })).then(items => {
+			let withFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: true }})).then(items => {
 					let item = items.find(x => x.label === 'Print');
 					assert.equal((<vscode.SnippetString>item.insertText).value, 'Print(${1:a ...interface{\\}})');
 
 				});
 
-				let withFunctionSnippetNotype = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true } })).then(items => {
+			let withFunctionSnippetNotype = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true }})).then(items => {
 					let item = items.find(x => x.label === 'Print');
 					assert.equal((<vscode.SnippetString>item.insertText).value, 'Print(${1:a})');
 				});
 
-				let noFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: false } })).then(items => {
+			let noFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: false }})).then(items => {
 					let item = items.find(x => x.label === 'funcAsVariable');
 					assert.equal(!item.insertText, true);
 				});
 
-				let withFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: true } })).then(items => {
+			let withFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: true }})).then(items => {
 					let item = items.find(x => x.label === 'funcAsVariable');
 					assert.equal((<vscode.SnippetString>item.insertText).value, 'funcAsVariable(${1:k string})');
 				});
 
-				let withFunctionAsVarSnippetNoType = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true } })).then(items => {
+			let withFunctionAsVarSnippetNoType = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true }})).then(items => {
 					let item = items.find(x => x.label === 'funcAsVariable');
 					assert.equal((<vscode.SnippetString>item.insertText).value, 'funcAsVariable(${1:k})');
 				});
 
-				let noFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: false } })).then(items => {
+			let noFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: false }})).then(items => {
 					let item1 = items.find(x => x.label === 'HandlerFunc');
 					let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
 					assert.equal(!item1.insertText, true);
 					assert.equal(!item2.insertText, true);
 				});
 
-				let withFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: true } })).then(items => {
+			let withFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: true }})).then(items => {
 					let item1 = items.find(x => x.label === 'HandlerFunc');
 					let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
 					assert.equal((<vscode.SnippetString>item1.insertText).value, 'HandlerFunc(func(${1:arg1} http.ResponseWriter, ${2:arg2} *http.Request) {\n\t$3\n})');

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -777,45 +777,45 @@ It returns the number of bytes written and any write error encountered.
 		vscode.workspace.openTextDocument(uri).then((textDocument) => {
 			return vscode.window.showTextDocument(textDocument).then(editor => {
 
-			let noFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: false }})).then(items => {
+				let noFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: false } })).then(items => {
 					let item = items.find(x => x.label === 'Print');
 					assert.equal(!item.insertText, true);
 				});
 
-			let withFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: true }})).then(items => {
+				let withFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: true } })).then(items => {
 					let item = items.find(x => x.label === 'Print');
 					assert.equal((<vscode.SnippetString>item.insertText).value, 'Print(${1:a ...interface{\\}})');
 
 				});
 
-			let withFunctionSnippetNotype = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true }})).then(items => {
+				let withFunctionSnippetNotype = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true } })).then(items => {
 					let item = items.find(x => x.label === 'Print');
 					assert.equal((<vscode.SnippetString>item.insertText).value, 'Print(${1:a})');
 				});
 
-			let noFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: false }})).then(items => {
+				let noFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: false } })).then(items => {
 					let item = items.find(x => x.label === 'funcAsVariable');
 					assert.equal(!item.insertText, true);
 				});
 
-			let withFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: true }})).then(items => {
+				let withFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: true } })).then(items => {
 					let item = items.find(x => x.label === 'funcAsVariable');
 					assert.equal((<vscode.SnippetString>item.insertText).value, 'funcAsVariable(${1:k string})');
 				});
 
-			let withFunctionAsVarSnippetNoType = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true }})).then(items => {
+				let withFunctionAsVarSnippetNoType = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true } })).then(items => {
 					let item = items.find(x => x.label === 'funcAsVariable');
 					assert.equal((<vscode.SnippetString>item.insertText).value, 'funcAsVariable(${1:k})');
 				});
 
-			let noFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: false }})).then(items => {
+				let noFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: false } })).then(items => {
 					let item1 = items.find(x => x.label === 'HandlerFunc');
 					let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
 					assert.equal(!item1.insertText, true);
 					assert.equal(!item2.insertText, true);
 				});
 
-			let withFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: true }})).then(items => {
+				let withFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: true } })).then(items => {
 					let item1 = items.find(x => x.label === 'HandlerFunc');
 					let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
 					assert.equal((<vscode.SnippetString>item1.insertText).value, 'HandlerFunc(func(${1:arg1} http.ResponseWriter, ${2:arg2} *http.Request) {\n\t$3\n})');
@@ -863,15 +863,14 @@ It returns the number of bytes written and any write error encountered.
 	test('Test Completion on Comments for Exported Members', (done) => {
 		let provider = new GoCompletionItemProvider();
 		let testCases: [vscode.Position, string[]][] = [
-			[new vscode.Position(6, 3), ['Language']],
-			[new vscode.Position(7, 29), []],
-			[new vscode.Position(10, 9), ['Greeting']],
-			[new vscode.Position(12, 8), ['GreetingText']],
-			[new vscode.Position(17, 8), ['HelloStatus']],
-			[new vscode.Position(19, 8), ['GreetingStatus']],
-			[new vscode.Position(23, 4), ['SayHello']],
-			[new vscode.Position(28, 5), ['HelloParams']],
-			[new vscode.Position(34, 8), ['Point']],
+			[new vscode.Position(6, 4), ['Language']],
+			[new vscode.Position(9, 4), ['GreetingText']],
+			// checking for comment completions with begining of comment without space
+			[new vscode.Position(12, 2), []],
+			// cursor between /$/ this should not trigger any completion
+			[new vscode.Position(12, 1), []],
+			[new vscode.Position(12, 4), ['SayHello']],
+			[new vscode.Position(17, 5), ['HelloParams']],
 		];
 		let uri = vscode.Uri.file(path.join(fixturePath, 'completions', 'exportedMemberDocs.go'));
 
@@ -880,9 +879,11 @@ It returns the number of bytes written and any write error encountered.
 				let promises = testCases.map(([position, expected]) =>
 					provider.provideCompletionItems(editor.document, position, null).then(items => {
 						let labels = items.map(x => x.label);
-						for (let entry of expected) {
-							assert.equal(labels.indexOf(entry) > -1, true, `missing expected item in completion list: ${entry} Actual: ${labels}`);
-						}
+						assert.equal(expected.length, labels.length, `expected number of completions: ${expected.length} Actual: ${labels.length} at position(${position.line},${position.character}) ${labels}`);
+						expected.forEach((entry, index) => {
+							assert.equal(entry, labels[index], `mismatch in comment completion list Expected: ${entry} Actual: ${labels[index]}`);
+						});
+
 					})
 				);
 				return Promise.all(promises).then(() => vscode.commands.executeCommand('workbench.action.closeActiveEditor'));

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -797,11 +797,12 @@ It returns the number of bytes written and any write error encountered.
 	test('Test Completion on Comments for Exported Members', (done) => {
 		let provider = new GoCompletionItemProvider();
 		let testCases: [vscode.Position, string[]][] = [
-			[new vscode.Position(7, 8), ['HelloStatus']],
-			[new vscode.Position(9, 8), ['GreetingStatus']],
-			[new vscode.Position(13, 4), ['SayHello']],
-			[new vscode.Position(18, 5), ['HelloParams']],
-			[new vscode.Position(25, 8), ['Point']]
+			[new vscode.Position(6, 3), ['Language']],
+			[new vscode.Position(10, 8), ['HelloStatus']],
+			[new vscode.Position(12, 8), ['GreetingStatus']],
+			[new vscode.Position(16, 4), ['SayHello']],
+			[new vscode.Position(21, 5), ['HelloParams']],
+			[new vscode.Position(28, 8), ['Point']],
 		];
 		let uri = vscode.Uri.file(path.join(fixturePath, 'completions', 'exportedMemberDocs.go'));
 

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -801,6 +801,7 @@ It returns the number of bytes written and any write error encountered.
 			[new vscode.Position(9, 8), ['GreetingStatus']],
 			[new vscode.Position(13, 4), ['SayHello']],
 			[new vscode.Position(18, 5), ['HelloParams']],
+			[new vscode.Position(25, 8), ['Point']]
 		];
 		let uri = vscode.Uri.file(path.join(fixturePath, 'completions', 'exportedMemberDocs.go'));
 

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -66,6 +66,7 @@ suite('Go Extension Tests', () => {
 		fs.copySync(path.join(fixtureSourcePath, 'buildTags', 'hello.go'), path.join(fixturePath, 'buildTags', 'hello.go'));
 		fs.copySync(path.join(fixtureSourcePath, 'completions', 'unimportedPkgs.go'), path.join(fixturePath, 'completions', 'unimportedPkgs.go'));
 		fs.copySync(path.join(fixtureSourcePath, 'completions', 'snippets.go'), path.join(fixturePath, 'completions', 'snippets.go'));
+		fs.copySync(path.join(fixtureSourcePath, 'completions', 'exportedMemberDocs.go'), path.join(fixturePath, 'completions', 'exportedMemberDocs.go'));
 		fs.copySync(path.join(fixtureSourcePath, 'importTest', 'noimports.go'), path.join(fixturePath, 'importTest', 'noimports.go'));
 		fs.copySync(path.join(fixtureSourcePath, 'importTest', 'groupImports.go'), path.join(fixturePath, 'importTest', 'groupImports.go'));
 		fs.copySync(path.join(fixtureSourcePath, 'importTest', 'singleImports.go'), path.join(fixturePath, 'importTest', 'singleImports.go'));
@@ -776,50 +777,50 @@ It returns the number of bytes written and any write error encountered.
 		vscode.workspace.openTextDocument(uri).then((textDocument) => {
 			return vscode.window.showTextDocument(textDocument).then(editor => {
 
-			let noFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: false }})).then(items => {
-				let item = items.find(x => x.label === 'Print');
-				assert.equal(!item.insertText, true);
-			});
+				let noFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: false } })).then(items => {
+					let item = items.find(x => x.label === 'Print');
+					assert.equal(!item.insertText, true);
+				});
 
-			let withFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: true }})).then(items => {
-				let item = items.find(x => x.label === 'Print');
-				assert.equal((<vscode.SnippetString>item.insertText).value, 'Print(${1:a ...interface{\\}})');
+				let withFunctionSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: true } })).then(items => {
+					let item = items.find(x => x.label === 'Print');
+					assert.equal((<vscode.SnippetString>item.insertText).value, 'Print(${1:a ...interface{\\}})');
 
-			});
+				});
 
-			let withFunctionSnippetNotype = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true }})).then(items => {
-				let item = items.find(x => x.label === 'Print');
-				assert.equal((<vscode.SnippetString>item.insertText).value, 'Print(${1:a})');
-			});
+				let withFunctionSnippetNotype = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(9, 6), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true } })).then(items => {
+					let item = items.find(x => x.label === 'Print');
+					assert.equal((<vscode.SnippetString>item.insertText).value, 'Print(${1:a})');
+				});
 
-			let noFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: false }})).then(items => {
-				let item = items.find(x => x.label === 'funcAsVariable');
-				assert.equal(!item.insertText, true);
-			});
+				let noFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: false } })).then(items => {
+					let item = items.find(x => x.label === 'funcAsVariable');
+					assert.equal(!item.insertText, true);
+				});
 
-			let withFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: true }})).then(items => {
-				let item = items.find(x => x.label === 'funcAsVariable');
-				assert.equal((<vscode.SnippetString>item.insertText).value, 'funcAsVariable(${1:k string})');
-			});
+				let withFunctionAsVarSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: true } })).then(items => {
+					let item = items.find(x => x.label === 'funcAsVariable');
+					assert.equal((<vscode.SnippetString>item.insertText).value, 'funcAsVariable(${1:k string})');
+				});
 
-			let withFunctionAsVarSnippetNoType = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true }})).then(items => {
-				let item = items.find(x => x.label === 'funcAsVariable');
-				assert.equal((<vscode.SnippetString>item.insertText).value, 'funcAsVariable(${1:k})');
-			});
+				let withFunctionAsVarSnippetNoType = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(11, 3), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggestWithoutType': { value: true } })).then(items => {
+					let item = items.find(x => x.label === 'funcAsVariable');
+					assert.equal((<vscode.SnippetString>item.insertText).value, 'funcAsVariable(${1:k})');
+				});
 
-			let noFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: false }})).then(items => {
-				let item1 = items.find(x => x.label === 'HandlerFunc');
-				let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
-				assert.equal(!item1.insertText, true);
-				assert.equal(!item2.insertText, true);
-			});
+				let noFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: false } })).then(items => {
+					let item1 = items.find(x => x.label === 'HandlerFunc');
+					let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
+					assert.equal(!item1.insertText, true);
+					assert.equal(!item2.insertText, true);
+				});
 
-			let withFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: true }})).then(items => {
-				let item1 = items.find(x => x.label === 'HandlerFunc');
-				let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
-				assert.equal((<vscode.SnippetString>item1.insertText).value, 'HandlerFunc(func(${1:arg1} http.ResponseWriter, ${2:arg2} *http.Request) {\n\t$3\n})');
-				assert.equal((<vscode.SnippetString>item2.insertText).value, 'HandlerFuncWithArgNames(func(${1:w} http.ResponseWriter, ${2:r} *http.Request) {\n\t$3\n})');
-			});
+				let withFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: true } })).then(items => {
+					let item1 = items.find(x => x.label === 'HandlerFunc');
+					let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
+					assert.equal((<vscode.SnippetString>item1.insertText).value, 'HandlerFunc(func(${1:arg1} http.ResponseWriter, ${2:arg2} *http.Request) {\n\t$3\n})');
+					assert.equal((<vscode.SnippetString>item2.insertText).value, 'HandlerFuncWithArgNames(func(${1:w} http.ResponseWriter, ${2:r} *http.Request) {\n\t$3\n})');
+				});
 
 				return Promise.all([
 					noFunctionSnippet, withFunctionSnippet, withFunctionSnippetNotype,
@@ -863,11 +864,13 @@ It returns the number of bytes written and any write error encountered.
 		let provider = new GoCompletionItemProvider();
 		let testCases: [vscode.Position, string[]][] = [
 			[new vscode.Position(6, 3), ['Language']],
-			[new vscode.Position(10, 8), ['HelloStatus']],
-			[new vscode.Position(12, 8), ['GreetingStatus']],
-			[new vscode.Position(16, 4), ['SayHello']],
-			[new vscode.Position(21, 5), ['HelloParams']],
-			[new vscode.Position(28, 8), ['Point']],
+			[new vscode.Position(10, 8), ['Greeting']],
+			[new vscode.Position(12, 8), ['GreetingText']],
+			[new vscode.Position(17, 8), ['HelloStatus']],
+			[new vscode.Position(19, 8), ['GreetingStatus']],
+			[new vscode.Position(23, 4), ['SayHello']],
+			[new vscode.Position(28, 5), ['HelloParams']],
+			[new vscode.Position(34, 8), ['Point']],
 		];
 		let uri = vscode.Uri.file(path.join(fixturePath, 'completions', 'exportedMemberDocs.go'));
 


### PR DESCRIPTION
This pull request adds functionality described #1005 by triggering autocompletion in comments if the next line is an exported member. This would be handy in adding documentation for exported members. 
 