### PR TITLE
Use mkdtemp for secure temp files

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -12,7 +12,7 @@ import { basename, dirname, extname } from 'path';
 import { spawn, ChildProcess, execSync, spawnSync, execFile } from 'child_process';
 import { Client, RPCConnection } from 'json-rpc2';
 import { parseEnvFile, getBinPathWithPreferredGopath, resolveHomeDir, getInferredGopath, getCurrentGoWorkspaceFromGOPATH, envPath, fixDriveCasingInWindows } from '../goPath';
-import { getTempFile } from '../util'
+import { getTempFile } from '../util';
 import * as logger from 'vscode-debug-logger';
 
 require('console-stamp')(console);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -12,6 +12,7 @@ import { basename, dirname, extname } from 'path';
 import { spawn, ChildProcess, execSync, spawnSync, execFile } from 'child_process';
 import { Client, RPCConnection } from 'json-rpc2';
 import { parseEnvFile, getBinPathWithPreferredGopath, resolveHomeDir, getInferredGopath, getCurrentGoWorkspaceFromGOPATH, envPath, fixDriveCasingInWindows } from '../goPath';
+import { getTempFile } from '../util'
 import * as logger from 'vscode-debug-logger';
 
 require('console-stamp')(console);
@@ -531,7 +532,7 @@ class GoDebugSession extends DebugSession {
 		this.delve = null;
 		this.breakpoints = new Map<string, DebugBreakpoint[]>();
 
-		const logPath = path.join(os.tmpdir(), 'vscode-go-debug.txt');
+		const logPath = getTempFile('vscode-go-debug.txt');
 		logger.init(e => this.sendEvent(e), logPath, isServer);
 	}
 

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -12,7 +12,6 @@ import { basename, dirname, extname } from 'path';
 import { spawn, ChildProcess, execSync, spawnSync, execFile } from 'child_process';
 import { Client, RPCConnection } from 'json-rpc2';
 import { parseEnvFile, getBinPathWithPreferredGopath, resolveHomeDir, getInferredGopath, getCurrentGoWorkspaceFromGOPATH, envPath, fixDriveCasingInWindows } from '../goPath';
-import { getTempFile } from '../util';
 import * as logger from 'vscode-debug-logger';
 
 require('console-stamp')(console);
@@ -532,7 +531,7 @@ class GoDebugSession extends DebugSession {
 		this.delve = null;
 		this.breakpoints = new Map<string, DebugBreakpoint[]>();
 
-		const logPath = getTempFile('vscode-go-debug.txt');
+		const logPath = path.join(os.tmpdir(), 'vscode-go-debug.txt');
 		logger.init(e => this.sendEvent(e), logPath, isServer);
 	}
 

--- a/src/goBuild.ts
+++ b/src/goBuild.ts
@@ -1,6 +1,6 @@
 import path = require('path');
 import vscode = require('vscode');
-import { getToolsEnvVars, runTool, ICheckResult, handleDiagnosticErrors, getWorkspaceFolderPath, getCurrentGoPath, TempFileProvider } from './util';
+import { getToolsEnvVars, runTool, ICheckResult, handleDiagnosticErrors, getWorkspaceFolderPath, getCurrentGoPath, getTempFilePath } from './util';
 import { outputChannel } from './goStatus';
 import os = require('os');
 import { getNonVendorPackages } from './goPackages';
@@ -70,7 +70,7 @@ export function goBuild(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigura
 	}
 
 	const buildEnv = Object.assign({}, getToolsEnvVars());
-	const tmpPath = TempFileProvider.getFilePath('go-code-check');
+	const tmpPath = getTempFilePath('go-code-check');
 	const isTestFile = fileUri && fileUri.fsPath.endsWith('_test.go');
 	const buildFlags: string[] = isTestFile ? getTestFlags(goConfig, null) : (Array.isArray(goConfig['buildFlags']) ? [...goConfig['buildFlags']] : []);
 	const buildArgs: string[] = isTestFile ? ['test', '-c'] : ['build'];

