### PR TITLE
The name of the extension should be lowercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Go",
+  "name": "go",
   "version": "0.6.86-beta.3",
   "publisher": "ms-vscode",
   "description": "Rich Go language support for Visual Studio Code",


### PR DESCRIPTION
According to this page, name of the extension should be all lowercase with no spaces.
https://code.visualstudio.com/docs/extensionAPI/extension-manifest

Other extensions are obeying this rule. (https://github.com/Microsoft/vscode-azureappservice/blob/master/package.json, https://github.com/Microsoft/vsts-vscode/blob/master/package.json)

Changing the name seems dangerous though...