### PR TITLE
Add debug configuration options for test debug codelens

### DIFF
--- a/package.json
+++ b/package.json
@@ -849,54 +849,6 @@
               "type": "boolean",
               "default": true,
               "description": "If true, enables code lens for running and debugging tests"
-            },
-            "runtest.debugConfig": {
-              "type": "object",
-              "properties": {
-                "dlvLoadConfig": {
-                  "type": "object",
-                  "properties": {
-                    "followPointers": {
-                      "type": "boolean",
-                      "description": "FollowPointers requests pointers to be automatically dereferenced",
-                      "default": true
-                    },
-                    "maxVariableRecurse": {
-                      "type": "number",
-                      "description": "MaxVariableRecurse is how far to recurse when evaluating nested types",
-                      "default": 1
-                    },
-                    "maxStringLen": {
-                      "type": "number",
-                      "description": "MaxStringLen is the maximum number of bytes read from a string",
-                      "default": 64
-                    },
-                    "maxArrayValues": {
-                      "type": "number",
-                      "description": "MaxArrayValues is the maximum number of elements read from an array, a slice or a map",
-                      "default": 64
-                    },
-                    "maxStructFields": {
-                      "type": "number",
-                      "description": "MaxStructFields is the maximum number of fields read from a struct, -1 will read all fields",
-                      "default": -1
-                    }
-                  },
-                  "description": "LoadConfig describes to delve, how to load values from target's memory",
-                  "default": {
-                    "followPointers": true,
-                    "maxVariableRecurse": 1,
-                    "maxStringLen": 64,
-                    "maxArrayValues": 64,
-                    "maxStructFields": -1
-                  }
-                },
-                "useApiV1": {
-                  "type": "boolean",
-                  "description": "If true, the v1 of delve apis will be used, else v2 will be used",
-                  "default": true
-                }
-              }
             }
           },
           "default": {
@@ -1110,6 +1062,55 @@
           },
           "default": [],
           "description": "Folder names (not paths) to ignore while using Go to Symbol in Workspace feature",
+          "scope": "resource"
+        },
+        "go.delveConfig": {
+          "type": "object",
+          "properties": {
+            "dlvLoadConfig": {
+              "type": "object",
+              "properties": {
+                "followPointers": {
+                  "type": "boolean",
+                  "description": "FollowPointers requests pointers to be automatically dereferenced",
+                  "default": true
+                },
+                "maxVariableRecurse": {
+                  "type": "number",
+                  "description": "MaxVariableRecurse is how far to recurse when evaluating nested types",
+                  "default": 1
+                },
+                "maxStringLen": {
+                  "type": "number",
+                  "description": "MaxStringLen is the maximum number of bytes read from a string",
+                  "default": 64
+                },
+                "maxArrayValues": {
+                  "type": "number",
+                  "description": "MaxArrayValues is the maximum number of elements read from an array, a slice or a map",
+                  "default": 64
+                },
+                "maxStructFields": {
+                  "type": "number",
+                  "description": "MaxStructFields is the maximum number of fields read from a struct, -1 will read all fields",
+                  "default": -1
+                }
+              },
+              "description": "LoadConfig describes to delve, how to load values from target's memory",
+              "default": {
+                "followPointers": true,
+                "maxVariableRecurse": 1,
+                "maxStringLen": 64,
+                "maxArrayValues": 64,
+                "maxStructFields": -1
+              }
+            },
+            "useApiV1": {
+              "type": "boolean",
+              "description": "If true, the v1 of delve apis will be used, else v2 will be used",
+              "default": true
+            }
+          },
           "scope": "resource"
         }
       }

--- a/package.json
+++ b/package.json
@@ -1156,6 +1156,7 @@
             }
           }
         }
+      }
     },
     "menus": {
       "editor/context": [

--- a/package.json
+++ b/package.json
@@ -453,13 +453,13 @@
                   }
                 },
                 "description": "LoadConfig describes to delve, how to load values from target's memory",
