### PR TITLE
include subtests when running tests via goTest

### DIFF
--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -332,7 +332,7 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 			// in running all the test methods, but one of them should call testify's `suite.Run(...)`
 			// which will result in the correct thing to happen
 			if (testFunctions.length > 0) {
-				params = params.concat(['-run', util.format('^%s$', testFunctions.join('|'))]);
+				params = params.concat(['-run', util.format('^%s(/.*|$)', testFunctions.join('|'))]);
 			}
 			if (testifyMethods.length > 0) {
 				params = params.concat(['-testify.m', util.format('^%s$', testifyMethods.join('|'))]);


### PR DESCRIPTION
This change extends the regular expression used to filter test functions when running tests via `testUtils.goTest`.

The actions `run file tests`, `run test` and `debug test` will now include subtests when running.

Running the following test with `run test` will also test `TestGroup/A` and `TestGroup/B` instead of skipping them.
```
func TestGroup(t *testing.T) {
  t.Run("A", func(t *testing.T) {})
  t.Run("B", func(t *testing.T) {})
}
```
