### PR TITLE
Detach to clean up debug file

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -587,7 +587,7 @@ class GoDebugSession extends DebugSession {
 	protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments): void {
 		verbose('DisconnectRequest');
 		this.delve.close();
-		
+
 		// Timeout to ensure detach is complete.
 		setTimeout(() => {
 			if (this.delve.debugProcess) {

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -464,7 +464,6 @@ class Delve {
 			});
 		} else {
 			this.call('Detach', [{ kill: true }], null);
-			
 		}
 	}
 }
@@ -589,6 +588,7 @@ class GoDebugSession extends DebugSession {
 		verbose('DisconnectRequest');
 		this.delve.close();
 		
+		// Timeout to ensure detach is complete.
 		setTimeout(() => {
 			if (this.delve.debugProcess) {
 				killTree(this.delve.debugProcess.pid);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -463,7 +463,8 @@ class Delve {
 				});
 			});
 		} else {
-			killTree(this.debugProcess.pid);
+			this.call('Detach', [{ kill: true }], null);
+			
 		}
 	}
 }
@@ -587,8 +588,14 @@ class GoDebugSession extends DebugSession {
 	protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments): void {
 		verbose('DisconnectRequest');
 		this.delve.close();
-		super.disconnectRequest(response, args);
-		verbose('DisconnectResponse');
+		
+		setTimeout(() => {
+			if (this.delve.debugProcess) {
+				killTree(this.delve.debugProcess.pid);
+			}
+			super.disconnectRequest(response, args);
+			verbose('DisconnectResponse');
+		}, 1000);
 	}
 
 	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {


### PR DESCRIPTION
This is an attempt to clean up the `debug` file that gets created after every debugging session.

@lggomez The Detach command deletes the said `debug` file successfully, but there are a few issues where I thought you could help me out
- It only works in Windows. On Mac, the debug file doesnt get removed
- The callback for the detach call never gets called, so I had to resort to `settimeout`

Thoughts?

@aarzilli  @derekparker What is the recommended way for a client to stop an headless dlv server such that
- the debug file that gets created is taken care of
- all processes started by the debug server (for eg: web servers) are killed (We had to manually kill the process corresponding to the headless server and all its children to achieve this)

From the docs I can see `Detach`, `Disconnect` (only available in v2) and `Kill` as possible choices.