-                  "default": {
-                    "followPointers": true,
-                    "maxVariableRecurse": 1,
-                    "maxStringLen": 64,
-                    "maxArrayValues": 64,
-                    "maxStructFields": -1
-                  }
+                "default": {
+                  "followPointers": true,
+                  "maxVariableRecurse": 1,
+                  "maxStringLen": 64,
+                  "maxArrayValues": 64,
+                  "maxStructFields": -1
+                }
               },
               "useApiV1": {
                 "type": "boolean",
@@ -645,71 +645,71 @@
           "scope": "resource"
         },
         "go.coverageDecorator": {
-           "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "default": "highlight",
-                "enum": [
-                  "highlight",
-                  "gutter"
-                ]
-              },
-              "coveredHighlightColor": {
-                "type": "string",
-                "default": "rgba(64,128,128,0.5)",
-                "description": "Color in the rgba format to use to highlight covered code."
-              },
-              "uncoveredHighlightColor": {
-                "type": "string",
-                "default": "rgba(128,64,64,0.25)",
-                "description": "Color in the rgba format to use to highlight uncovered code."
-              },
-              "coveredGutterStyle": {
-                "type": "string",
-                "default": "blockblue",
-                "enum": [
-                  "blockblue",
-                  "blockred",
-                  "blockgreen",
-                  "blockyellow",
-                  "slashred",
-                  "slashgreen",
-                  "slashblue",
-                  "slashyellow",
-                  "verticalred",
-                  "verticalgreen",
-                  "verticalblue",
-                  "verticalyellow"
-                ],
-                "description": "Gutter style to indicate covered code."
-              },
-              "uncoveredGutterStyle": {
-                "type": "string",
-                "default": "blockblue",
-                "enum": [
-                  "blockblue",
-                  "blockred",
-                  "blockgreen",
-                  "blockyellow",
-                  "slashred",
-                  "slashgreen",
-                  "slashblue",
-                  "slashyellow",
-                  "verticalred",
-                  "verticalgreen",
-                  "verticalblue",
-                  "verticalyellow"
-                ],
-                "description": "Gutter style to indicate covered code."
-              }
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "default": "highlight",
+              "enum": [
+                "highlight",
+                "gutter"
+              ]
             },
+            "coveredHighlightColor": {
+              "type": "string",
+              "default": "rgba(64,128,128,0.5)",
+              "description": "Color in the rgba format to use to highlight covered code."
+            },
+            "uncoveredHighlightColor": {
+              "type": "string",
+              "default": "rgba(128,64,64,0.25)",
+              "description": "Color in the rgba format to use to highlight uncovered code."
+            },
+            "coveredGutterStyle": {
+              "type": "string",
+              "default": "blockblue",
+              "enum": [
+                "blockblue",
+                "blockred",
+                "blockgreen",
+                "blockyellow",
+                "slashred",
+                "slashgreen",
+                "slashblue",
+                "slashyellow",
+                "verticalred",
+                "verticalgreen",
+                "verticalblue",
+                "verticalyellow"
+              ],
+              "description": "Gutter style to indicate covered code."
+            },
+            "uncoveredGutterStyle": {
+              "type": "string",
+              "default": "blockblue",
+              "enum": [
+                "blockblue",
+                "blockred",
+                "blockgreen",
+                "blockyellow",
+                "slashred",
+                "slashgreen",
+                "slashblue",
+                "slashyellow",
+                "verticalred",
+                "verticalgreen",
+                "verticalblue",
+                "verticalyellow"
+              ],
+              "description": "Gutter style to indicate covered code."
+            }
+          },
           "default": {
             "type": "highlight",
             "coveredHighlightColor": "rgba(64,128,128,0.5)",
             "uncoveredHighlightColor": "rgba(128,64,64,0.25)",
             "coveredGutterStyle": "blockblue",
-		        "uncoveredGutterStyle": "slashyellow"
+            "uncoveredGutterStyle": "slashyellow"
           },
           "description": "This option lets you choose the way to display code coverage. Choose either to highlight the complete line or to show a decorator in the gutter. You can customize the color for the former and the style for the latter.",
           "scope": "resource"
@@ -849,6 +849,54 @@
               "type": "boolean",
               "default": true,
               "description": "If true, enables code lens for running and debugging tests"
