### PR TITLE
Added support for tests using stretchr/testify

### DIFF
--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -8,7 +8,7 @@
 import vscode = require('vscode');
 import path = require('path');
 import { TextDocument, CancellationToken, CodeLens, Command } from 'vscode';
-import { getTestFunctions, getBenchmarkFunctions, getTestFlags } from './testUtils';
+import { getTestFunctions, getBenchmarkFunctions, getTestFlags, extractInstanceTestName } from './testUtils';
 import { GoDocumentSymbolProvider } from './goOutline';
 import { getCurrentGoPath } from './util';
 import { GoBaseCodeLensProvider } from './goBaseCodelens';
@@ -94,10 +94,13 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 
 				codelens.push(new CodeLens(func.location.range, runTestCmd));
 
+				let instanceMethod = extractInstanceTestName(func.name);
+				let args = !instanceMethod ? ['-test.run', `^${func.name}$`] : ['-testify.m', `^${instanceMethod}$`];
+
 				let debugTestCmd: Command = {
 					title: 'debug test',
 					command: 'go.debug.startSession',
-					arguments: [Object.assign({}, currentDebugConfig, { args: ['-test.run', '^' + func.name + '$'] })]
+					arguments: [Object.assign({}, currentDebugConfig, { args: args })]
 				};
 
 				codelens.push(new CodeLens(func.location.range, debugTestCmd));

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -97,9 +97,9 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 				let args: string[] = [];
 				let instanceMethod = extractInstanceTestName(func.name);
 				if (instanceMethod) {
-					const testFn = findTestFnForInstanceTest(func.name, document, testFunctions);
-					if (testFn) {
-						args = args.concat('-test.run', `^${testFn.name}$`);
+					const testFns = findTestFnForInstanceTest(func.name, document, testFunctions);
+					if (testFns && testFns.length > 0) {
+						args = args.concat('-test.run', `^${testFns.map(t => t.name).join('|')}$`);
 					}
 					args = args.concat('-testify.m', `^${instanceMethod}$`);
 				} else {

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -8,7 +8,7 @@
 import vscode = require('vscode');
 import path = require('path');
 import { TextDocument, CancellationToken, CodeLens, Command } from 'vscode';
-import { getTestFunctions, getBenchmarkFunctions, getTestFlags, extractInstanceTestName, findTestFnForInstanceTest } from './testUtils';
+import { getTestFunctions, getBenchmarkFunctions, getTestFlags, extractInstanceTestName, findAllTestSuiteRuns } from './testUtils';
 import { GoDocumentSymbolProvider } from './goOutline';
 import { getCurrentGoPath } from './util';
 import { GoBaseCodeLensProvider } from './goBaseCodelens';
@@ -97,7 +97,7 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 				let args: string[] = [];
 				let instanceMethod = extractInstanceTestName(func.name);
 				if (instanceMethod) {
-					const testFns = findTestFnForInstanceTest(func.name, document, testFunctions);
+					const testFns = findAllTestSuiteRuns(document, testFunctions);
 					if (testFns && testFns.length > 0) {
 						args = args.concat('-test.run', `^${testFns.map(t => t.name).join('|')}$`);
 					}

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -8,7 +8,7 @@
 import path = require('path');
 import vscode = require('vscode');
 import os = require('os');
-import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions } from './testUtils';
+import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions, extractInstanceTestName, findTestFnForInstanceTest } from './testUtils';
 import { getCoverage } from './goCover';
 
 // lastTestConfig holds a reference to the last executed TestConfig which allows
@@ -59,11 +59,21 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, isBenchmar
 				return;
 			}
 
+			const testConfigFns = [testFunctionName];
+
+			if (!isBenchmark && extractInstanceTestName(testFunctionName)) {
+				// find test function with corresponding suite.Run
+				const t = findTestFnForInstanceTest(testFunctionName, editor.document, testFunctions);
+				if (t) {
+					testConfigFns.push(t.name);
+				}
+			}
+
 			const testConfig: TestConfig = {
 				goConfig: goConfig,
 				dir: path.dirname(editor.document.fileName),
 				flags: testFlags,
-				functions: [testFunctionName],
+				functions: testConfigFns,
 				isBenchmark: isBenchmark,
 			};
 

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -59,13 +59,13 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, isBenchmar
 				return;
 			}
 