--- a/src/goBuild.ts
+++ b/src/goBuild.ts
@@ -1,6 +1,6 @@
 import path = require('path');
 import vscode = require('vscode');
-import { getToolsEnvVars, runTool, ICheckResult, handleDiagnosticErrors, getWorkspaceFolderPath, getCurrentGoPath, getUserNameHash } from './util';
+import { getToolsEnvVars, runTool, ICheckResult, handleDiagnosticErrors, getWorkspaceFolderPath, getCurrentGoPath, getUserNameHash, getTempFile } from './util';
 import { outputChannel } from './goStatus';
 import os = require('os');
 import { getNonVendorPackages } from './goPackages';
@@ -70,7 +70,7 @@ export function goBuild(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigura
 	}
 
 	const buildEnv = Object.assign({}, getToolsEnvVars());
-	const tmpPath = path.normalize(path.join(os.tmpdir(), 'go-code-check.' + getUserNameHash()));
+	const tmpPath = getTempFile('go-code-check.' + getUserNameHash());
 	const isTestFile = fileUri && fileUri.fsPath.endsWith('_test.go');
 	const buildFlags: string[] = isTestFile ? getTestFlags(goConfig, null) : (Array.isArray(goConfig['buildFlags']) ? [...goConfig['buildFlags']] : []);
 	const buildArgs: string[] = isTestFile ? ['test', '-c'] : ['build'];

--- a/src/goBuild.ts
+++ b/src/goBuild.ts
@@ -1,6 +1,6 @@
 import path = require('path');
 import vscode = require('vscode');
-import { getToolsEnvVars, runTool, ICheckResult, handleDiagnosticErrors, getWorkspaceFolderPath, getCurrentGoPath, getUserNameHash, getTempFile } from './util';
+import { getToolsEnvVars, runTool, ICheckResult, handleDiagnosticErrors, getWorkspaceFolderPath, getCurrentGoPath, TempFileProvider } from './util';
 import { outputChannel } from './goStatus';
 import os = require('os');
 import { getNonVendorPackages } from './goPackages';
@@ -70,7 +70,7 @@ export function goBuild(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigura
 	}
 
 	const buildEnv = Object.assign({}, getToolsEnvVars());
-	const tmpPath = getTempFile('go-code-check.' + getUserNameHash());
+	const tmpPath = TempFileProvider.getFilePath('go-code-check');
 	const isTestFile = fileUri && fileUri.fsPath.endsWith('_test.go');
 	const buildFlags: string[] = isTestFile ? getTestFlags(goConfig, null) : (Array.isArray(goConfig['buildFlags']) ? [...goConfig['buildFlags']] : []);
 	const buildArgs: string[] = isTestFile ? ['test', '-c'] : ['build'];

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -11,7 +11,7 @@ import os = require('os');
 import { getCoverage } from './goCover';
 import { outputChannel, diagnosticsStatusBarItem } from './goStatus';
 import { goTest } from './testUtils';
-import { ICheckResult, getBinPath, getTempFile } from './util';
+import { ICheckResult, getBinPath, TempFileProvider } from './util';
 import { goLint } from './goLint';
 import { goVet } from './goVet';
 import { goBuild } from './goBuild';
@@ -69,7 +69,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 
 		let args = [...buildFlags];
 		if (goConfig['coverOnSave']) {
-			tmpCoverPath = getTempFile('go-code-cover');
+			tmpCoverPath = TempFileProvider.getFilePath('go-code-cover');
 			args = ['-coverprofile=' + tmpCoverPath, ...buildFlags];
 		}
 

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -11,7 +11,7 @@ import os = require('os');
 import { getCoverage } from './goCover';
 import { outputChannel, diagnosticsStatusBarItem } from './goStatus';
 import { goTest } from './testUtils';
