### PR TITLE
Fix lint tool cancellation

### DIFF
--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -45,6 +45,7 @@ export function lintCode(lintWorkspace?: boolean) {
 export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfiguration, lintWorkspace?: boolean): Promise<ICheckResult[]> {
 	if (running) {
 		tokenSource.cancel();
+		tokenSource = new vscode.CancellationTokenSource();
 	}
 
 	const currentWorkspace = getWorkspaceFolderPath(fileUri);

--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -45,6 +45,7 @@ export function lintCode(lintWorkspace?: boolean) {
 export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfiguration, lintWorkspace?: boolean): Promise<ICheckResult[]> {
 	if (running) {
 		tokenSource.cancel();
+		tokenSource.dispose();
 		tokenSource = new vscode.CancellationTokenSource();
 	}
 

--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -43,11 +43,13 @@ export function lintCode(lintWorkspace?: boolean) {
  * @param lintWorkspace If true runs linter in all workspace.
  */
 export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfiguration, lintWorkspace?: boolean): Promise<ICheckResult[]> {
-	if (running) {
-		tokenSource.cancel();
+	if (tokenSource) {
+		if (running) {
+			tokenSource.cancel();
+		}
 		tokenSource.dispose();
-		tokenSource = new vscode.CancellationTokenSource();
 	}
+	tokenSource = new vscode.CancellationTokenSource();
 
 	const currentWorkspace = getWorkspaceFolderPath(fileUri);
 	const cwd = (lintWorkspace && currentWorkspace) ? currentWorkspace : path.dirname(fileUri.fsPath);
@@ -107,5 +109,5 @@ export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurat
 	return lintPromise;
 }
 
-let tokenSource = new vscode.CancellationTokenSource();
+let tokenSource: vscode.CancellationTokenSource;
 let running = false;

--- a/src/goVet.ts
+++ b/src/goVet.ts
@@ -44,11 +44,13 @@ export function vetCode(vetWorkspace?: boolean) {
  * @param vetWorkspace If true vets code in all workspace.
  */
 export function goVet(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfiguration, vetWorkspace?: boolean): Promise<ICheckResult[]> {
-	if (running) {
-		tokenSource.cancel();
+	if (tokenSource) {
+		if (running) {
+			tokenSource.cancel();
+		}
 		tokenSource.dispose();
-		tokenSource = new vscode.CancellationTokenSource();
 	}
+	tokenSource = new vscode.CancellationTokenSource();
 
 	const currentWorkspace = getWorkspaceFolderPath(fileUri);
 	const cwd = (vetWorkspace && currentWorkspace) ? currentWorkspace : path.dirname(fileUri.fsPath);
@@ -89,5 +91,5 @@ export function goVet(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 	return vetPromise;
 }
 
-let tokenSource = new vscode.CancellationTokenSource();
+let tokenSource: vscode.CancellationTokenSource;
 let running = false;

--- a/src/goVet.ts
+++ b/src/goVet.ts
@@ -46,6 +46,8 @@ export function vetCode(vetWorkspace?: boolean) {
 export function goVet(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfiguration, vetWorkspace?: boolean): Promise<ICheckResult[]> {
 	if (running) {
 		tokenSource.cancel();
+		tokenSource.dispose();
+		tokenSource = new vscode.CancellationTokenSource();
 	}
 
 	const currentWorkspace = getWorkspaceFolderPath(fileUri);


### PR DESCRIPTION
When a lint tool takes a non-trivial amount of time to execute (e.g. gometalinter), and the user has `lintOnSave` enabled, saving a file twice in quick succession causes the previous lint tool execution to be cancelled.

However, subsequent executions of the lint tool will be [terminated immediately](https://github.com/Microsoft/vscode-go/blob/2075d98808e10bbe475500e2a1752d3790e55251/src/util.ts#L584) because the "global" CancellationTokenSource used for cancelling the lint tool is still in the cancelled state.

This is fixed by recreating the CancellationTokenSource after it has been cancelled.