### PR TITLE
Increase overall performance by speeding up GoDocumentSymbolProvider

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,21 @@
 	"version": "0.1.0",
 	"configurations": [
 		{
+			"type": "node",
+			"request": "launch",
+			"name": "Mocha Tests",
+			"program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+			"args": [
+				"-u",
+				"tdd",
+				"--timeout",
+				"5000",
+				"--colors",
+				"${workspaceRoot}/out/test/unit"
+			],
+			"internalConsoleOptions": "openOnSessionStart"
+		},
+		{
 			"name": "Launch Extension",
 			"type": "extensionHost",
 			"request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,9 +2,55 @@
 	"version": "0.1.0",
 	"configurations": [
 		{
+			"name": "Launch Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			// path to VSCode executable
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}"
+			],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceRoot}/out/**/*.js"
+			],
+			"preLaunchTask": "npm"
+		},
+		{
+			"name": "Launch as server",
+			"type": "node2",
+			"request": "launch",
+			"program": "${workspaceRoot}/out/src/debugAdapter/goDebug.js",
+			"args": [
+				"--server=4712"
+			],
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceRoot}/out/**/*.js"
+			]
+		},
+		{
+			"name": "Launch Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			// the workspace path should be GOPATH
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}",
+				"--extensionTestsPath=${workspaceRoot}/out/test"
+			],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceRoot}/out/**/*.js"
+			],
+			"preLaunchTask": "npm"
+		},
+		{
 			"type": "node",
 			"request": "launch",
-			"name": "Mocha Tests",
+			"name": "Unit Tests",
 			"program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
 			"args": [
 				"-u",
@@ -15,45 +61,15 @@
 				"${workspaceRoot}/out/test/unit"
 			],
 			"internalConsoleOptions": "openOnSessionStart"
-		},
-		{
-			"name": "Launch Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			// path to VSCode executable
-			"runtimeExecutable": "${execPath}",
-			"args": [ "--extensionDevelopmentPath=${workspaceRoot}" ],
-			"stopOnEntry": false,
-			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/out/**/*.js"],
-			"preLaunchTask": "npm"
-		},
-		{
-			"name": "Launch as server",
-			"type": "node2",
-			"request": "launch",
-			"program": "${workspaceRoot}/out/src/debugAdapter/goDebug.js",
-			"args": [ "--server=4712" ],
-			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/out/**/*.js"]
-		},
-		{
-			"name": "Launch Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			// the workspace path should be GOPATH
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test"],
-			"stopOnEntry": false,
-			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/out/**/*.js"],
-			"preLaunchTask": "npm"
 		}
 	],
 	"compounds": [
 		{
 			"name": "Extension + Debug server",
-			"configurations": ["Launch Extension", "Launch as server"]
+			"configurations": [
+				"Launch Extension",
+				"Launch as server"
+			]
 		}
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Go",
-  "version": "0.6.81-beta.2",
+  "version": "0.6.85-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3429,17 +3429,24 @@
       "resolved": "https://registry.npmjs.org/vscode-debug-logger/-/vscode-debug-logger-0.0.4.tgz",
       "integrity": "sha1-PZGQCVzzhhG73KU90dWbKw/lSaQ=",
       "requires": {
-        "vscode-debugadapter": "1.28.0",
+        "vscode-debugadapter": "1.30.0",
         "vscode-debugprotocol": "1.28.0"
       }
     },
     "vscode-debugadapter": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.28.0.tgz",
