### PR TITLE
fixed 1743, go.gopath and go.toolsGopath now expand ${env:XXX}

### DIFF
--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -1,6 +1,6 @@
 import path = require('path');
 import vscode = require('vscode');
-import { getToolsEnvVars, resolvePath, runTool, ICheckResult, handleDiagnosticErrors, getWorkspaceFolderPath } from './util';
+import { getToolsEnvVars, resolvePath, runTool, ICheckResult, handleDiagnosticErrors, getWorkspaceFolderPath, getToolsGopath } from './util';
 import { outputChannel } from './goStatus';
 import { diagnosticsStatusBarItem } from './goStatus';
 /**
@@ -87,7 +87,7 @@ export function goLint(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurat
 		if (goConfig['toolsGopath']) {
 			// gometalinter will expect its linters to be in the GOPATH
 			// So add the toolsGopath to GOPATH
-			lintEnv['GOPATH'] += path.delimiter + goConfig['toolsGopath'];
+			lintEnv['GOPATH'] += path.delimiter + getToolsGopath();
 		}
 	}
 	if (lintTool === 'golangci-lint') {

--- a/src/util.ts
+++ b/src/util.ts
@@ -348,7 +348,7 @@ export function getToolsGopath(useCache: boolean = true): string {
 
 function resolveToolsGopath(): string {
 
-	let toolsGopathForWorkspace = vscode.workspace.getConfiguration('go')['toolsGopath'] || '';
+	let toolsGopathForWorkspace = substituteEnv(vscode.workspace.getConfiguration('go')['toolsGopath'] || '');
 
 	// In case of single root, use resolvePath to resolve ~ and ${workspaceRoot}
 	if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length <= 1) {
@@ -371,6 +371,12 @@ function resolveToolsGopath(): string {
 			return toolsGopath;
 		}
 	}
+}
+
+export function substituteEnv(input: string): string {
+	return input.replace(/\${env:([^}]+)}/g, function (match, capture) {
+		return process.env[capture.trim()] || '';
+	});
 }
 
 export function getBinPath(tool: string): string {
@@ -443,7 +449,7 @@ export function getCurrentGoPath(workspaceUri?: vscode.Uri): string {
 		}
 	}
 
-	const configGopath = config['gopath'] ? resolvePath(config['gopath'], currentRoot) : '';
+	const configGopath = config["gopath"] ? resolvePath(substituteEnv(config["gopath"]), currentRoot) : ""
 	return inferredGopath ? inferredGopath : (configGopath || process.env['GOPATH']);
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -449,7 +449,7 @@ export function getCurrentGoPath(workspaceUri?: vscode.Uri): string {
 		}
 	}
 
-	const configGopath = config["gopath"] ? resolvePath(substituteEnv(config["gopath"]), currentRoot) : ""
+	const configGopath = config['gopath'] ? resolvePath(substituteEnv(config['gopath']), currentRoot) : '';
 	return inferredGopath ? inferredGopath : (configGopath || process.env['GOPATH']);
 }
 


### PR DESCRIPTION
I replicated the changes of @sphawk and I also deleted the flag m

Following the conversation https://github.com/Microsoft/vscode-go/pull/1743