### PR TITLE
Avoid duplicate function parameter body on function suggest snippets

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -199,12 +199,10 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 										paramSnippets.push('${' + (i + 1) + ':' + param + '}');
 									}
 								}
-								let currentWordIndex = lineText.toLowerCase().lastIndexOf(currentWord.toLowerCase());
-								let nextSymbolIndex = currentWordIndex + currentWord.length;
 								let newSnippetString = null;
 								// Avoid adding snippet for function suggest when cursor is followed by ()
 								// i.e: met() -> method()()
-								if ((nextSymbolIndex < lineText.length) && (lineText.charAt(nextSymbolIndex) === '(')) {
+								if (lineText.substr(position.character, 2) === '()') {
 									newSnippetString = new vscode.SnippetString(suggest.name);
 								} else {
 									newSnippetString = new vscode.SnippetString(suggest.name + '(' + paramSnippets.join(', ') + ')');

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -199,15 +199,11 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 										paramSnippets.push('${' + (i + 1) + ':' + param + '}');
 									}
 								}
-								let newSnippetString = null;
 								// Avoid adding snippet for function suggest when cursor is followed by ()
 								// i.e: met() -> method()()
-								if (lineText.substr(position.character, 2) === '()') {
-									newSnippetString = new vscode.SnippetString(suggest.name);
-								} else {
-									newSnippetString = new vscode.SnippetString(suggest.name + '(' + paramSnippets.join(', ') + ')');
+								if (lineText.substr(position.character, 2) !== '()') {
+									item.insertText = new vscode.SnippetString(suggest.name + '(' + paramSnippets.join(', ') + ')');
 								}
-								item.insertText = newSnippetString;
 							}
 							if (config['useCodeSnippetsOnFunctionSuggest'] && suggest.class === 'type' && suggest.type.startsWith('func(')) {
 								let { params, returnType } = getParametersAndReturnType(suggest.type.substring(4));

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -199,7 +199,17 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 										paramSnippets.push('${' + (i + 1) + ':' + param + '}');
 									}
 								}
-								item.insertText = new vscode.SnippetString(suggest.name + '(' + paramSnippets.join(', ') + ')');
+								let currentWordIndex = lineText.toLowerCase().lastIndexOf(currentWord.toLowerCase());
+								let nextSymbolIndex = currentWordIndex + currentWord.length;
+								let newSnippetString = null;
+								// Avoid adding snippet for function suggest when cursor is followed by ()
+								// i.e: met() -> method()()
+								if ((nextSymbolIndex < lineText.length) && (lineText.charAt(nextSymbolIndex) === '(')) {
+									newSnippetString = new vscode.SnippetString(suggest.name);
+								} else {
+									newSnippetString = new vscode.SnippetString(suggest.name + '(' + paramSnippets.join(', ') + ')');
+								}
+								item.insertText = newSnippetString;
 							}
 							if (config['useCodeSnippetsOnFunctionSuggest'] && suggest.class === 'type' && suggest.type.startsWith('func(')) {
 								let { params, returnType } = getParametersAndReturnType(suggest.type.substring(4));


### PR DESCRIPTION
Avoid adding snippet for function suggest when cursor is followed by (). Fixes #1655