### PR TITLE
Fix  `build worksapce fails when editing _test file`#(1789)

### DIFF
--- a/src/goBuild.ts
+++ b/src/goBuild.ts
@@ -89,7 +89,7 @@ export function goBuild(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigura
 		buildArgs.push(goConfig['buildTags']);
 	}
 
-	if (buildWorkspace && currentWorkspace && !isTestFile) {
+	if (buildWorkspace && currentWorkspace) {
 		return getNonVendorPackages(currentWorkspace).then(pkgs => {
 			let buildPromises = [];
 			buildPromises = pkgs.map(pkgPath => {


### PR DESCRIPTION
Remove `isTestFile` check when `buildWorkspace` is true