-import { ICheckResult, getBinPath, TempFileProvider } from './util';
+import { ICheckResult, getBinPath, getTempFilePath } from './util';
 import { goLint } from './goLint';
 import { goVet } from './goVet';
 import { goBuild } from './goBuild';
@@ -69,7 +69,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 
 		let args = [...buildFlags];
 		if (goConfig['coverOnSave']) {
-			tmpCoverPath = TempFileProvider.getFilePath('go-code-cover');
+			tmpCoverPath = getTempFilePath('go-code-cover');
 			args = ['-coverprofile=' + tmpCoverPath, ...buildFlags];
 		}
 

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -11,7 +11,7 @@ import os = require('os');
 import { getCoverage } from './goCover';
 import { outputChannel, diagnosticsStatusBarItem } from './goStatus';
 import { goTest } from './testUtils';
-import { ICheckResult, getBinPath } from './util';
+import { ICheckResult, getBinPath, getTempFile } from './util';
 import { goLint } from './goLint';
 import { goVet } from './goVet';
 import { goBuild } from './goBuild';
@@ -69,7 +69,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 
 		let args = [...buildFlags];
 		if (goConfig['coverOnSave']) {
-			tmpCoverPath = path.normalize(path.join(os.tmpdir(), 'go-code-cover'));
+			tmpCoverPath = getTempFile('go-code-cover');
 			args = ['-coverprofile=' + tmpCoverPath, ...buildFlags];
 		}
 

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -8,7 +8,7 @@ import vscode = require('vscode');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
-import { getTempFile } from './util';
+import { TempFileProvider } from './util';
 import { showTestOutput, goTest } from './testUtils';
 import rl = require('readline');
 
