### PR TITLE
Diposing decorators before applying new ones for code coverage.

### DIFF
--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -89,11 +89,11 @@ export function updateCodeCoverageDecorators(coverageDecoratorConfig: any) {
 			decoratorConfig[k] = coverageDecoratorConfig[k];
 		}
 	}
-	disposeDecorators();
 	setDecorators();
 }
 
 function setDecorators() {
+	disposeDecorators();
 	decorators = {
 		type: decoratorConfig.type,
 		coveredGutterDecorator: vscode.window.createTextEditorDecorationType({ gutterIconPath: gutterSvgs[decoratorConfig.coveredGutterStyle] }),
@@ -234,7 +234,6 @@ export function applyCodeCoverage(editor: vscode.TextEditor) {
 
 	const cfg = vscode.workspace.getConfiguration('go', editor.document.uri);
 	const coverageOptions = cfg['coverageOptions'];
-	disposeDecorators();
 	setDecorators();
 
 	for (let filename in coverageFiles) {


### PR DESCRIPTION
I've updated Microsoft/vscode-go#2047 with the changes requested

> Following the suggestions described on issue #2045
> 
> Similar to the function [updateCodeCoverageDecorators](https://github.com/Microsoft/vscode-go/blob/master/src/goCover.ts#L73) the `applyCodeCoverage` function now disposes of any existing decorators before applying new ones.