-			const testConfigFns = [testFunctionName];
+			let testConfigFns = [testFunctionName];
 
 			if (!isBenchmark && extractInstanceTestName(testFunctionName)) {
 				// find test function with corresponding suite.Run
-				const t = findTestFnForInstanceTest(testFunctionName, editor.document, testFunctions);
-				if (t) {
-					testConfigFns.push(t.name);
+				const testFns = findTestFnForInstanceTest(testFunctionName, editor.document, testFunctions);
+				if (testFns) {
+					testConfigFns = testConfigFns.concat(testFns.map(t => t.name));
 				}
 			}
 

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -8,7 +8,7 @@
 import path = require('path');
 import vscode = require('vscode');
 import os = require('os');
-import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions, isInstanceTestMethod } from './testUtils';
+import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions } from './testUtils';
 import { getCoverage } from './goCover';
 
 // lastTestConfig holds a reference to the last executed TestConfig which allows

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -8,7 +8,7 @@
 import path = require('path');
 import vscode = require('vscode');
 import os = require('os');
-import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions, extractInstanceTestName, findTestFnForInstanceTest } from './testUtils';
+import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions, extractInstanceTestName, findAllTestSuiteRuns } from './testUtils';
 import { getCoverage } from './goCover';
 
 // lastTestConfig holds a reference to the last executed TestConfig which allows
@@ -63,7 +63,7 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, isBenchmar
 
 			if (!isBenchmark && extractInstanceTestName(testFunctionName)) {
 				// find test function with corresponding suite.Run
-				const testFns = findTestFnForInstanceTest(testFunctionName, editor.document, testFunctions);
+				const testFns = findAllTestSuiteRuns(editor.document, testFunctions);
 				if (testFns) {
 					testConfigFns = testConfigFns.concat(testFns.map(t => t.name));
 				}

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -8,7 +8,7 @@
 import path = require('path');
 import vscode = require('vscode');
 import os = require('os');
-import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions } from './testUtils';
+import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions, isInstanceTestMethod } from './testUtils';
 import { getCoverage } from './goCover';
 
 // lastTestConfig holds a reference to the last executed TestConfig which allows
@@ -34,7 +34,7 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, isBenchmar
 
 	const getFunctions = isBenchmark ? getBenchmarkFunctions : getTestFunctions;
 
