### PR TITLE
Fix error handling for when err is not a string

### DIFF
--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -35,7 +35,7 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 		}
 
 		return this.runFormatter(formatTool, formatFlags, document).then(edits => edits, err => {
-			if (err && err.startsWith('flag provided but not defined: -srcdir')) {
+			if (typeof err === 'string' && err.startsWith('flag provided but not defined: -srcdir')) {
 				promptForUpdatingTool(formatTool);
 				return Promise.resolve([]);
 			}


### PR DESCRIPTION
Currently, I'm getting a `spawn EACCES` error, but the console is reporting it as `TypeError: err.startsWith is not a function` because the `err` variable is an object and doesn't have the `startsWith` method.