### PR TITLE
Add 'file' option for lintOnSave setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -546,12 +546,13 @@
         "go.lintOnSave": {
           "type": "string",
           "enum": [
+            "file",
             "package",
             "workspace",
             "off"
           ],
           "default": "package",
-          "description": "Lints code on file save using the configured Lint tool. Options are 'workspace', 'package' or 'off'.",
+          "description": "Lints code on file save using the configured Lint tool. Options are 'file', 'package', 'workspace' or 'off'.",
           "scope": "resource"
         },
         "go.lintTool": {

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -103,7 +103,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 	}
 
 	if (!!goConfig['lintOnSave'] && goConfig['lintOnSave'] !== 'off') {
-		runningToolsPromises.push(goLint(fileUri, goConfig, goConfig['lintOnSave'] === 'workspace'));
+		runningToolsPromises.push(goLint(fileUri, goConfig));
 	}
 
 	if (!!goConfig['vetOnSave'] && goConfig['vetOnSave'] !== 'off') {

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -103,7 +103,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 	}
 
 	if (!!goConfig['lintOnSave'] && goConfig['lintOnSave'] !== 'off') {
-		runningToolsPromises.push(goLint(fileUri, goConfig, (goConfig['lintOnSave'] === 'workspace'), (goConfig['lintOnSave'] === 'file')));
+		runningToolsPromises.push(goLint(fileUri, goConfig, (goConfig['lintOnSave'])));
 	}
 
 	if (!!goConfig['vetOnSave'] && goConfig['vetOnSave'] !== 'off') {

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -103,7 +103,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 	}
 
 	if (!!goConfig['lintOnSave'] && goConfig['lintOnSave'] !== 'off') {
-		runningToolsPromises.push(goLint(fileUri, goConfig));
+		runningToolsPromises.push(goLint(fileUri, goConfig, (goConfig['lintOnSave'] === 'workspace'), (goConfig['lintOnSave'] === 'file')));
 	}
 
 	if (!!goConfig['vetOnSave'] && goConfig['vetOnSave'] !== 'off') {

--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -43,7 +43,7 @@ export function lintCode(lintWorkspace?: boolean, lintFile?: boolean) {
  * @param lintWorkspace If true, runs linter in the entire workspace.
  * @param lintFile If true, runs linter on a single file.
  */
-export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfiguration, lintWorkspace?:boolean, lintFile?: boolean): Promise<ICheckResult[]> {
+export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfiguration, lintWorkspace?: boolean, lintFile?: boolean): Promise<ICheckResult[]> {
 	epoch++;
 	let closureEpoch = epoch;
 	if (tokenSource) {
@@ -106,11 +106,11 @@ export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurat
 	if (lintWorkspace && currentWorkspace) {
 		args.push('./...');
 	}
-	
+
 	if (lintFile) {
-		args.push(fileUri)
+		args.push(fileUri);
 	}
-	
+
 	running = true;
 	const lintPromise = runTool(
 		args,

--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -107,6 +107,10 @@ export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurat
 		args.push('./...');
 	}
 	
+	if (lintFile) {
+		args.push(fileUri)
+	}
+	
 	running = true;
 	const lintPromise = runTool(
 		args,

--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -24,7 +24,7 @@ export function lintCode(lintWorkspace?: boolean) {
 	diagnosticsStatusBarItem.show();
 	diagnosticsStatusBarItem.text = 'Linting...';
 
-	goLint(documentUri, goConfig, lintWorkspace)
+	goLint(documentUri, goConfig)
 		.then(warnings => {
 			handleDiagnosticErrors(editor ? editor.document : null, warnings, vscode.DiagnosticSeverity.Warning);
 			diagnosticsStatusBarItem.hide();
@@ -111,6 +111,8 @@ export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurat
 		args.push('./...');
 	}
 
+	console.log(cwd);
+	
 	running = true;
 	const lintPromise = runTool(
 		args,

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -387,9 +387,11 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.playground', playgroundCommand));
 
-	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.package', lintCode));
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.package', () => lintCode(false, false)));
 
-	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.workspace', () => lintCode(true)));
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.workspace', () => lintCode(true, false)));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.file', () => lintCode(false, true)));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.vet.package', vetCode));
 

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -387,11 +387,11 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.playground', playgroundCommand));
 
-	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.package', () => lintCode(false, false)));
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.package', () => lintCode('package')));
 
-	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.workspace', () => lintCode(true, false)));
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.workspace', () => lintCode('workspace')));
 
-	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.file', () => lintCode(false, true)));
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.file', () => lintCode('file')));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.vet.package', vetCode));
 


### PR DESCRIPTION
### What was added

- Adds the feature described on Issue [1931](https://github.com/Microsoft/vscode-go/issues/1931) - enabling lint on save on an individual file basis

### What was tested
I sideloaded the extension then tested the following linters in `"go.lintOnSave"` `file` mode by adding some unused variables and uncommented functions in a Go project.

- `golint`
- `gometalinter`
- `megacheck`
- `golangci-lint`
- `revive`

Please let me know if there's anything I've overlooked or if anything be improved. Thanks!