### PR TITLE
Add command: "Go: Benchmark package."

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,11 @@
         "description": "Runs all unit tests in the package of the current file."
       },
       {
+        "command": "go.benchmark.package",
+        "title": "Go: Benchmark Package",
+        "description": "Runs all unit tests in the package of the current file."
+      },
+      {
         "command": "go.test.workspace",
         "title": "Go: Test All Packages In Workspace",
         "description": "Runs all unit tests from all packages in the current workspace."

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
       {
         "command": "go.benchmark.package",
         "title": "Go: Benchmark Package",
-        "description": "Runs all unit tests in the package of the current file."
+        "description": "Runs all benchmarks in the package of the current file."
       },
       {
         "command": "go.test.workspace",

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -243,13 +243,13 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.package', (args) => {
 		let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
 		let isBenchmark = false;
-		testCurrentPackage(goConfig, args);
+		testCurrentPackage(goConfig, isBenchmark, args);
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.benchmark.package', (args) => {
 		let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
 		let isBenchmark = true;
-		testCurrentPackage(goConfig, args);
+		testCurrentPackage(goConfig, isBenchmark, args);
 	}));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.file', (args) => {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -242,6 +242,13 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.test.package', (args) => {
 		let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
+		let isBenchmark = false;
+		testCurrentPackage(goConfig, args);
+	}));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.benchmark.package', (args) => {
+		let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
+		let isBenchmark = true;
 		testCurrentPackage(goConfig, args);
 	}));
 

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -104,7 +104,7 @@ export function testCurrentPackage(goConfig: vscode.WorkspaceConfiguration, isBe
 	}
 
 	const { tmpCoverPath, testFlags } = makeCoverData(goConfig, 'coverOnTestPackage', args);
-	
+
 	const testConfig: TestConfig = {
 		goConfig: goConfig,
 		dir: path.dirname(editor.document.fileName),

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -96,7 +96,7 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, isBenchmar
  *
  * @param goConfig Configuration for the Go extension.
  */
-export function testCurrentPackage(goConfig: vscode.WorkspaceConfiguration, args: any) {
+export function testCurrentPackage(goConfig: vscode.WorkspaceConfiguration, isBenchmark: boolean, args: any) {
 	let editor = vscode.window.activeTextEditor;
 	if (!editor) {
 		vscode.window.showInformationMessage('No editor is active.');
@@ -104,11 +104,12 @@ export function testCurrentPackage(goConfig: vscode.WorkspaceConfiguration, args
 	}
 
 	const { tmpCoverPath, testFlags } = makeCoverData(goConfig, 'coverOnTestPackage', args);
-
+	
 	const testConfig: TestConfig = {
 		goConfig: goConfig,
 		dir: path.dirname(editor.document.fileName),
 		flags: testFlags,
+		isBenchmark: isBenchmark,
 	};
 	// Remember this config as the last executed test.
 	lastTestConfig = testConfig;

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -339,7 +339,11 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 			}
 		}
 		return Promise.resolve(params);
-	} else if (testconfig.includeSubDirectories && !testconfig.isBenchmark) {
+	}
+	let params: string[] = [];
+	if (testconfig.isBenchmark) {
+		params = ['-bench', '.'];
+	} else if (testconfig.includeSubDirectories) {
 		return getGoVersion().then((ver: SemVersion) => {
 			if (ver && (ver.major > 1 || (ver.major === 1 && ver.minor >= 9))) {
 				return ['./...'];
@@ -347,5 +351,5 @@ function targetArgs(testconfig: TestConfig): Thenable<Array<string>> {
 			return getNonVendorPackages(testconfig.dir);
 		});
 	}
-	return Promise.resolve([]);
+	return Promise.resolve(params);
 }


### PR DESCRIPTION
This PR adds a new command called "go.benchmark.package" that runs benchmark tests for the current package.
I did this adding a new isBenchmark flag to the testCurrentPackage file. 
Also, according to [this](https://golang.org/cmd/go/#hdr-Testing_flags) docs, the `-bench` flag doesn't have a default value and by default doesn't run any tests. I've edited the testConfig to send `.` when it is running for a package.