### PR TITLE
Fix single quotes uses for JSON examples.

### DIFF
--- a/package.json
+++ b/package.json
@@ -523,7 +523,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Flags to `go build`/`go test` used during build-on-save or running tests. (e.g. ['-ldflags=\"-s\"'])",
+          "description": "Flags to `go build`/`go test` used during build-on-save or running tests. (e.g. [\"-ldflags='-s'\"])",
           "scope": "resource"
         },
         "go.buildTags": {
@@ -598,7 +598,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Flags to pass to `go tool vet` (e.g. ['-all', '-shadow'])",
+          "description": "Flags to pass to `go tool vet` (e.g. [\"-all\", \"-shadow\"])",
           "scope": "resource"
         },
         "go.formatTool": {
@@ -619,7 +619,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Flags to pass to format tool (e.g. ['-s'])",
+          "description": "Flags to pass to format tool (e.g. [\"-s\"])",
           "scope": "resource"
         },
         "go.inferGopath": {


### PR DESCRIPTION
Hi,
There were some single quotes in use for the JSON config file examples.
As JSON doesn't allow single quotes the UI was returning the error "[jsonc] Value expected" if they were copy-pasted. This was a little bit confusing.
Thanks