### PR TITLE
Prioritize current project import suggestions

### DIFF
--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -188,7 +188,7 @@ export function getImportablePackages(filePath: string, useCache: boolean = fals
 			if (!foundPkgRootDir) {
 				// try to guess package root dir
 				let vendorIndex = pkgPath.indexOf('/vendor/');
-				if (vendorIndex !== -1 ) {
+				if (vendorIndex !== -1) {
 					foundPkgRootDir = path.join(currentWorkspace, pkgPath.substring(0, vendorIndex).replace('/', path.sep));
 					pkgRootDirs.set(fileDirPath, foundPkgRootDir);
 				}

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -355,7 +355,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 	// Return importable packages that match given word as Completion Items
 	private getMatchingPackages(document: vscode.TextDocument, word: string, suggestionSet: Set<string>): vscode.CompletionItem[] {
 		if (!word) return [];
-	
+
 		const cwd = path.dirname(document.fileName);
 		const goWorkSpace = getCurrentGoWorkspaceFromGOPATH(getCurrentGoPath(), cwd);
 		const workSpaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
@@ -375,7 +375,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 					arguments: [pkgPath]
 				};
 				item.kind = vscode.CompletionItemKind.Module;
-				
+
 				// Unimported packages should appear after the suggestions from gocode
 				const isStandardPackage = !item.detail.includes('.');
 				item.sortText = isStandardPackage ? 'za' : pkgPath.startsWith(currentPkgRootPath) ? 'zb' : 'zc';

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -363,6 +363,8 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 		const goPath = getCurrentGoPath();
 		const goWorkSpace = getCurrentGoWorkspaceFromGOPATH(goPath, cwd);
 		const workspaceRootPath = workSpaceFolder ? workSpaceFolder.uri.path : cwd;
+		// deduce rootPath so that unimported packages are prioritized in 
+		// import suggestions.
 		const rootPath = workspaceRootPath.slice(goWorkSpace.length + 1);
 
 		this.pkgsList.forEach((pkgName: string, pkgPath: string) => {
@@ -380,13 +382,8 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				item.kind = vscode.CompletionItemKind.Module;
 				// Add same sortText to the unimported packages so that they appear after the suggestions from gocode
 				const isStandardPackage = !item.detail.includes('.');
-				item.sortText = isStandardPackage ? 'za' : 'zb';
-				if (pkgPath.startsWith(rootPath)) {
-					item.sortText = 'a';
-					completionItems.unshift(item);
-				} else {
-					completionItems.push(item);
-				}
+				item.sortText = isStandardPackage ? 'za' : pkgPath.startsWith(rootPath) ? 'zb' : 'zc';
+				completionItems.push(item);
 			}
 		});
 


### PR DESCRIPTION
This PR will make it so that "import suggestions" will always put your project's packages at the top. This really helps when there are very common package names like `log` or `errors` and you want to import them through the autocomplete feature. Before this pr, you'd have to scroll through 10s if not 100s of packages to find the one form you're workspace. 

From the screenshot below, you can see that if you're inside `upspin.io`'s sourcode, then the autocomplete shows you imports from that package first.
<img width="1262" alt="screen shot 2018-07-09 at 11 11 48 pm" src="https://user-images.githubusercontent.com/16294261/42487117-7c2cc894-83cd-11e8-9a3a-df723596bd10.png">
