### PR TITLE
Migrate from nsf/gocode to mdempsky/gocode for completion results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   -  nvm install $TRAVIS_NODE_VERSION;
   - npm install
   - npm run vscode:prepublish
-  - go get -u -v github.com/nsf/gocode
+  - go get -u -v github.com/mdempsky/gocode
   - go get -u -v github.com/rogpeppe/godef
   - if [[ "$(go version)" =~ "go version go1.5" ]]; then echo hello; else go get -u -v github.com/zmb3/gogetdoc; fi
   - if [[ "$(go version)" =~ "go version go1.5" ]]; then echo cannot get golint; else go get -u -v github.com/golang/lint/golint; fi

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -18,7 +18,7 @@ import { goLiveErrorsEnabled } from './goLiveErrors';
 let updatesDeclinedTools: string[] = [];
 let installsDeclinedTools: string[] = [];
 const allTools: { [key: string]: string } = {
-	'gocode': 'github.com/nsf/gocode',
+	'gocode': 'github.com/mdempsky/gocode',
 	'gopkgs': 'github.com/uudashr/gopkgs/cmd/gopkgs',
 	'go-outline': 'github.com/ramya-rao-a/go-outline',
 	'go-symbols': 'github.com/acroca/go-symbols',

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -124,11 +124,11 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 									item.additionalTextEdits = getTextEditForAddImport(pkgPath);
 								});
 								resolve(newsuggestions);
-							});
+							}, reject);
 						}
 					}
 					resolve(suggestions);
-				});
+				}, reject);
 			});
 		});
 	}
@@ -166,7 +166,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 
 					let wordAtPosition = document.getWordRangeAtPosition(position);
 
-					if (results[1]) {
+					if (results && results[1]) {
 						for (let suggest of results[1]) {
 							if (inString && suggest.class !== 'import') continue;
 							let item = new vscode.CompletionItem(suggest.name);


### PR DESCRIPTION
As package nsf/gocode is unmaintaned this is now consuming mdempsky/gocode.
In order to cater for changes, correctly handle empty results and promise
rejections.

This would solve #1645 although for reasons unclear to me, the updated `gocode` package will not provide any results for members of unimported packages (hence the skipped test case). Don't know if this is a dealbreaker or can be fixed deeper down in `goSuggest.ts`.