### PR TITLE
Add support for debugging single files

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -262,7 +262,7 @@ function fileContainsEntryPoint(filePath: string) {
 		);
 	}
 	catch (e) {
-		//If go-outline failed, we are probably not in a position to debug this file.
+		//If go-outline failed or it's not installed, we can't assume this file is executable.
 		return false;
 	}
 }


### PR DESCRIPTION
Address #1229 

In cases where you might have multiple files defining a `main` function in the same directory, this change allows the debugger to detect if you are trying to debug just a single file directly, rather than having to debug an entire directory (which fails because there are multiple `main` functions).

Should work in all situations that the `launch.json` config for the workspace has the `program` property set to `${file}`.

I'm open to any and all suggestions on how this could be improved if required :)