-      "integrity": "sha512-GCR1326LFtfYjl7SDN1wmU2pBJ98HgUCnbWoU3s3bz0GhUWYN1xSYGg7MfuwxY6WwZk2cuqzANhy/oaKADMXaw==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.30.0.tgz",
+      "integrity": "sha512-nvLyfe/ep4Le+Zf4RnZbcmvo5Osbp/KeAo7KJA39CRsbB5ttFS/LuG58NrZuDdnCAdmRzZJ60OhkPD+scoO4uA==",
       "requires": {
-        "vscode-debugprotocol": "1.28.0",
-        "vscode-uri": "1.0.1"
+        "mkdirp": "0.5.1",
+        "vscode-debugprotocol": "1.30.0"
+      },
+      "dependencies": {
+        "vscode-debugprotocol": {
+          "version": "1.30.0",
+          "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.30.0.tgz",
+          "integrity": "sha512-cWio/bEEiLwaeJ2X7GKzRd/mGmYqnBx1z4CWjP04+W5VDw9RtaqmkSrKsSUdEooYgsuX8kLyZ8ROaJ11dBM0Tg=="
+        }
       }
     },
     "vscode-debugprotocol": {
@@ -3481,11 +3488,6 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.7.1.tgz",
       "integrity": "sha512-ftGfU79AnnI3OHCG7kzCCN47jNI7BjECPAH2yhddtYTiQk0bnFbuFeQKvpXQcyNI3GsKEx5b6kSiBYshTiep6w=="
-    },
-    "vscode-uri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
     },
     "websocket-driver": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Go",