-	const {tmpCoverPath, testFlags } = makeCoverData(goConfig, 'coverOnSingleTest', args);
+	const { tmpCoverPath, testFlags } = makeCoverData(goConfig, 'coverOnSingleTest', args);
 
 	editor.document.save().then(() => {
 		return getFunctions(editor.document, null).then(testFunctions => {
@@ -59,13 +59,12 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, isBenchmar
 				return;
 			}
 
-			const testConfig = {
+			const testConfig: TestConfig = {
 				goConfig: goConfig,
 				dir: path.dirname(editor.document.fileName),
 				flags: testFlags,
 				functions: [testFunctionName],
 				isBenchmark: isBenchmark,
-				showTestCoverage: true
 			};
 
 			// Remember this config as the last executed test.
@@ -94,13 +93,12 @@ export function testCurrentPackage(goConfig: vscode.WorkspaceConfiguration, args
 		return;
 	}
 
-	const {tmpCoverPath, testFlags } = makeCoverData(goConfig, 'coverOnTestPackage', args);
+	const { tmpCoverPath, testFlags } = makeCoverData(goConfig, 'coverOnTestPackage', args);
 
-	const testConfig = {
+	const testConfig: TestConfig = {
 		goConfig: goConfig,
 		dir: path.dirname(editor.document.fileName),
 		flags: testFlags,
-		showTestCoverage: true
 	};
 	// Remember this config as the last executed test.
 	lastTestConfig = testConfig;
@@ -160,11 +158,11 @@ export function testCurrentFile(goConfig: vscode.WorkspaceConfiguration, args: s
 
 	return editor.document.save().then(() => {
 		return getTestFunctions(editor.document, null).then(testFunctions => {
-			const testConfig = {
+			const testConfig: TestConfig = {
 				goConfig: goConfig,
 				dir: path.dirname(editor.document.fileName),
 				flags: getTestFlags(goConfig, args),
-				functions: testFunctions.map(func => { return func.name; })
+				functions: testFunctions.map(sym => sym.name),
 			};
 			// Remember this config as the last executed test.
 			lastTestConfig = testConfig;
@@ -203,5 +201,5 @@ function makeCoverData(goConfig: vscode.WorkspaceConfiguration, confFlag: string
 		testFlags.push('-coverprofile=' + tmpCoverPath);
 	}
 
-	return {tmpCoverPath, testFlags};
+	return { tmpCoverPath, testFlags };
 }

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -270,7 +270,12 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 				testifyMethods = testifyMethods.map(extractInstanceTestName);
 			}
 
-			params = params.concat(['-run', util.format('^%s$', testFunctions.join('|'))]);
+			// we'll skip the '-run' param when running only testify methods, which will result
+			// in running all the test methods, but that is necessary, cause one of them should
+			// call testify's `suite.Run(...)`
+			if (testFunctions.length > 0) {
+				params = params.concat(['-run', util.format('^%s$', testFunctions.join('|'))]);
+			}
 			if (testifyMethods.length > 0) {
 				params = params.concat(['-testify.m', util.format('^%s$', testifyMethods.join('|'))]);
 			}

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -110,39 +110,16 @@ export function extractInstanceTestName(symbolName: string): string {
 }
 
 /**
- * Finds test method containing suite.Run() call for the given instance test name.
- * Uses a few heuristics, we're not analyzing the code to be 100% sure.
+ * Finds test methods containing "suite.Run()" call.
  *
- * @param symbolName Instance test function name (including the type name)
  * @param doc Editor document
  * @param allTests All test functions
  */
-export function findTestFnForInstanceTest(symbolName: string, doc: vscode.TextDocument, allTests: vscode.SymbolInformation[]): vscode.SymbolInformation[] {
+export function findAllTestSuiteRuns(doc: vscode.TextDocument, allTests: vscode.SymbolInformation[]): vscode.SymbolInformation[] {
 	// get non-instance test functions
 	const testFunctions = allTests.filter(t => !testSuiteMethodRegex.test(t.name));
 	// filter further to ones containing suite.Run()
-	const candidates = testFunctions.filter(t => doc.getText(t.location.range).includes('suite.Run('));
-	switch (candidates.length) {
-		case 0: return null;
-		case 1: return candidates;
-	}
-
-	// we have multiple matches, filter even more
-	const match = symbolName.match(testSuiteMethodRegex);
-	if (!match || match.length !== 3) {
-		return null;
-	}
-	// drop pointers, lowercase for more lenient matching
-	const instanceType = match[1].replace(/[*]/g, '').toLowerCase();
-	const filtered = candidates.filter(t => {
-		const text = doc.getText(t.location.range).toLowerCase();
-		if (text.includes(instanceType)) {
-			return true;
-		}
-		// try the test name as well (minus the "Test" part)
-		return t.name.substring(4).includes(instanceType);
-	});
-	return filtered.length > 0 ? filtered : candidates;
+	return testFunctions.filter(t => doc.getText(t.location.range).includes('suite.Run('));
 }
 
 /**


### PR DESCRIPTION
This adds support for tests using the widely used [stretchr/testify](https://github.com/stretchr/testify) framework, and allows running and debugging individual test methods with instances which use github.com/stretchr/testify/suite interfaces.

![image](https://user-images.githubusercontent.com/5833104/40881902-8ef5e0f2-66ca-11e8-877a-8337301af41e.png)