@@ -113,7 +113,7 @@ export function toggleCoverageCurrentPackage() {
 	let cwd = path.dirname(editor.document.uri.fsPath);
 
 	let buildFlags = goConfig['testFlags'] || goConfig['buildFlags'] || [];
-	let tmpCoverPath = getTempFile('go-code-cover');
+	let tmpCoverPath = TempFileProvider.getFilePath('go-code-cover');
 	let args = ['-coverprofile=' + tmpCoverPath, ...buildFlags];
 	return goTest({
 		goConfig: goConfig,

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -8,7 +8,7 @@ import vscode = require('vscode');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
-import { getTempFile } from './util'
+import { getTempFile } from './util';
 import { showTestOutput, goTest } from './testUtils';
 import rl = require('readline');
 
@@ -114,7 +114,6 @@ export function toggleCoverageCurrentPackage() {
 
 	let buildFlags = goConfig['testFlags'] || goConfig['buildFlags'] || [];
 	let tmpCoverPath = getTempFile('go-code-cover');
-	console.log(tmpCoverPath)
 	let args = ['-coverprofile=' + tmpCoverPath, ...buildFlags];
 	return goTest({
 		goConfig: goConfig,

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -8,6 +8,7 @@ import vscode = require('vscode');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
+import { getTempFile } from './util'
 import { showTestOutput, goTest } from './testUtils';
 import rl = require('readline');
 
@@ -112,7 +113,8 @@ export function toggleCoverageCurrentPackage() {
 	let cwd = path.dirname(editor.document.uri.fsPath);
 
 	let buildFlags = goConfig['testFlags'] || goConfig['buildFlags'] || [];
-	let tmpCoverPath = path.normalize(path.join(os.tmpdir(), 'go-code-cover'));
+	let tmpCoverPath = getTempFile('go-code-cover');
+	console.log(tmpCoverPath)
 	let args = ['-coverprofile=' + tmpCoverPath, ...buildFlags];
 	return goTest({
 		goConfig: goConfig,

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -8,7 +8,7 @@ import vscode = require('vscode');
 import path = require('path');
 import os = require('os');
 import fs = require('fs');
-import { TempFileProvider } from './util';
+import { getTempFilePath } from './util';
 import { showTestOutput, goTest } from './testUtils';
 import rl = require('readline');
 
@@ -113,7 +113,7 @@ export function toggleCoverageCurrentPackage() {
 	let cwd = path.dirname(editor.document.uri.fsPath);
 
 	let buildFlags = goConfig['testFlags'] || goConfig['buildFlags'] || [];
-	let tmpCoverPath = TempFileProvider.getFilePath('go-code-cover');
+	let tmpCoverPath = getTempFilePath('go-code-cover');
 	let args = ['-coverprofile=' + tmpCoverPath, ...buildFlags];
 	return goTest({
 		goConfig: goConfig,

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -50,7 +50,6 @@ export let errorDiagnosticCollection: vscode.DiagnosticCollection;
 export let warningDiagnosticCollection: vscode.DiagnosticCollection;
 
 export function activate(ctx: vscode.ExtensionContext): void {
-	TempFileProvider.registerStore(ctx.globalState);
 	let useLangServer = vscode.workspace.getConfiguration('go')['useLanguageServer'];
 
 	updateGoPathGoRootFromConfig().then(() => {
@@ -402,6 +401,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 }
 
 export function deactivate() {
+	TempFileProvider.cleanUp();
 	return Promise.all([disposeTelemetryReporter(), cancelRunningTests()]);
 }
 

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -29,7 +29,7 @@ import { showTestOutput, cancelRunningTests } from './testUtils';
 import * as goGenerateTests from './goGenerateTests';
 import { addImport, addImportToWorkspace } from './goImport';
 import { installAllTools, checkLanguageServer } from './goInstallTools';
-import { isGoPathSet, getBinPath, sendTelemetryEvent, getExtensionCommands, getGoVersion, getCurrentGoPath, getToolsGopath, handleDiagnosticErrors, disposeTelemetryReporter, getToolsEnvVars } from './util';
+import { isGoPathSet, getBinPath, sendTelemetryEvent, getExtensionCommands, getGoVersion, getCurrentGoPath, getToolsGopath, handleDiagnosticErrors, disposeTelemetryReporter, getToolsEnvVars, TempFileProvider } from './util';
 import { LanguageClient, RevealOutputChannelOn, FormattingOptions, ProvideDocumentFormattingEditsSignature, ProvideCompletionItemsSignature } from 'vscode-languageclient';
 import { clearCacheForTools, fixDriveCasingInWindows } from './goPath';
 import { addTags, removeTags } from './goModifytags';
@@ -50,7 +50,7 @@ export let errorDiagnosticCollection: vscode.DiagnosticCollection;
 export let warningDiagnosticCollection: vscode.DiagnosticCollection;
 
 export function activate(ctx: vscode.ExtensionContext): void {
-
+	TempFileProvider.registerStore(ctx.globalState);
 	let useLangServer = vscode.workspace.getConfiguration('go')['useLanguageServer'];
 
 	updateGoPathGoRootFromConfig().then(() => {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -29,7 +29,7 @@ import { showTestOutput, cancelRunningTests } from './testUtils';
 import * as goGenerateTests from './goGenerateTests';
 import { addImport, addImportToWorkspace } from './goImport';
 import { installAllTools, checkLanguageServer } from './goInstallTools';
-import { isGoPathSet, getBinPath, sendTelemetryEvent, getExtensionCommands, getGoVersion, getCurrentGoPath, getToolsGopath, handleDiagnosticErrors, disposeTelemetryReporter, getToolsEnvVars, TempFileProvider } from './util';
+import { isGoPathSet, getBinPath, sendTelemetryEvent, getExtensionCommands, getGoVersion, getCurrentGoPath, getToolsGopath, handleDiagnosticErrors, disposeTelemetryReporter, getToolsEnvVars, cleanupTempDir } from './util';
 import { LanguageClient, RevealOutputChannelOn, FormattingOptions, ProvideDocumentFormattingEditsSignature, ProvideCompletionItemsSignature } from 'vscode-languageclient';
 import { clearCacheForTools, fixDriveCasingInWindows } from './goPath';
 import { addTags, removeTags } from './goModifytags';
@@ -401,8 +401,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 }
 
 export function deactivate() {
-	TempFileProvider.cleanUp();
-	return Promise.all([disposeTelemetryReporter(), cancelRunningTests()]);
+	return Promise.all([disposeTelemetryReporter(), cancelRunningTests(), Promise.resolve(cleanupTempDir())]);
 }
 
 function runBuilds(document: vscode.TextDocument, goConfig: vscode.WorkspaceConfiguration) {

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -8,7 +8,7 @@
 import path = require('path');
 import vscode = require('vscode');
 import os = require('os');
-import { TempFileProvider } from './util';
+import { getTempFilePath } from './util';
 import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions, extractInstanceTestName, findAllTestSuiteRuns } from './testUtils';
 import { getCoverage } from './goCover';
 
@@ -213,7 +213,7 @@ function makeCoverData(goConfig: vscode.WorkspaceConfiguration, confFlag: string
 	let tmpCoverPath = '';
 	let testFlags = getTestFlags(goConfig, args) || [];
 	if (goConfig[confFlag] === true) {
-		tmpCoverPath = TempFileProvider.getFilePath('go-code-cover');
+		tmpCoverPath = getTempFilePath('go-code-cover');
 		testFlags.push('-coverprofile=' + tmpCoverPath);
 	}
 

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -8,6 +8,7 @@
 import path = require('path');
 import vscode = require('vscode');
 import os = require('os');
+import { getTempFile } from './util'
 import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions, extractInstanceTestName, findAllTestSuiteRuns } from './testUtils';
 import { getCoverage } from './goCover';
 
@@ -212,7 +213,7 @@ function makeCoverData(goConfig: vscode.WorkspaceConfiguration, confFlag: string
 	let tmpCoverPath = '';
 	let testFlags = getTestFlags(goConfig, args) || [];
 	if (goConfig[confFlag] === true) {
-		tmpCoverPath = path.normalize(path.join(os.tmpdir(), 'go-code-cover'));
+		tmpCoverPath = getTempFile('go-code-cover');
 		testFlags.push('-coverprofile=' + tmpCoverPath);
 	}
 

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -8,7 +8,7 @@
 import path = require('path');
 import vscode = require('vscode');
 import os = require('os');
-import { getTempFile } from './util'
+import { getTempFile } from './util';
 import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions, extractInstanceTestName, findAllTestSuiteRuns } from './testUtils';
 import { getCoverage } from './goCover';
 

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -8,7 +8,7 @@
 import path = require('path');
 import vscode = require('vscode');
 import os = require('os');
-import { getTempFile } from './util';
+import { TempFileProvider } from './util';
 import { goTest, TestConfig, getTestFlags, getTestFunctions, getBenchmarkFunctions, extractInstanceTestName, findAllTestSuiteRuns } from './testUtils';
 import { getCoverage } from './goCover';
 
@@ -213,7 +213,7 @@ function makeCoverData(goConfig: vscode.WorkspaceConfiguration, confFlag: string
 	let tmpCoverPath = '';
 	let testFlags = getTestFlags(goConfig, args) || [];
 	if (goConfig[confFlag] === true) {
-		tmpCoverPath = getTempFile('go-code-cover');
+		tmpCoverPath = TempFileProvider.getFilePath('go-code-cover');
 		testFlags.push('-coverprofile=' + tmpCoverPath);
 	}
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -844,3 +844,19 @@ export function makeMemoizedByteOffsetConverter(buffer: Buffer): (byteOffset: nu
 	};
 }
 
+export const getTempDir = (() => {
+	let dir: string | undefined;
+	return (): string => {
+		if (!dir) {
+			dir = fs.mkdtempSync(os.tmpdir() + '/vscode-go');
+			if (!fs.existsSync(dir)) {
+				fs.mkdirSync(dir);
+			}
+		}
+		return dir;
+	}
+})();
+
+export function getTempFile(name: string): string {
+	return path.normalize(path.join(getTempDir(), name))
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -858,35 +858,28 @@ function rmdirRecursive(dir) {
 	}
 }
 
-export class TempFileProvider {
-	private static dir: string | undefined;
+let tmpDir: string;
 
-	/**
-	 * returns path to temp file with name
-	 */
-	static getFilePath(name: string): string {
-		let { dir } = TempFileProvider;
-
-		if (!TempFileProvider.dir) {
-			dir = fs.mkdtempSync(os.tmpdir() + path.sep + 'vscode-go');
-			TempFileProvider.dir = dir;
-		}
-
-		if (!fs.existsSync(dir)) {
-			fs.mkdirSync(dir);
-		}
-
-		return path.normalize(path.join(dir, name));
+/**
+ * Returns file path for given name in temp dir
+ * @param name Name of the file
+ */
+export function getTempFilePath(name: string): string {
+	if (!tmpDir) {
+		tmpDir = fs.mkdtempSync(os.tmpdir() + path.sep + 'vscode-go');
 	}
 
-	/**
-	 * deletes temp directory
-	 */
-	static cleanUp() {
-		const { dir } = TempFileProvider;
-		if (dir) {
-			rmdirRecursive(dir);
-			TempFileProvider.dir = undefined;
-		}
+	if (!fs.existsSync(tmpDir)) {
+		fs.mkdirSync(tmpDir);
 	}
+
+	return path.normalize(path.join(tmpDir, name));
 }
+
+export function cleanupTempDir() {
+	if (!tmpDir) {
+		rmdirRecursive(tmpDir);
+	}
+	tmpDir = undefined;
+}
+

--- a/src/util.ts
+++ b/src/util.ts
@@ -859,15 +859,16 @@ export class TempFileProvider {
 	 * TempFileProvider.registerStore must be called before this
 	 */
 	static getFilePath(name: string): string {
-		let tempDir = TempFileProvider.globalState.get<string>('tempDir');
-
-		if (!tempDir) {
-			tempDir = fs.mkdtempSync(os.tmpdir() + path.sep + 'vscode-go');
-			TempFileProvider.globalState.update('tempDir', tempDir);
+		let tempDir;
+		if (TempFileProvider.globalState) {
+			tempDir = TempFileProvider.globalState.get<string>('tempDir');
 		}
 
-		if (!fs.existsSync(tempDir)) {
-			fs.mkdirSync(tempDir);
+		if (!tempDir || !fs.existsSync(tempDir)) {
+			tempDir = fs.mkdtempSync(os.tmpdir() + path.sep + 'vscode-go');
+			if (TempFileProvider.globalState) {
+				TempFileProvider.globalState.update('tempDir', tempDir);
+			}
 		}
 
 		return path.normalize(path.join(tempDir, name));

--- a/src/util.ts
+++ b/src/util.ts
@@ -854,9 +854,9 @@ export const getTempDir = (() => {
 			}
 		}
 		return dir;
-	}
+	};
 })();
 
 export function getTempFile(name: string): string {
-	return path.normalize(path.join(getTempDir(), name))
+	return path.normalize(path.join(getTempDir(), name));
 }


### PR DESCRIPTION
Closes #1905.

This closely mirrors the [official TypeScript extension's implementation](https://github.com/Microsoft/vscode/blob/ad68ff316c472aea4acfa31b3a5bab3b101d968b/extensions/typescript-language-features/src/utils/electron.ts#L17), which does not persist the directory path for reuse between activations.

@ramya-rao-a, making the directory path persistent is pretty hacky and not the convention for any of the official extensions I've seen, so I've left it out (let me know your thoughts on this).