-"version": "0.6.85-beta.1",
+  "version": "0.6.85-beta.1",
   "publisher": "ms-vscode",
   "description": "Rich Go language support for Visual Studio Code",
   "author": {
@@ -40,7 +40,7 @@
     "json-rpc2": "^1.0.2",
     "vscode": "^1.1.4",
     "vscode-debug-logger": "^0.0.4",
-    "vscode-debugadapter": "^1.11.0",
+    "vscode-debugadapter": "^1.29.0",
     "vscode-debugprotocol": "^1.11.0",
     "vscode-extension-telemetry": "^0.0.15",
     "vscode-languageclient": "^4.1.3"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "json-rpc2": "^1.0.2",
     "vscode": "^1.1.4",
     "vscode-debug-logger": "^0.0.4",
-    "vscode-debugadapter": "^1.29.0",
+    "vscode-debugadapter": "^1.30.0",
     "vscode-debugprotocol": "^1.11.0",
     "vscode-extension-telemetry": "^0.0.15",
     "vscode-languageclient": "^4.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Go",
-"version": "0.6.84",
+"version": "0.6.85-beta.1",
   "publisher": "ms-vscode",
   "description": "Rich Go language support for Visual Studio Code",
   "author": {

--- a/src/avlTree.ts
+++ b/src/avlTree.ts
@@ -208,7 +208,7 @@ export class NearestNeighborDict<K, V> {
 	}
 
 	/**
-	 * Gets the value of a node within the tree with a specific key.
+	 * Gets a node within the tree with a specific key, or the nearest neighbor to that node if it does not exist.
 	 * @param key The key being searched for.
 	 * @return The (key, value) pair of the node with key nearset the given key in value.
 	 */
@@ -217,10 +217,11 @@ export class NearestNeighborDict<K, V> {
 	}
 
 	/**
-	 * Gets the value of a node within the tree with a specific key.
+	 * Gets a node within the tree with a specific key, or the node closest (as measured by this._distance) to that node if the key is not present
 	 * @param key The key being searched for.
 	 * @param root The root of the tree to search in.
-	 * @return The value of the node or null if it doesn't exist.
+	 * @param closest The current best estimate of the node closest to the node being searched for, as measured by this._distance
+	 * @return The (key, value) pair of the node with key nearset the given key in value.
 	 */
 	private _get(key: K, root: Node<K, V>, closest: Node<K, V>): Node<K, V> {
 		const result = this._compare(key, root.key);
@@ -251,7 +252,12 @@ export class NearestNeighborDict<K, V> {
 			case -1: return BalanceState.SLIGHTLY_UNBALANCED_RIGHT;
 			case 1: return BalanceState.SLIGHTLY_UNBALANCED_LEFT;
 			case 2: return BalanceState.UNBALANCED_LEFT;
-			default: return BalanceState.BALANCED;
+			case 0: return BalanceState.BALANCED;
+			default: {
+				console.error('Internal error: Avl tree should never be more than two levels unbalanced');
+				if (heightDifference > 0) return BalanceState.UNBALANCED_LEFT;
+				if (heightDifference < 0) return BalanceState.UNBALANCED_RIGHT;
+			}
 		}
 	}
 }

--- a/src/avlTree.ts
+++ b/src/avlTree.ts
@@ -1,0 +1,247 @@
+/**
+ * @license
+ * Copyright Daniel Imms <http://www.growingwiththeweb.com>
+ * Released under MIT license:
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Daniel Imms, http://www.growingwiththeweb.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Modified by Jackson Kearl <Microsoft/t-jakea@microsoft.com>
+ */
+
+/**
+ * Represents a node in the binary tree, which has a key and a value, as well as left and right subtrees
+ */
+export class Node<K, V> {
+	public left: Node<K, V> = null;
+	public right: Node<K, V> = null;
+	public height: number = null;
+
+	/**
+	 * Creates a new AVL Tree node.
+	 * @param key The key of the new node.
+	 * @param value The value of the new node.
+	 */
+	constructor(
+		public key: K,
+		public value: V
+	) {
+	}
+
+	/**
+	 * Performs a right rotate on this node.
+	 * @return The root of the sub-tree; the node where this node used to be.
+	 */
+	public rotateRight(): Node<K, V> {
+		//     b                           a
+		//    / \                         / \
+		//   a   e -> b.rotateRight() -> c   b
+		//  / \                             / \
+		// c   d                           d   e
+		const other = this.left;
+		this.left = other.right;
+		other.right = this;
+		this.height = Math.max(this.leftHeight, this.rightHeight) + 1;
+		other.height = Math.max(other.leftHeight, this.height) + 1;
+		return other;
+	}
+
+	/**
+	 * Performs a left rotate on this node.
+	 * @return The root of the sub-tree; the node where this node used to be.
+	 */
+	public rotateLeft(): Node<K, V> {
+		//   a                              b
+		//  / \                            / \
+		// c   b   -> a.rotateLeft() ->   a   e
+		//    / \                        / \
+		//   d   e                      c   d
+		const other = this.right;
+		this.right = other.left;
+		other.left = this;
+		this.height = Math.max(this.leftHeight, this.rightHeight) + 1;
+		other.height = Math.max(other.rightHeight, this.height) + 1;
+		return other;
+	}
+
+	/**
+	 * Convenience function to get the height of the left child of the node,
+	 * returning -1 if the node is null.
+	 * @return The height of the left child, or -1 if it doesn't exist.
+	 */
+	public get leftHeight(): number {
+		if (!this.left) {
+			return -1;
+		}
+		return this.left.height;
+	}
+
+	/**
+	 * Convenience function to get the height of the right child of the node,
+	 * returning -1 if the node is null.
+	 * @return The height of the right child, or -1 if it doesn't exist.
+	 */
+	public get rightHeight(): number {
+		if (!this.right) {
+			return -1;
+		}
+		return this.right.height;
+	}
+}
+
+export type DistanceFunction<K> = (a: K, b: K) => number;
+
+/**
+ * Represents how balanced a node's left and right children are.
+ */
+const enum BalanceState {
+	/** Right child's height is 2+ greater than left child's height */
+	UNBALANCED_RIGHT,
+	/** Right child's height is 1 greater than left child's height */
+	SLIGHTLY_UNBALANCED_RIGHT,
+	/** Left and right children have the same height */
+	BALANCED,
+	/** Left child's height is 1 greater than right child's height */
+	SLIGHTLY_UNBALANCED_LEFT,
+	/** Left child's height is 2+ greater than right child's height */
+	UNBALANCED_LEFT
+}
+
+export class NearestNeighborDict<K, V> {
+	protected _root: Node<K, V> = null;
+
+	/**
+	 * Creates a new AVL Tree.
+	 */
+	constructor(
+		start: Node<K, V>,
+		private _distance: DistanceFunction<K>
+	) {
+		this.insert(start.key, start.value);
+	}
+
+	/**
+	 * Inserts a new node with a specific key into the tree.
+	 * @param key The key being inserted.
+	 * @param value The value being inserted.
+	 */
+	public insert(key: K, value?: V): void {
+		this._root = this._insert(key, value, this._root);
+	}
+
+	/**
+	 * Inserts a new node with a specific key into the tree.
+	 * @param key The key being inserted.
+	 * @param root The root of the tree to insert in.
+	 * @return The new tree root.
+	 */
+	private _insert(key: K, value: V, root: Node<K, V>): Node<K, V> {
+		// Perform regular BST insertion
+		if (root === null) {
+			return new Node(key, value);
+		}
+
+		if (this._distance(key, root.key) < 0) {
+			root.left = this._insert(key, value, root.left);
+		} else if (this._distance(key, root.key) > 0) {
+			root.right = this._insert(key, value, root.right);
+		} else {
+			return root;
+		}
+
+		// Update height and rebalance tree
+		root.height = Math.max(root.leftHeight, root.rightHeight) + 1;
+		const balanceState = this._getBalanceState(root);
+
+		if (balanceState === BalanceState.UNBALANCED_LEFT) {
+			if (this._distance(key, root.left.key) < 0) {
+				// Left left case
+				root = root.rotateRight();
+			} else {
+				// Left right case
+				root.left = root.left.rotateLeft();
+				return root.rotateRight();
+			}
+		}
+
+		if (balanceState === BalanceState.UNBALANCED_RIGHT) {
+			if (this._distance(key, root.right.key) > 0) {
+				// Right right case
+				root = root.rotateLeft();
+			} else {
+				// Right left case
+				root.right = root.right.rotateRight();
+				return root.rotateLeft();
+			}
+		}
+
+		return root;
+	}
+
+	/**
+	 * Gets the value of a node within the tree with a specific key.
+	 * @param key The key being searched for.
+	 * @return The (key, value) pair of the node with key nearset the given key in value.
+	 */
+	public get(key: K): Node<K, V> {
+		return this._get(key, this._root, this._root);
+	}
+
+	/**
+	 * Gets the value of a node within the tree with a specific key.
+	 * @param key The key being searched for.
+	 * @param root The root of the tree to search in.
+	 * @return The value of the node or null if it doesn't exist.
+	 */
+	private _get(key: K, root: Node<K, V>, closest: Node<K, V>): Node<K, V> {
+		const result = this._distance(key, root.key);
+		if (result === 0) {
+			return root;
+		}
+
+		closest = this._distance(key, root.key) < this._distance(key, closest.key) ? root : closest;
+
+		if (result < 0) {
+			return root.left ? this._get(key, root.left, closest) : closest;
+		}
+		else {
+			return root.right ? this._get(key, root.right, closest) : closest;
+		}
+	}
+
+	/**
+	 * Gets the balance state of a node, indicating whether the left or right
+	 * sub-trees are unbalanced.
+	 * @param node The node to get the difference from.
+	 * @return The BalanceState of the node.
+	 */
+	private _getBalanceState(node: Node<K, V>): BalanceState {
+		const heightDifference = node.leftHeight - node.rightHeight;
+		switch (heightDifference) {
+			case -2: return BalanceState.UNBALANCED_RIGHT;
+			case -1: return BalanceState.SLIGHTLY_UNBALANCED_RIGHT;
+			case 1: return BalanceState.SLIGHTLY_UNBALANCED_LEFT;
+			case 2: return BalanceState.UNBALANCED_LEFT;
+			default: return BalanceState.BALANCED;
+		}
+	}
+}

--- a/src/avlTree.ts
+++ b/src/avlTree.ts
@@ -212,8 +212,8 @@ export class NearestNeighborDict<K, V> {
 	 * @param key The key being searched for.
 	 * @return The (key, value) pair of the node with key nearset the given key in value.
 	 */
-	public get(key: K): Node<K, V> {
-		return this._get(key, this._root, this._root);
+	public getNearest(key: K): Node<K, V> {
+		return this._getNearest(key, this._root, this._root);
 	}
 
 	/**
@@ -223,7 +223,7 @@ export class NearestNeighborDict<K, V> {
 	 * @param closest The current best estimate of the node closest to the node being searched for, as measured by this._distance
 	 * @return The (key, value) pair of the node with key nearset the given key in value.
 	 */
-	private _get(key: K, root: Node<K, V>, closest: Node<K, V>): Node<K, V> {
+	private _getNearest(key: K, root: Node<K, V>, closest: Node<K, V>): Node<K, V> {
 		const result = this._compare(key, root.key);
 		if (result === 0) {
 			return root;
@@ -232,10 +232,10 @@ export class NearestNeighborDict<K, V> {
 		closest = this._distance(key, root.key) < this._distance(key, closest.key) ? root : closest;
 
 		if (result < 0) {
-			return root.left ? this._get(key, root.left, closest) : closest;
+			return root.left ? this._getNearest(key, root.left, closest) : closest;
 		}
 		else {
-			return root.right ? this._get(key, root.right, closest) : closest;
+			return root.right ? this._getNearest(key, root.right, closest) : closest;
 		}
 	}
 

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -92,7 +92,9 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 				   }
 				 */
 				sendTelemetryEvent('format', { tool: formatTool }, { timeTaken });
-				console.log(`Formatting took (${timeTaken}ms).`);
+				if (timeTaken > 750) {
+					console.log(`Formatting took too long(${timeTaken}ms). Format On Save feature could be aborted.`);
+				}
 				return resolve(textEdits);
 			});
 			p.stdin.end(document.getText());

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -47,8 +47,6 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 	}
 
 	private runFormatter(formatTool: string, formatFlags: string[], document: vscode.TextDocument): Thenable<vscode.TextEdit[]> {
-		console.log(`Formatting started.`);
-
 		let formatCommandBinPath = getBinPath(formatTool);
 
 		return new Promise<vscode.TextEdit[]>((resolve, reject) => {
@@ -105,4 +103,3 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 // package main; import \"fmt\"; func main() {fmt.Print(\"Hello\")}
 // package main; import \"fmt\"; import \"math\"; func main() {fmt.Print(\"Hello\")}
 // package main; import \"fmt\"; import \"gopkg.in/Shopify/sarama.v1\"; func main() {fmt.Print(sarama.V0_10_0_0)}
-;

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -47,6 +47,8 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 	}
 
 	private runFormatter(formatTool: string, formatFlags: string[], document: vscode.TextDocument): Thenable<vscode.TextEdit[]> {
+		console.log(`Formatting started.`);
+
 		let formatCommandBinPath = getBinPath(formatTool);
 
 		return new Promise<vscode.TextEdit[]>((resolve, reject) => {
@@ -90,9 +92,7 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 				   }
 				 */
 				sendTelemetryEvent('format', { tool: formatTool }, { timeTaken });
-				if (timeTaken > 750) {
-					console.log(`Formatting took too long(${timeTaken}ms). Format On Save feature could be aborted.`);
-				}
+				console.log(`Formatting took (${timeTaken}ms).`);
 				return resolve(textEdits);
 			});
 			p.stdin.end(document.getText());
@@ -103,3 +103,4 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 // package main; import \"fmt\"; func main() {fmt.Print(\"Hello\")}
 // package main; import \"fmt\"; import \"math\"; func main() {fmt.Print(\"Hello\")}
 // package main; import \"fmt\"; import \"gopkg.in/Shopify/sarama.v1\"; func main() {fmt.Print(sarama.V0_10_0_0)}
+;

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -99,7 +99,3 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 		});
 	}
 }
