### PR TITLE
delete unneeded godoc

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -55,7 +55,6 @@ const importantTools = [
 	'gorename',
 	'godef',
 	'godef-gomod',
-	'godoc',
 	'gogetdoc',
 	'goreturns',
 	'goimports',


### PR DESCRIPTION
since last commit, when installing, output shows:

```
Installing 13 tools at /home/ying/Documents/sources/toolsForGolang/bin
  gocode
  gopkgs
  go-outline
  go-symbols
  guru
  gorename
  dlv
  gocode-gomod
  godef
  godef-gomod
  godoc
  goreturns
  golint

Installing github.com/mdempsky/gocode SUCCEEDED
Installing github.com/uudashr/gopkgs/cmd/gopkgs SUCCEEDED
Installing github.com/ramya-rao-a/go-outline SUCCEEDED
Installing github.com/acroca/go-symbols SUCCEEDED
Installing golang.org/x/tools/cmd/guru SUCCEEDED
Installing golang.org/x/tools/cmd/gorename SUCCEEDED
Installing github.com/derekparker/delve/cmd/dlv SUCCEEDED
Installing github.com/stamblerre/gocode SUCCEEDED
Installing github.com/rogpeppe/godef SUCCEEDED
Installing github.com/ianthehat/godef SUCCEEDED
Installing undefined FAILED
Installing github.com/sqs/goreturns SUCCEEDED
Installing golang.org/x/lint/golint SUCCEEDED

1 tools failed to install.

godoc:
Error: Command failed: /snap/go/current/bin/go get -u -v 
package undefined: unrecognized import path "undefined" (import path does not begin with hostname)
package undefined: unrecognized import path "undefined" (import path does not begin with hostname)
```