### PR TITLE
Do not suggest function parameters if passing it as an argument

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -195,7 +195,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 								);
 							}
 							if ((config['useCodeSnippetsOnFunctionSuggest'] || config['useCodeSnippetsOnFunctionSuggestWithoutType'])
-								&& (suggest.class === 'func' || suggest.class === 'var' && suggest.type.startsWith('func('))) {
+								&& (suggest.class === 'func' || suggest.class === 'var' && suggest.type.startsWith('func(') && lineText.substr(position.character, 1) !== ')' && lineText.substr(position.character, 1) !== ',')) {
 								let { params, returnType } = getParametersAndReturnType(suggest.type.substring(4));
 								let paramSnippets = [];
 								for (let i = 0; i < params.length; i++) {
@@ -213,7 +213,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 								}
 								// Avoid adding snippet for function suggest when cursor is followed by ()
 								// i.e: met() -> method()()
-								if (lineText.substr(position.character, 2) !== '()' && lineText.substr(position.character, 1) !== ')' && lineText.substr(position.character, 1) !== ',') {
+								if (lineText.substr(position.character, 2) !== '()') {
 									item.insertText = new vscode.SnippetString(suggest.name + '(' + paramSnippets.join(', ') + ')');
 								}
 							}

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -213,7 +213,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 								}
 								// Avoid adding snippet for function suggest when cursor is followed by ()
 								// i.e: met() -> method()()
-								if (lineText.substr(position.character, 2) !== '()') {
+								if (lineText.substr(position.character, 2) !== '()' && lineText.substr(position.character, 1) !== ')' && lineText.substr(position.character, 1) !== ',') {
 									item.insertText = new vscode.SnippetString(suggest.name + '(' + paramSnippets.join(', ') + ')');
 								}
 							}


### PR DESCRIPTION
As per the suggestion: https://github.com/Microsoft/vscode-go/issues/1779#issuecomment-403675528

This PR disables suggesting function parameters if passing the suggestion as an argument. If cursor ends with `,` or `)` it skips parameter suggestion.

For more info: https://github.com/Microsoft/vscode-go/issues/1779