### PR TITLE
Triggering Completion of Exported Methods on Structs

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -37,7 +37,7 @@ interface GoCodeSuggestion {
 }
 
 const lineCommentRegex = /^\s*\/\/\s+/;
-const exportedMemberRegex = /(const|func|type|var)\s+([A-Z]\w*)/;
+const exportedMemberRegex = /(const|func|type|var)(\s+\(.*\))?\s+([A-Z]\w*)/;
 
 export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 
@@ -60,8 +60,8 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 					let nextLine = document.lineAt(position.line + 1).text.trim();
 					let memberType = nextLine.match(exportedMemberRegex);
 					let suggestionItem: vscode.CompletionItem;
-					if (memberType && memberType.length === 3) {
-						suggestionItem = new vscode.CompletionItem(memberType[2], vscodeKindFromGoCodeClass(memberType[1]));
+					if (memberType && memberType.length === 4) {
+						suggestionItem = new vscode.CompletionItem(memberType[3], vscodeKindFromGoCodeClass(memberType[1]));
 					}
 					return resolve(suggestionItem ? [suggestionItem] : []);
 				}

--- a/test/fixtures/completions/exportedMemberDocs.go
+++ b/test/fixtures/completions/exportedMemberDocs.go
@@ -19,3 +19,12 @@ func SayHello() {
 type HelloParams struct {
 	language string
 }
+
+type Vertex struct {
+	X, Y float64
+}
+
+// A
+func (v Vertex) Abs() float64 {
+	return (v.X*v.X + v.Y*v.Y)
+}

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -809,23 +809,23 @@ It returns the number of bytes written and any write error encountered.
 					assert.equal((<vscode.SnippetString>item.insertText).value, 'funcAsVariable(${1:k})');
 				});
 
-			let noFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: false }})).then(items => {
-				let item1 = items.find(x => x.label === 'HandlerFunc');
-				let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
-				let item3 = items.find(x => x.label === 'HandlerFuncNoReturnType');
-				assert.equal(!item1.insertText, true);
-				assert.equal(!item2.insertText, true);
-				assert.equal(!item3.insertText, true);
-			});
+				let noFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: false } })).then(items => {
+					let item1 = items.find(x => x.label === 'HandlerFunc');
+					let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
+					let item3 = items.find(x => x.label === 'HandlerFuncNoReturnType');
+					assert.equal(!item1.insertText, true);
+					assert.equal(!item2.insertText, true);
+					assert.equal(!item3.insertText, true);
+				});
 
-			let withFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, {'useCodeSnippetsOnFunctionSuggest': { value: true }})).then(items => {
-				let item1 = items.find(x => x.label === 'HandlerFunc');
-				let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
-				let item3 = items.find(x => x.label === 'HandlerFuncNoReturnType');
-				assert.equal((<vscode.SnippetString>item1.insertText).value, 'HandlerFunc(func(${1:arg1} string, ${2:arg2} string) {\n\t$3\n}) (string, string)');
-				assert.equal((<vscode.SnippetString>item2.insertText).value, 'HandlerFuncWithArgNames(func(${1:w} string, ${2:r} string) {\n\t$3\n}) int');
-				assert.equal((<vscode.SnippetString>item3.insertText).value, 'HandlerFuncNoReturnType(func(${1:arg1} string, ${2:arg2} string) {\n\t$3\n})');
-			});
+				let withFunctionAsTypeSnippet = provider.provideCompletionItemsInternal(editor.document, new vscode.Position(14, 0), null, Object.create(baseConfig, { 'useCodeSnippetsOnFunctionSuggest': { value: true } })).then(items => {
+					let item1 = items.find(x => x.label === 'HandlerFunc');
+					let item2 = items.find(x => x.label === 'HandlerFuncWithArgNames');
+					let item3 = items.find(x => x.label === 'HandlerFuncNoReturnType');
+					assert.equal((<vscode.SnippetString>item1.insertText).value, 'HandlerFunc(func(${1:arg1} string, ${2:arg2} string) {\n\t$3\n}) (string, string)');
+					assert.equal((<vscode.SnippetString>item2.insertText).value, 'HandlerFuncWithArgNames(func(${1:w} string, ${2:r} string) {\n\t$3\n}) int');
+					assert.equal((<vscode.SnippetString>item3.insertText).value, 'HandlerFuncNoReturnType(func(${1:arg1} string, ${2:arg2} string) {\n\t$3\n})');
+				});
 
 				return Promise.all([
 					noFunctionSnippet, withFunctionSnippet, withFunctionSnippetNotype,
@@ -876,6 +876,7 @@ It returns the number of bytes written and any write error encountered.
 			[new vscode.Position(12, 1), []],
 			[new vscode.Position(12, 4), ['SayHello']],
 			[new vscode.Position(17, 5), ['HelloParams']],
+			[new vscode.Position(26, 5), ['Abs']],
 		];
 		let uri = vscode.Uri.file(path.join(fixturePath, 'completions', 'exportedMemberDocs.go'));
 


### PR DESCRIPTION
When testing for #1698 noticed that completion in comments was not triggered for exported methods on structs. Modified the regex to capture this condition and added test to check for appropriate function in triggering completions. 