-
-// package main; import \"fmt\"; func main() {fmt.Print(\"Hello\")}
-// package main; import \"fmt\"; import \"math\"; func main() {fmt.Print(\"Hello\")}
-// package main; import \"fmt\"; import \"gopkg.in/Shopify/sarama.v1\"; func main() {fmt.Print(sarama.V0_10_0_0)}

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -109,7 +109,7 @@ export class GoDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 		decls: GoOutlineDeclaration[],
 		symbols: vscode.SymbolInformation[],
 		containerName: string,
-		byteOffsetToDocumentOffset: (offset: number) => number): void {
+		byteOffsetToDocumentOffset: (byteOffset: number) => number): void {
 
 		let gotoSymbolConfig = vscode.workspace.getConfiguration('go', document.uri)['gotoSymbol'];
 		let includeImports = gotoSymbolConfig ? gotoSymbolConfig['includeImports'] : false;
@@ -137,7 +137,6 @@ export class GoDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 	}
 
 	public provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): Thenable<vscode.SymbolInformation[]> {
-		let t0 = Date.now();
 		let options = { fileName: document.fileName, document: document };
 		return documentSymbols(options, token).then(decls => {
 			let symbols: vscode.SymbolInformation[] = [];

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -7,7 +7,7 @@
 
 import vscode = require('vscode');
 import cp = require('child_process');
-import { getBinPath, getFileArchive, getToolsEnvVars, killProcess, makeMemoizedOffsetConverter } from './util';
+import { getBinPath, getFileArchive, getToolsEnvVars, killProcess, makeMemoizedByteOffsetConverter } from './util';
 import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
 
 // Keep in sync with https://github.com/ramya-rao-a/go-outline
@@ -140,7 +140,7 @@ export class GoDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 		let options = { fileName: document.fileName, document: document };
 		return documentSymbols(options, token).then(decls => {
 			let symbols: vscode.SymbolInformation[] = [];
-			this.convertToCodeSymbols(document, decls, symbols, '', makeMemoizedOffsetConverter(new Buffer(document.getText())));
+			this.convertToCodeSymbols(document, decls, symbols, '', makeMemoizedByteOffsetConverter(new Buffer(document.getText())));
 			return symbols;
 		});
 	}

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -7,7 +7,7 @@
 
 import vscode = require('vscode');
 import cp = require('child_process');
-import { getBinPath, getFileArchive, getToolsEnvVars, killProcess, makeMemoizedOffsetBuffer } from './util';
+import { getBinPath, getFileArchive, getToolsEnvVars, killProcess, makeMemoizedOffsetConverter } from './util';
 import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
 
 // Keep in sync with https://github.com/ramya-rao-a/go-outline
@@ -141,7 +141,7 @@ export class GoDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 		let options = { fileName: document.fileName, document: document };
 		return documentSymbols(options, token).then(decls => {
 			let symbols: vscode.SymbolInformation[] = [];
-			this.convertToCodeSymbols(document, decls, symbols, '', makeMemoizedOffsetBuffer(new Buffer(document.getText())));
+			this.convertToCodeSymbols(document, decls, symbols, '', makeMemoizedOffsetConverter(new Buffer(document.getText())));
 			return symbols;
 		});
 	}

--- a/src/util.ts
+++ b/src/util.ts
@@ -792,23 +792,23 @@ export function killTree(processId: number): void {
 	}
 }
 
