### PR TITLE
Fixed "IntelliSense should not appear within multiline strings"

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -53,7 +53,7 @@ class ExtendedCompletionItem extends vscode.CompletionItem {
 	fileName: string;
 }
 
-const lineCommentFirstWordRegex = /^\s*\/\/\s+[\S]*$/;
+export const lineCommentFirstWordRegex = /^\s*\/\/\s+[\S]*$/;
 const exportedMemberRegex = /(const|func|type|var)(\s+\(.*\))?\s+([A-Z]\w*)/;
 const gocodeNoSupportForgbMsgKey = 'dontshowNoSupportForgb';
 


### PR DESCRIPTION
Closes #569 
Counts backticks that appear before the cursor location. If the number of backticks is odd, we are in a multiline/raw string