### PR TITLE
Add support for revive as lintTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This extension adds rich language support for the Go language to VS Code, includ
 - Workspace symbol search (using `go-symbols`)
 - Rename (using `gorename`. Note: For Undo after rename to work in Windows you need to have `diff` tool in your path)
 - Build-on-save (using `go build` and `go test`)
-- Lint-on-save (using `golint` or `gometalinter` or `megacheck` or `golangci-lint`)
+- Lint-on-save (using `golint` or `gometalinter` or `megacheck` or `golangci-lint` or `revive`)
 - Format on save as well as format manually (using `goreturns` or `goimports` or `gofmt`)
 - Generate unit tests skeleton (using `gotests`)
 - Add Imports (using `gopkgs`)
@@ -96,6 +96,14 @@ You can configure golangci-lint with `go.lintFlags`, for example to show issues 
 
 ```javascript
   "go.lintFlags": ["--enable-all", "--new"],
+```
+
+An alternative of golint is [revive](https://github.com/mgechev/revive). It is extensible, configurable, provides superset of the rules of golint, and has significantly better performance.
+
+To configure revive, use:
+
+```javascript
+  "go.lintFlags": ["--exclude vendor/...", "--config=${workspaceRoot}/config.toml"]
 ```
 
 Finally, the result of those linters will show right in the code (locations with suggestions will be underlined),

--- a/package.json
+++ b/package.json
@@ -522,7 +522,8 @@
             "golint",
             "gometalinter",
             "megacheck",
-            "golangci-lint"
+            "golangci-lint",
+            "revive"
           ]
         },
         "go.lintFlags": {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -39,6 +39,7 @@ const allTools: { [key: string]: string } = {
 	'gometalinter': 'github.com/alecthomas/gometalinter',
 	'megacheck': 'honnef.co/go/tools/...',
 	'golangci-lint': 'github.com/golangci/golangci-lint/cmd/golangci-lint',
+	'revive': 'github.com/mgechev/revive',
 	'go-langserver': 'github.com/sourcegraph/go-langserver',
 	'dlv': 'github.com/derekparker/delve/cmd/dlv',
 	'fillstruct': 'github.com/davidrjenni/reftools/cmd/fillstruct'
@@ -61,6 +62,7 @@ const importantTools = [
 	'gometalinter',
 	'megacheck',
 	'golangci-lint',
+	'revive',
 	'dlv'
 ];
 
@@ -116,6 +118,10 @@ function getTools(goVersion: SemVersion): string[] {
 
 	if (goConfig['lintTool'] === 'golangci-lint') {
 		tools.push('golangci-lint');
+	}
+
+	if (goConfig['lintTool'] === 'revive') {
+		tools.push('revive');
 	}
 
 	if (goConfig['useLanguageServer'] && process.platform !== 'win32') {


### PR DESCRIPTION
Introduces support for revive. Revive is an extensible, configurable, and faster alternative of golint.