### PR TITLE
fix: Fix debug debugger tasks and guide

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"configurations": [
 		{
 			"name": "Launch Extension",
@@ -7,28 +7,21 @@
 			"request": "launch",
 			// path to VSCode executable
 			"runtimeExecutable": "${execPath}",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
-			],
+			"args": ["--extensionDevelopmentPath=${workspaceFolder}"],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
-			],
+			"outFiles": ["${workspaceFolder}/out/**/*.js"],
 			"preLaunchTask": "npm"
 		},
 		{
 			"name": "Launch as server",
-			"type": "node2",
+			"type": "node",
+			"protocol": "inspector",
 			"request": "launch",
 			"program": "${workspaceFolder}/out/src/debugAdapter/goDebug.js",
-			"args": [
-				"--server=4712"
-			],
+			"args": ["--server=4711"],
 			"sourceMaps": true,
-			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
-			]
+			"outFiles": ["${workspaceFolder}/out/**/*.js"]
 		},
 		{
 			"name": "Launch Tests",
@@ -42,9 +35,7 @@
 			],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
-			],
+			"outFiles": ["${workspaceFolder}/out/**/*.js"],
 			"preLaunchTask": "npm"
 		},
 		{
@@ -66,10 +57,7 @@
 	"compounds": [
 		{
 			"name": "Extension + Debug server",
-			"configurations": [
-				"Launch Extension",
-				"Launch as server"
-			]
+			"configurations": ["Launch Extension", "Launch as server"]
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,16 +9,18 @@
 // A task runner that calls the Typescript compiler (tsc) and
 // compiles the extension.
 {
-	"version": "0.1.0",
+	"version": "2.0.0",
 
 	// we want to run npm
 	"command": "npm",
 
 	// the command is a shell script
-	"isShellCommand": true,
+	"type": "shell",
 
 	// show the output window only if unrecognized errors occur.
-	"showOutput": "silent",
+	"presentation": {
+		"reveal": "silent"
+	},
 
 	// we run the custom script "compile" as defined in package.json
 	"args": ["run", "compile"],

--- a/src/debugAdapter/.vscode/launch.json
+++ b/src/debugAdapter/.vscode/launch.json
@@ -5,11 +5,11 @@
 			"name": "debug-debugger",
 			"type": "node",
 			"request": "launch",
-			"program": "${workspaceRoot}/../../out/src/debugAdapter/goDebug.js",
+			"program": "${workspaceFolder}/../../out/src/debugAdapter/goDebug.js",
 			"stopOnEntry": false,
 			"args": ["--server=4711"],
 			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/../../out/src/debugAdapter"]
+			"outFiles": ["${workspaceFolder}/../../out/src/debugAdapter"]
 		}
 	]
 }

--- a/src/debugAdapter/.vscode/launch.json
+++ b/src/debugAdapter/.vscode/launch.json
@@ -7,9 +7,9 @@
 			"request": "launch",
 			"program": "${workspaceRoot}/../../out/src/debugAdapter/goDebug.js",
 			"stopOnEntry": false,
-			"args": [ "--server=4711" ],
+			"args": ["--server=4711"],
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/../../out/src/debugAdapter"
+			"outFiles": ["${workspaceRoot}/../../out/src/debugAdapter"]
 		}
 	]
 }

--- a/src/debugAdapter/Readme.md
+++ b/src/debugAdapter/Readme.md
@@ -6,13 +6,15 @@ This code runs in a seperate Node process spawned by Code when launch the 'go' t
 
 The ideal setup involves three instances of Code:
 
-1. Clone this [repo](https://github.com/Microsoft/vscode-go) and then run `npm install` 
+1. Clone this [repo](https://github.com/Microsoft/vscode-go) and then run `npm install`
+
 ```
 git clone https://github.com/Microsoft/vscode-go
 cd vscode-go
 npm install
 ```
-2. Open the `vscode-go` folder in one instance.  Choose the `Launch Extension` debug target and hit F5 to launch a second instance.
-3. In the second instance, open the Go application you'd like to test against.  In that instance, create a new Go debug target pointing at the program you want to debug, and add `"debugServer": 4711` in the root of the configuration.
-4. Open another instance of Code on the `vscode-go/src/debugAdapter` folder.  In that instance hit F5 to launch the debug adapter in server mode under the debugger.
-5. Go back to the second instance and hit F5 to debug your Go code.  Debuggers from the other two Code windows are attached to the Go debug adapter and the Go language integation respectively, so you can set breakpoints, step through code and inspect state as needed. 
+
+2. Open the `vscode-go` folder in one instance. Choose the `Launch Extension` debug target and hit F5 to launch a second instance.
+3. In the second instance, open the Go application you'd like to test against. In that instance, create a new Go debug target pointing at the program you want to debug, and add `"debugServer": 4711` in the root of the configuration.
+4. Open another instance of Code on the `vscode-go/src/debugAdapter` folder. In that instance hit F5 to launch the debug adapter in server mode under the debugger.
+5. Go back to the second instance and hit F5 to debug your Go code. Debuggers from the other two Code windows are attached to the Go debug adapter and the Go language integation respectively, so you can set breakpoints, step through code and inspect state as needed.


### PR DESCRIPTION
I was trying to tackle #1529 and while trying to follow the guide from https://github.com/Microsoft/vscode-go/tree/master/src/debugAdapter I faced a few errors and saw an old task that had deprecated options. This pr fixes those issues and updates the task's option according to the recent spec.