### PR TITLE
Disallow import internal root package

### DIFF
--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -277,10 +277,14 @@ export function getNonVendorPackages(folderPath: string): Promise<string[]> {
 // see: https://golang.org/doc/go1.4#internalpackages
 // see: https://golang.org/s/go14internal
 function isAllowToImportPackage(toDirPath: string, currentWorkspace: string, pkgPath: string) {
-	let internalPkgFound = pkgPath.match(/(^|\/)internal(\/|$)/);
+	if (pkgPath.startsWith('internal/')) {
+		return false;
+	}
+
+	let internalPkgFound = pkgPath.match(/\/internal\/|\/internal$/);
 	if (internalPkgFound) {
 		let rootProjectForInternalPkg = path.join(currentWorkspace, pkgPath.substr(0, internalPkgFound.index));
-		return (rootProjectForInternalPkg !== currentWorkspace && toDirPath.startsWith(rootProjectForInternalPkg + path.sep)) || toDirPath === rootProjectForInternalPkg;
+		return toDirPath.startsWith(rootProjectForInternalPkg + path.sep) || toDirPath === rootProjectForInternalPkg;
 	}
 	return true;
 }

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -279,8 +279,12 @@ export function getNonVendorPackages(folderPath: string): Promise<string[]> {
 function isAllowToImportPackage(toDirPath: string, currentWorkspace: string, pkgPath: string) {
 	let internalPkgFound = pkgPath.match(/\/internal\/|\/internal$/);
 	if (internalPkgFound) {
+		internalPkgFound = pkgPath.match(/^internal\b/);
+	}
+
+	if (internalPkgFound) {
 		let rootProjectForInternalPkg = path.join(currentWorkspace, pkgPath.substr(0, internalPkgFound.index));
-		return toDirPath.startsWith(rootProjectForInternalPkg + path.sep) || toDirPath === rootProjectForInternalPkg;
+		return (rootProjectForInternalPkg !== currentWorkspace && toDirPath.startsWith(rootProjectForInternalPkg + path.sep)) || toDirPath === rootProjectForInternalPkg;
 	}
 	return true;
 }

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -277,11 +277,7 @@ export function getNonVendorPackages(folderPath: string): Promise<string[]> {
 // see: https://golang.org/doc/go1.4#internalpackages
 // see: https://golang.org/s/go14internal
 function isAllowToImportPackage(toDirPath: string, currentWorkspace: string, pkgPath: string) {
-	let internalPkgFound = pkgPath.match(/\/internal\/|\/internal$/);
-	if (internalPkgFound) {
-		internalPkgFound = pkgPath.match(/^internal\b/);
-	}
-
+	let internalPkgFound = pkgPath.match(/(^|\/)internal(\/|$)/);
 	if (internalPkgFound) {
 		let rootProjectForInternalPkg = path.join(currentWorkspace, pkgPath.substr(0, internalPkgFound.index));
 		return (rootProjectForInternalPkg !== currentWorkspace && toDirPath.startsWith(rootProjectForInternalPkg + path.sep)) || toDirPath === rootProjectForInternalPkg;


### PR DESCRIPTION
This should ignore any import of internal packages on the root such as:
```
internal/syscall/windows/registry
internal/nettrace
internal/singleflight
internal/cpu
internal/testenv
internal/trace
internal/testlog
internal/syscall/windows/sysdll
internal/syscall/windows
internal/syscall/unix
internal/poll
internal/race
```