### PR TITLE
Diposing decorators before applying new ones for code coverage.

### DIFF
--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -234,6 +234,7 @@ export function applyCodeCoverage(editor: vscode.TextEditor) {
 
 	const cfg = vscode.workspace.getConfiguration('go', editor.document.uri);
 	const coverageOptions = cfg['coverageOptions'];
+	disposeDecorators();
 	setDecorators();
 
 	for (let filename in coverageFiles) {


### PR DESCRIPTION
Following the suggestions described on issue https://github.com/Microsoft/vscode-go/issues/2045

Similar to the function [updateCodeCoverageDecorators](https://github.com/Microsoft/vscode-go/blob/master/src/goCover.ts#L73) the `applyCodeCoverage` function now disposes of any existing decorators before applying new ones.