### PR TITLE
Remove env mask on GOOS and GOARCH

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -187,7 +187,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				return reject();
 			}
 
-			let env = Object.assign({}, getToolsEnvVars());
+			let env = getToolsEnvVars();
 			let stdout = '';
 			let stderr = '';
 

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -187,10 +187,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				return reject();
 			}
 
-			// Unset GOOS and GOARCH for the `gocode` process to ensure that GOHOSTOS and GOHOSTARCH
-			// are used as the target operating system and architecture. `gocode` is unable to provide
-			// autocompletion when the Go environment is configured for cross compilation.
-			let env = Object.assign({}, getToolsEnvVars(), { GOOS: '', GOARCH: '' });
+			let env = Object.assign({}, getToolsEnvVars());
 			let stdout = '';
 			let stderr = '';
 


### PR DESCRIPTION
Removed to allow suggestions on platform-specific syscall like `syscall/js`

<s>WORK IN PROGRESS! Still undecided on how to resolve packages without precompiled objects.</s>