-export function makeMemoizedOffsetConverter(buffer: Buffer): (offset: number) => number {
+export function makeMemoizedOffsetConverter(buffer: Buffer): (byteOffset: number) => number {
 	let defaultValue = new Node<number, number>(0, 0); // 0 bytes will always be 0 characters
 	let memo = new NearestNeighborDict(defaultValue, NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
-	return (offset: number) => {
-		let nearest = memo.get(offset);
-		let byteDelta = offset - nearest.key;
+	return (byteOffset: number) => {
+		let nearest = memo.get(byteOffset);
+		let byteDelta = byteOffset - nearest.key;
 
 		if (byteDelta === 0)
 			return nearest.value;
 
 		let charDelta: number;
 		if (byteDelta > 0)
-			charDelta = buffer.toString('utf8', nearest.key, offset).length;
+			charDelta = buffer.toString('utf8', nearest.key, byteOffset).length;
 		else
-			charDelta = -buffer.toString('utf8', offset, nearest.key).length;
+			charDelta = -buffer.toString('utf8', byteOffset, nearest.key).length;
 
-		memo.insert(offset, nearest.value + charDelta);
+		memo.insert(byteOffset, nearest.value + charDelta);
 		return nearest.value + charDelta;
 	};
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -792,7 +792,7 @@ export function killTree(processId: number): void {
 	}
 }
 
-export function makeMemoizedOffsetBuffer(buffer: Buffer): (offset: number) => number {
+export function makeMemoizedOffsetConverter(buffer: Buffer): (offset: number) => number {
 	let memo = new NearestNeighborDict(new Node<number, number>(0, 0), (a, b) => a < b ? b - a : a - b);
 	return (offset: number) => {
 		let nearest = memo.get(offset);

--- a/src/util.ts
+++ b/src/util.ts
@@ -793,7 +793,8 @@ export function killTree(processId: number): void {
 }
 
 export function makeMemoizedOffsetConverter(buffer: Buffer): (offset: number) => number {
-	let memo = new NearestNeighborDict(new Node<number, number>(0, 0), (a, b) => a < b ? b - a : a - b);
+	let defaultValue = new Node<number, number>(0, 0); // 0 bytes will always be 0 characters
+	let memo = new NearestNeighborDict(defaultValue, NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
 	return (offset: number) => {
 		let nearest = memo.get(offset);
 		let byteDelta = offset - nearest.key;

--- a/src/util.ts
+++ b/src/util.ts
@@ -792,7 +792,7 @@ export function killTree(processId: number): void {
 	}
 }
 
-export function makeMemoizedOffsetConverter(buffer: Buffer): (byteOffset: number) => number {
+export function makeMemoizedByteOffsetConverter(buffer: Buffer): (byteOffset: number) => number {
 	let defaultValue = new Node<number, number>(0, 0); // 0 bytes will always be 0 characters
 	let memo = new NearestNeighborDict(defaultValue, NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
 	return (byteOffset: number) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -796,7 +796,7 @@ export function makeMemoizedOffsetConverter(buffer: Buffer): (byteOffset: number
 	let defaultValue = new Node<number, number>(0, 0); // 0 bytes will always be 0 characters
 	let memo = new NearestNeighborDict(defaultValue, NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
 	return (byteOffset: number) => {
-		let nearest = memo.get(byteOffset);
+		let nearest = memo.getNearest(byteOffset);
 		let byteDelta = byteOffset - nearest.key;
 
 		if (byteDelta === 0)

--- a/test/unit/NNDict.test.ts
+++ b/test/unit/NNDict.test.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Node, NearestNeighborDict } from '../../src/avlTree';
+
+suite('NearestNeighborDict Tests', () => {
+	test('basic insert/get: random', () => {
+		let dict = new NearestNeighborDict(new Node(0, 0), NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
+		let entries = [5, 2, 9, 23, 3, 0, 1, -4, -2];
+		entries.forEach(x => dict.insert(x));
+		assert(dict.height() < 4);
+
+		entries.forEach(x => {
+			assert.equal(dict.get(x + 0.1).key, x);
+			assert.equal(dict.get(x - 0.1).key, x);
+		});
+
+		assert.equal(dict.get(23 + 10).key, 23);
+		assert.equal(dict.get(23 - 4).key, 23);
+	});
+
+	test('basic insert/get: increasing', () => {
+		let dict = new NearestNeighborDict(new Node(0, 0), NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
+		let entries = [-10, -5, -4, -1, 0, 1, 5, 10, 23];
+		entries.forEach(x => dict.insert(x));
+		assert(dict.height() < 4);
+
+		entries.forEach(x => {
+			assert.equal(dict.get(x + 0.1).key, x);
+			assert.equal(dict.get(x - 0.1).key, x);
+		});
+
+		assert.equal(dict.get(23 + 10).key, 23);
+		assert.equal(dict.get(23 - 4).key, 23);
+	});
+
+	test('basic insert/get: decreasing', () => {
+		let dict = new NearestNeighborDict(new Node(0, 0), NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
+		let entries = [-10, -5, -4, -1, 0, 1, 5, 10, 23].reverse();
+		entries.forEach(x => dict.insert(x));
+		assert(dict.height() < 4);
+
+		entries.forEach(x => {
+			assert.equal(dict.get(x + 0.1).key, x);
+			assert.equal(dict.get(x - 0.1).key, x);
+		});
+
+		assert.equal(dict.get(23 + 10).key, 23);
+		assert.equal(dict.get(23 - 4).key, 23);
+	});
+});

--- a/test/unit/NNDict.test.ts
+++ b/test/unit/NNDict.test.ts
@@ -14,12 +14,12 @@ suite('NearestNeighborDict Tests', () => {
 		assert(dict.height() < 4);
 
 		entries.forEach(x => {
-			assert.equal(dict.get(x + 0.1).key, x);
-			assert.equal(dict.get(x - 0.1).key, x);
+			assert.equal(dict.getNearest(x + 0.1).key, x);
+			assert.equal(dict.getNearest(x - 0.1).key, x);
 		});
 
-		assert.equal(dict.get(23 + 10).key, 23);
-		assert.equal(dict.get(23 - 4).key, 23);
+		assert.equal(dict.getNearest(23 + 10).key, 23);
+		assert.equal(dict.getNearest(23 - 4).key, 23);
 	});
 
 	test('basic insert/get: increasing', () => {
@@ -29,12 +29,12 @@ suite('NearestNeighborDict Tests', () => {
 		assert(dict.height() < 4);
 
 		entries.forEach(x => {
-			assert.equal(dict.get(x + 0.1).key, x);
-			assert.equal(dict.get(x - 0.1).key, x);
+			assert.equal(dict.getNearest(x + 0.1).key, x);
+			assert.equal(dict.getNearest(x - 0.1).key, x);
 		});
 
-		assert.equal(dict.get(23 + 10).key, 23);
-		assert.equal(dict.get(23 - 4).key, 23);
+		assert.equal(dict.getNearest(23 + 10).key, 23);
+		assert.equal(dict.getNearest(23 - 4).key, 23);
 	});
 
 	test('basic insert/get: decreasing', () => {
@@ -44,11 +44,11 @@ suite('NearestNeighborDict Tests', () => {
 		assert(dict.height() < 4);
 
 		entries.forEach(x => {
-			assert.equal(dict.get(x + 0.1).key, x);
-			assert.equal(dict.get(x - 0.1).key, x);
+			assert.equal(dict.getNearest(x + 0.1).key, x);
+			assert.equal(dict.getNearest(x - 0.1).key, x);
 		});
 
-		assert.equal(dict.get(23 + 10).key, 23);
-		assert.equal(dict.get(23 - 4).key, 23);
+		assert.equal(dict.getNearest(23 + 10).key, 23);
+		assert.equal(dict.getNearest(23 - 4).key, 23);
 	});
 });


### PR DESCRIPTION
This removes massive copy overhead from recreating Buffers of the entire document for every symbol in the file. Also reduces the quadratic time approach to converting from byte-offsets to character-offsets to log-linear time.

Hopefully closes #1668.