### PR TITLE
Improve debugging of pointer values

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -935,8 +935,8 @@ class GoDebugSession extends DebugSession {
 					});
 				}
 				return {
-					variablesReference: v.children[0].children.length > 0 ? this._variableHandles.create(v.children[0]) : 0
 					result: `<${v.type}>(0x${v.children[0].addr.toString(16)})`,
+					variablesReference: v.children.length > 0 ? this._variableHandles.create(v) : 0
 				};
 			}
 		} else if (v.kind === GoReflectKind.Slice) {

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -935,8 +935,8 @@ class GoDebugSession extends DebugSession {
 					});
 				}
 				return {
-					result: '<' + v.type + '>',
 					variablesReference: v.children[0].children.length > 0 ? this._variableHandles.create(v.children[0]) : 0
+					result: `<${v.type}>(0x${v.children[0].addr.toString(16)})`,
 				};
 			}
 		} else if (v.kind === GoReflectKind.Slice) {


### PR DESCRIPTION
See #1989 

This displays the address of the variable the pointer is pointing to (for pointer comparison). It also allows expansion in the debugger.

Example code:
```
package main

import "testing"

func TestX(t *testing.T) {
	var i, j int
	i = 0
	j = 1
	k := []string{"asdf"}
	var p = &i
	var q = &j
	var r = &k
	t.Logf("%#v %#v %#v", p, q, r)
}
```

Shown in debugger:
<img width="323" alt="screen shot 2018-11-02 at 2 35 52 pm" src="https://user-images.githubusercontent.com/1010430/47934050-a643c300-deac-11e8-8995-5efca4770536.png">
