### PR TITLE
Add item documentation to completions

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -90,7 +90,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 		const env = getToolsEnvVars();
 		const cwd = path.dirname(item.fileName);
 
-		return new Promise<vscode.CompletionItem>((resolve, reject) => {
+		return new Promise<vscode.CompletionItem>(resolve => {
 			const args = ['doc', '-c', '-cmd', '-u'];
 			if (item.package) {
 				args.push(item.package, item.label);
@@ -99,9 +99,10 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				args.push(item.label);
 			}
 
-			cp.execFile(goRuntimePath, args, { cwd, env }, (err, stdout, stderr) => {
+			cp.execFile(goRuntimePath, args, { cwd, env }, (err, stdout) => {
 				if (err) {
-					reject(err);
+					console.log(err);
+					return resolve(item);
 				}
 
 				let doc = '';

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -41,13 +41,13 @@ function vscodeKindFromGoCodeClass(kind: string, type: string): vscode.Completio
 
 interface GoCodeSuggestion {
 	class: string;
-	package: string;
+	package?: string;
 	name: string;
 	type: string;
 }
 
 class ExtendedCompletionItem extends vscode.CompletionItem {
-	package: string;
+	package?: string;
 	fileName: string;
 }
 
@@ -84,6 +84,11 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 	public resolveCompletionItem(item: vscode.CompletionItem, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CompletionItem> {
 		const goRuntimePath = getBinPath('go');
 		if (!goRuntimePath || !(item instanceof ExtendedCompletionItem)) {
+			return;
+		}
+
+		if (typeof item.package === 'undefined') {
+			promptForUpdatingTool('gocode');
 			return;
 		}
 


### PR DESCRIPTION
Using `go doc` instead of `godoc` due to https://github.com/golang/go/issues/25443 (plus `godoc` doesn't show doc for unexported identifiers nor for anything in a main package)

`go doc` doesn't seem to support giving the code of an unsaved file via stdin like `gocode`, so it won't display documentation for unsaved changes.

Fixes #194 

cc @ramya-rao-a 