+            },
+            "runtest.debugConfig": {
+              "type": "object",
+              "properties": {
+                "dlvLoadConfig": {
+                  "type": "object",
+                  "properties": {
+                    "followPointers": {
+                      "type": "boolean",
+                      "description": "FollowPointers requests pointers to be automatically dereferenced",
+                      "default": true
+                    },
+                    "maxVariableRecurse": {
+                      "type": "number",
+                      "description": "MaxVariableRecurse is how far to recurse when evaluating nested types",
+                      "default": 1
+                    },
+                    "maxStringLen": {
+                      "type": "number",
+                      "description": "MaxStringLen is the maximum number of bytes read from a string",
+                      "default": 64
+                    },
+                    "maxArrayValues": {
+                      "type": "number",
+                      "description": "MaxArrayValues is the maximum number of elements read from an array, a slice or a map",
+                      "default": 64
+                    },
+                    "maxStructFields": {
+                      "type": "number",
+                      "description": "MaxStructFields is the maximum number of fields read from a struct, -1 will read all fields",
+                      "default": -1
+                    }
+                  },
+                  "description": "LoadConfig describes to delve, how to load values from target's memory",
+                  "default": {
+                    "followPointers": true,
+                    "maxVariableRecurse": 1,
+                    "maxStringLen": 64,
+                    "maxArrayValues": 64,
+                    "maxStructFields": -1
+                  }
+                },
+                "useApiV1": {
+                  "type": "boolean",
+                  "description": "If true, the v1 of delve apis will be used, else v2 will be used",
+                  "default": true
+                }
+              }
             }
           },
           "default": {

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -1,30 +1,17 @@
 'use strict';
 
 import vscode = require('vscode');
-import { getCurrentGoPath } from './util';
+import { getDefaultDebugConfiguration, getCurrentGoPath } from './util';
 
 export class GoDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 
 	public provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): vscode.DebugConfiguration[] {
 		return [
-			{
-				'name': 'Launch',
-				'type': 'go',
-				'request': 'launch',
-				'mode': 'debug',
-				'remotePath': '',
-				'port': 2345,
-				'host': '127.0.0.1',
-				'program': '${fileDirname}',
-				'env': {},
-				'args': [],
-				'showLog': true
-			}
+			getDefaultDebugConfiguration(vscode.workspace.getConfiguration('go', folder.uri))
 		];
 	}
 
 	public resolveDebugConfiguration?(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.DebugConfiguration {
-
 		const gopath = getCurrentGoPath(folder ? folder.uri : null);
 
 		if (!debugConfiguration || !debugConfiguration.request) { // if 'request' is missing interpret this as a missing launch.json

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -1,41 +1,57 @@
 'use strict';
 
 import vscode = require('vscode');
-import { getDefaultDebugConfiguration, getCurrentGoPath } from './util';
+import { getCurrentGoPath } from './util';
 
 export class GoDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 
 	public provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): vscode.DebugConfiguration[] {
 		return [
-			getDefaultDebugConfiguration(vscode.workspace.getConfiguration('go', folder.uri))
+			{
+				'name': 'Launch',
+				'type': 'go',
+				'request': 'launch',
+				'mode': 'debug',
+				'remotePath': '',
+				'port': 2345,
+				'host': '127.0.0.1',
+				'program': '${fileDirname}',
+				'env': {},
+				'args': [],
+				'showLog': true
+			}
 		];
 	}
 
 	public resolveDebugConfiguration?(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.DebugConfiguration {
-		const gopath = getCurrentGoPath(folder ? folder.uri : null);
-
 		if (!debugConfiguration || !debugConfiguration.request) { // if 'request' is missing interpret this as a missing launch.json
 			let activeEditor = vscode.window.activeTextEditor;
 			if (!activeEditor || activeEditor.document.languageId !== 'go') {
 				return;
 			}
 
-			return {
+			debugConfiguration = {
 				'name': 'Launch',
 				'type': 'go',
 				'request': 'launch',
 				'mode': 'debug',
-				'program': activeEditor.document.fileName,
-				'env': {
-					'GOPATH': gopath
-				}
+				'program': activeEditor.document.fileName
 			};
 		}
 
+		const gopath = getCurrentGoPath(folder ? folder.uri : null);
 		if (!debugConfiguration['env']) {
 			debugConfiguration['env'] = { 'GOPATH': gopath };
 		} else if (!debugConfiguration['env']['GOPATH']) {
 			debugConfiguration['env']['GOPATH'] = gopath;
+		}
+
+		const dlvConfig = vscode.workspace.getConfiguration('go', folder ? folder.uri : null).get('delveConfig');
+		if (!debugConfiguration.hasOwnProperty('useApiV1') && dlvConfig.hasOwnProperty('useApiV1')) {
+			debugConfiguration['useApiV1'] = dlvConfig['useApiV1'];
+		}
+		if (!debugConfiguration.hasOwnProperty('dlvLoadConfig') && dlvConfig.hasOwnProperty('dlvLoadConfig')) {
+			debugConfiguration['dlvLoadConfig'] = dlvConfig['dlvLoadConfig'];
 		}
 
 		return debugConfiguration;

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -24,28 +24,6 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 		}
 	};
 
-	private getDebugConfig(vsConfig: vscode.WorkspaceConfiguration): any {
-		let debugConfig: any = this.defaultDebugConfig;
-		let launchConfig = vsConfig.get('enableCodeLens')['runtest.debugConfig'];
-
-		if (launchConfig !== undefined) {
-			if (launchConfig.useApiV1 !== undefined) {
-				debugConfig.useApiV1 = launchConfig.useApiV1;
-			}
-			if (launchConfig.dlvLoadConfig !== undefined) {
-				debugConfig.dlvLoadConfig = {
-					followPointers: launchConfig.dlvLoadConfig.followPointers,
-					maxVariableRecurse: launchConfig.dlvLoadConfig.maxVariableRecurse,
-					maxStringLen: launchConfig.dlvLoadConfig.maxStringLen,
-					maxArrayValues: launchConfig.dlvLoadConfig.maxArrayValues,
-					maxStructFields: launchConfig.dlvLoadConfig.maxStructFields
-				};
-			}
-		}
-
-		return debugConfig;
-	}
-
 	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
 		if (!this.enabled) {
 			return [];
@@ -149,5 +127,27 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 		});
 
 		return Promise.all([testPromise, benchmarkPromise]).then(() => codelens);
+	}
+
+	private getDebugConfig(vsConfig: vscode.WorkspaceConfiguration): any {
+		let debugConfig: any = this.defaultDebugConfig;
+		let delveConfig: any = vsConfig.get('delveConfig');
+
+		if (delveConfig !== undefined) {
+			if (delveConfig.useApiV1 !== undefined) {
+				debugConfig.useApiV1 = delveConfig.useApiV1;
+			}
+			if (delveConfig.dlvLoadConfig !== undefined) {
+				debugConfig.dlvLoadConfig = {
+					followPointers: delveConfig.dlvLoadConfig.followPointers,
+					maxVariableRecurse: delveConfig.dlvLoadConfig.maxVariableRecurse,
+					maxStringLen: delveConfig.dlvLoadConfig.maxStringLen,
+					maxArrayValues: delveConfig.dlvLoadConfig.maxArrayValues,
+					maxStructFields: delveConfig.dlvLoadConfig.maxStructFields
+				};
+			}
+		}
+
+		return debugConfig;
 	}
 }

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -26,15 +26,22 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 
 	private getDebugConfig(vsConfig: vscode.WorkspaceConfiguration): any {
 		let debugConfig: any = this.defaultDebugConfig;
-		let launchConfig = vsConfig.get('launch')['configurations'];
+		let launchConfig = vsConfig.get('enableCodeLens')['runtest.debugConfig'];
+
 		if (launchConfig !== undefined) {
-			let goLaunchConfigs = launchConfig.filter(cfg => cfg.type === 'go');
-			if (goLaunchConfigs.length > 1) {
-				debugConfig = launchConfig[0];
+			if (launchConfig.useApiV1 !== undefined) {
+				debugConfig.useApiV1 = launchConfig.useApiV1;
+			}
+			if (launchConfig.dlvLoadConfig !== undefined) {
+				debugConfig.dlvLoadConfig = {
+					followPointers: launchConfig.dlvLoadConfig.followPointers,
+					maxVariableRecurse: launchConfig.dlvLoadConfig.maxVariableRecurse,
+					maxStringLen: launchConfig.dlvLoadConfig.maxStringLen,
+					maxArrayValues: launchConfig.dlvLoadConfig.maxArrayValues,
+					maxStructFields: launchConfig.dlvLoadConfig.maxStructFields
+				};
 			}
 		}
-
-		debugConfig.env.GOPATH = getCurrentGoPath();
 
 		return debugConfig;
 	}

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,30 +17,6 @@ const extensionId: string = 'ms-vscode.Go';
 const extensionVersion: string = vscode.extensions.getExtension(extensionId).packageJSON.version;
 const aiKey: string = 'AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217';
 
-export const defaultDebugConfig: any = {
-	'name': 'Launch',
-	'type': 'go',
-	'request': 'launch',
-	'mode': 'debug',
-	'remotePath': '',
-	'port': 2345,
-	'host': '127.0.0.1',
-	'program': '${fileDirname}',
-	'args': [],
-	'showLog': true,
-	'env': {
-		'GOPATH': getCurrentGoPath() // Passing current GOPATH to Delve as it runs in another process
-	},
-	'useApiV1': true,
-	'dlvLoadConfig': {
-		'followPointers': true,
-		'maxVariableRecurse': 1,
-		'maxStringLen': 128,
-		'maxArrayValues': 128,
-		'maxStructFields': -1
-	}
-};
-
 export const goKeywords: string[] = [
 	'break',
 	'case',
@@ -813,27 +789,4 @@ export function killTree(processId: number): void {
 		} catch (err) {
 		}
 	}
-}
-
-export function getDefaultDebugConfiguration(vsConfig: vscode.WorkspaceConfiguration): any {
-	let debugConfig: any = defaultDebugConfig;
-	let delveConfig: any = vsConfig.get('delveConfig');
-
-	// Default Delve config is overridable by workspace settings
-	if (delveConfig !== undefined) {
-		if (delveConfig.useApiV1 !== undefined) {
-			debugConfig.useApiV1 = delveConfig.useApiV1;
-		}
-		if (delveConfig.dlvLoadConfig !== undefined) {
-			debugConfig.dlvLoadConfig = {
-				followPointers: delveConfig.dlvLoadConfig.followPointers,
-				maxVariableRecurse: delveConfig.dlvLoadConfig.maxVariableRecurse,
-				maxStringLen: delveConfig.dlvLoadConfig.maxStringLen,
-				maxArrayValues: delveConfig.dlvLoadConfig.maxArrayValues,
-				maxStructFields: delveConfig.dlvLoadConfig.maxStructFields
-			};
-		}
-	}
-
-	return debugConfig;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,6 +17,30 @@ const extensionId: string = 'ms-vscode.Go';
 const extensionVersion: string = vscode.extensions.getExtension(extensionId).packageJSON.version;
 const aiKey: string = 'AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217';
 
+export const defaultDebugConfig: any = {
+	'name': 'Launch',
+	'type': 'go',
+	'request': 'launch',
+	'mode': 'debug',
+	'remotePath': '',
+	'port': 2345,
+	'host': '127.0.0.1',
+	'program': '${fileDirname}',
+	'args': [],
+	'showLog': true,
+	'env': {
+		'GOPATH': getCurrentGoPath() // Passing current GOPATH to Delve as it runs in another process
+	},
+	'useApiV1': true,
+	'dlvLoadConfig': {
+		'followPointers': true,
+		'maxVariableRecurse': 1,
+		'maxStringLen': 128,
+		'maxArrayValues': 128,
+		'maxStructFields': -1
+	}
+};
+
 export const goKeywords: string[] = [
 	'break',
 	'case',
@@ -789,4 +813,27 @@ export function killTree(processId: number): void {
 		} catch (err) {
 		}
 	}
+}
+
+export function getDefaultDebugConfiguration(vsConfig: vscode.WorkspaceConfiguration): any {
+	let debugConfig: any = defaultDebugConfig;
+	let delveConfig: any = vsConfig.get('delveConfig');
+
+	// Default Delve config is overridable by workspace settings
+	if (delveConfig !== undefined) {
+		if (delveConfig.useApiV1 !== undefined) {
+			debugConfig.useApiV1 = delveConfig.useApiV1;
+		}
+		if (delveConfig.dlvLoadConfig !== undefined) {
+			debugConfig.dlvLoadConfig = {
+				followPointers: delveConfig.dlvLoadConfig.followPointers,
+				maxVariableRecurse: delveConfig.dlvLoadConfig.maxVariableRecurse,
+				maxStringLen: delveConfig.dlvLoadConfig.maxStringLen,
+				maxArrayValues: delveConfig.dlvLoadConfig.maxArrayValues,
+				maxStructFields: delveConfig.dlvLoadConfig.maxStructFields
+			};
+		}
+	}
+
+	return debugConfig;
 }


### PR DESCRIPTION
This PR adds a new runtest.debugConfig setting inside of go.enableCodeLens that mimicks the launch.json options for delve, so we can configure the test debugger
Fixes #1735 

An example user setting using this feature:
```json
    "go.enableCodeLens": {
        "runtest": true,
        "runtest.debugConfig": {
            "useApiV1": false,
            "dlvLoadConfig": {
                "followPointers": true,
                "maxVariableRecurse": 1,
                "maxStringLen": 128,
                "maxArrayValues": 128,
                "maxStructFields": -1
            }
        }
    },
```