### PR TITLE
Include delve error in apicall error logs

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -463,7 +463,7 @@ class Delve {
 			}
 		}, err => {
 			if (!this.debugProcess && err) {
-				return logError('Failed to halt.');
+				return logError('Failed to halt - ' + err.toString());
 			}
 		}).then(() => {
 			if (this.debugProcess) {
@@ -701,7 +701,7 @@ class GoDebugSession extends DebugSession {
 			}
 
 			if (err) {
-				logError('Failed to get threads.');
+				logError('Failed to get threads - ' + err.toString());
 				return this.sendErrorResponse(response, 2003, 'Unable to display threads: "{e}"', { e: err.toString() });
 			}
 			const goroutines = this.delve.isApiV1 ? <DebugGoroutine[]>out : (<ListGoroutinesOut>out).Goroutines;
@@ -754,7 +754,7 @@ class GoDebugSession extends DebugSession {
 		const listLocalVarsIn = { goroutineID: this.debugState.currentGoroutine.id, frame: args.frameId };
 		this.delve.call<DebugVariable[] | ListLocalVarsOut>('ListLocalVars', this.delve.isApiV1 ? [listLocalVarsIn] : [{ scope: listLocalVarsIn, cfg: this.delve.loadConfig }], (err, out) => {
 			if (err) {
-				logError('Failed to list local variables.');
+				logError('Failed to list local variables - ' + err.toString());
 				return this.sendErrorResponse(response, 2005, 'Unable to list locals: "{e}"', { e: err.toString() });
 			}
 			const locals = this.delve.isApiV1 ? <DebugVariable[]>out : (<ListLocalVarsOut>out).Variables;
@@ -762,7 +762,7 @@ class GoDebugSession extends DebugSession {
 			let listLocalFunctionArgsIn = { goroutineID: this.debugState.currentGoroutine.id, frame: args.frameId };
 			this.delve.call<DebugVariable[] | ListFunctionArgsOut>('ListFunctionArgs', this.delve.isApiV1 ? [listLocalFunctionArgsIn] : [{ scope: listLocalFunctionArgsIn, cfg: this.delve.loadConfig }], (err, outArgs) => {
 				if (err) {
-					logError('Failed to list function args.');
+					logError('Failed to list function args - ' + err.toString());
 					return this.sendErrorResponse(response, 2006, 'Unable to list args: "{e}"', { e: err.toString() });
 				}
 				const args = this.delve.isApiV1 ? <DebugVariable[]>outArgs : (<ListFunctionArgsOut>outArgs).Args;
@@ -891,7 +891,7 @@ class GoDebugSession extends DebugSession {
 			// [TODO] Can we avoid doing this? https://github.com/Microsoft/vscode/issues/40#issuecomment-161999881
 			this.delve.call<DebugGoroutine[] | ListGoroutinesOut>('ListGoroutines', [], (err, out) => {
 				if (err) {
-					logError('Failed to get threads.');
+					logError('Failed to get threads - ' + err.toString());
 				}
 				const goroutines = this.delve.isApiV1 ? <DebugGoroutine[]>out : (<ListGoroutinesOut>out).Goroutines;
 				// Assume we need to stop all the threads we saw before...
@@ -924,7 +924,7 @@ class GoDebugSession extends DebugSession {
 		verbose('ContinueRequest');
 		this.delve.call<DebuggerState | CommandOut>('Command', [{ name: 'continue' }], (err, out) => {
 			if (err) {
-				logError('Failed to continue.');
+				logError('Failed to continue - ' + err.toString());
 			}
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('continue state', state);
@@ -939,7 +939,7 @@ class GoDebugSession extends DebugSession {
 		verbose('NextRequest');
 		this.delve.call<DebuggerState | CommandOut>('Command', [{ name: 'next' }], (err, out) => {
 			if (err) {
-				logError('Failed to next.');
+				logError('Failed to next - ' + err.toString());
 			}
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('next state', state);
@@ -954,7 +954,7 @@ class GoDebugSession extends DebugSession {
 		verbose('StepInRequest');
 		this.delve.call<DebuggerState | CommandOut>('Command', [{ name: 'step' }], (err, out) => {
 			if (err) {
-				logError('Failed to step.');
+				logError('Failed to step - ' + err.toString());
 			}
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('stop state', state);
@@ -969,7 +969,7 @@ class GoDebugSession extends DebugSession {
 		verbose('StepOutRequest');
 		this.delve.call<DebuggerState | CommandOut>('Command', [{ name: 'stepOut' }], (err, out) => {
 			if (err) {
-				logError('Failed to stepout.');
+				logError('Failed to stepout - ' + err.toString());
 			}
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('stepout state', state);
@@ -984,7 +984,7 @@ class GoDebugSession extends DebugSession {
 		verbose('PauseRequest');
 		this.delve.call<DebuggerState | CommandOut>('Command', [{ name: 'halt' }], (err, out) => {
 			if (err) {
-				logError('Failed to halt.');
+				logError('Failed to halt - ' + err.toString());
 				return this.sendErrorResponse(response, 2010, 'Unable to halt execution: "{e}"', { e: err.toString() });
 			}
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;


### PR DESCRIPTION
@ramya-rao-a 

This should make delve errors more identifiable that just the standard error messages