### PR TITLE
Add support for golangci-lint as the lintTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ If you want to run only specific linters (some linters are slow), you can modify
 Alternatively, you can use [megacheck](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck) which 
 may have significantly better performance than `gometalinter`, while only supporting a subset of the tools.
 
+Another alternative is [golangci-lint](https://github.com/golangci/golangci-lint) which shares some of the performance
+characteristics of megacheck, but supports a broader range of tools.
+
 Finally, the result of those linters will show right in the code (locations with suggestions will be underlined),
 as well as in the output pane.
 

--- a/package.json
+++ b/package.json
@@ -478,7 +478,8 @@
           "enum": [
             "golint",
             "gometalinter",
-            "megacheck"
+            "megacheck",
+            "golangci-lint"
           ]
         },
         "go.lintFlags": {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -38,6 +38,7 @@ const allTools: { [key: string]: string } = {
 	'gotests': 'github.com/cweill/gotests/...',
 	'gometalinter': 'github.com/alecthomas/gometalinter',
 	'megacheck': 'honnef.co/go/tools/...',
+	'golangci-lint': 'github.com/golangci/golangci-lint/cmd/golangci-lint',
 	'go-langserver': 'github.com/sourcegraph/go-langserver',
 	'dlv': 'github.com/derekparker/delve/cmd/dlv',
 	'fillstruct': 'github.com/davidrjenni/reftools/cmd/fillstruct'

--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -82,6 +82,11 @@ export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurat
 			lintEnv['GOPATH'] += path.delimiter + goConfig['toolsGopath'];
 		}
 	}
+	if (lintTool === 'golangci-lint') {
+		if (args.indexOf('run') === -1) {
+			args.unshift('run');
+		}
+	}
 
 	if (lintWorkspace && currentWorkspace) {
 		args.push('./...');


### PR DESCRIPTION
This PR adds support for the `golangci-lint` linter tool.