### PR TITLE
Duplicate Lint command into 'Slow Lint' (e. g. for manual gometalinter)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -524,7 +524,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -634,14 +634,14 @@
       "dev": true
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
+        "randomatic": "^3.0.0",
         "repeat-element": "^1.1.2",
         "repeat-string": "^1.5.2"
       }
@@ -1459,6 +1459,12 @@
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
+    },
     "meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -1884,43 +1890,27 @@
       }
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -2329,9 +2319,9 @@
       }
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
       "dev": true
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -224,6 +224,16 @@
         "description": "Run linter in the current workspace."
       },
       {
+        "command": "go.slowlint.package",
+        "title": "Go: Slow Lint Current Package",
+        "description": "Run slow linter in the package of the current file."
+      },
+      {
+        "command": "go.slowlint.workspace",
+        "title": "Go: Slow Lint Workspace",
+        "description": "Run slow linter in the current workspace."
+      },
+      {
         "command": "go.vet.package",
         "title": "Go: Vet Current Package",
         "description": "Run go vet in the package of the current file."
@@ -579,6 +589,28 @@
           },
           "default": [],
           "description": "Flags to pass to Lint tool (e.g. [\"-min_confidence=.8\"])",
+          "scope": "resource"
+        },
+        "go.slowLintTool": {
+          "type": "string",
+          "default": "gometalinter",
+          "description": "Specifies Slow Lint tool name.",
+          "scope": "resource",
+          "enum": [
+            "golint",
+            "gometalinter",
+            "megacheck",
+            "golangci-lint",
+            "revive"
+          ]
+        },
+        "go.slowLintFlags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Flags to pass to Slow Lint tool (e.g. [\"--disable=megacheck\"])",
           "scope": "resource"
         },
         "go.vetOnSave": {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -108,19 +108,19 @@ function getTools(goVersion: SemVersion): string[] {
 		tools.push('golint');
 	}
 
-	if (goConfig['lintTool'] === 'gometalinter') {
+	if (goConfig['lintTool'] === 'gometalinter' || goConfig['slowLintTool'] === 'gometalinter') {
 		tools.push('gometalinter');
 	}
 
-	if (goConfig['lintTool'] === 'megacheck') {
+	if (goConfig['lintTool'] === 'megacheck' || goConfig['slowLintTool'] === 'megacheck') {
 		tools.push('megacheck');
 	}
 
-	if (goConfig['lintTool'] === 'golangci-lint') {
+	if (goConfig['lintTool'] === 'golangci-lint' || goConfig['slowLintTool'] === 'golangci-lint') {
 		tools.push('golangci-lint');
 	}
 
-	if (goConfig['lintTool'] === 'revive') {
+	if (goConfig['lintTool'] === 'revive' || goConfig['slowLintTool'] === 'revive') {
 		tools.push('revive');
 	}
 

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -40,7 +40,7 @@ import { browsePackages } from './goBrowsePackage';
 import { goGetPackage } from './goGetPackage';
 import { GoDebugConfigurationProvider } from './goDebugConfiguration';
 import { playgroundCommand } from './goPlayground';
-import { lintCode } from './goLint';
+import { lintCode, lintSlow } from './goLint';
 import { vetCode } from './goVet';
 import { buildCode } from './goBuild';
 import { installCurrentPackage } from './goInstall';
@@ -343,6 +343,9 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		if (e.affectsConfiguration('go.lintTool')) {
 			checkToolExists(updatedGoConfig['lintTool']);
 		}
+		if (e.affectsConfiguration('go.slowLintTool')) {
+			checkToolExists(updatedGoConfig['slowLintTool']);
+		}
 		if (e.affectsConfiguration('go.docsTool')) {
 			checkToolExists(updatedGoConfig['docsTool']);
 		}
@@ -379,20 +382,20 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.show.commands', () => {
 		let extCommands = getExtensionCommands();
 		extCommands.push({
-			command : 'editor.action.goToDeclaration',
-			title : 'Go to Definition'
+			command: 'editor.action.goToDeclaration',
+			title: 'Go to Definition'
 		});
 		extCommands.push({
-			command : 'editor.action.goToImplementation',
-			title : 'Go to Implementation'
+			command: 'editor.action.goToImplementation',
+			title: 'Go to Implementation'
 		});
 		extCommands.push({
-			command : 'workbench.action.gotoSymbol',
-			title : 'Go to Symbol in File...'
+			command: 'workbench.action.gotoSymbol',
+			title: 'Go to Symbol in File...'
 		});
 		extCommands.push({
-			command : 'workbench.action.showAllSymbols',
-			title : 'Go to Symbol in Workspace...'
+			command: 'workbench.action.showAllSymbols',
+			title: 'Go to Symbol in Workspace...'
 		});
 		vscode.window.showQuickPick(extCommands.map(x => x.title)).then(cmd => {
 			let selectedCmd = extCommands.find(x => x.title === cmd);
@@ -409,6 +412,10 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.package', () => lintCode('package')));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.workspace', () => lintCode('workspace')));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.slowlint.package', () => lintSlow('package')));
+
+	ctx.subscriptions.push(vscode.commands.registerCommand('go.slowlint.workspace', () => lintSlow('workspace')));
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.lint.file', () => lintCode('file')));
 
@@ -470,6 +477,7 @@ function sendTelemetryEventForConfig(goConfig: vscode.WorkspaceConfiguration) {
 		  "lintOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
 		  "lintFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
 		  "lintTool": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+		  "slowLintTool": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
 		  "vetOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
 		  "vetFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
 		  "testOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
@@ -508,6 +516,7 @@ function sendTelemetryEventForConfig(goConfig: vscode.WorkspaceConfiguration) {
 		lintOnSave: goConfig['lintOnSave'] + '',
 		lintFlags: goConfig['lintFlags'],
 		lintTool: goConfig['lintTool'],
+		slowLintTool: goConfig['slowLintTool'],
 		generateTestsFlags: goConfig['generateTestsFlags'],
 		vetOnSave: goConfig['vetOnSave'] + '',
 		vetFlags: goConfig['vetFlags'],


### PR DESCRIPTION
As discussed in issues like #2039, #1451: Some users have the need to occasionally and manually run a different linter than the `lintOnSave` linter. This patch essentially doubles the Lint command with a separate config setting `slowLintTool` that can be used as a manual override, using the same problemMatcher and thereby displaying results from the slow lint tool in the Problems pane as well.