### PR TITLE
Add support for setting variables

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -546,6 +546,7 @@ class GoDebugSession extends DebugSession {
 		verbose('InitializeRequest');
 		// This debug adapter implements the configurationDoneRequest.
 		response.body.supportsConfigurationDoneRequest = true;
+		response.body.supportsSetVariable = true;
 		this.sendResponse(response);
 		verbose('InitializeResponse');
 	}
@@ -1156,6 +1157,27 @@ class GoDebugSession extends DebugSession {
 			response.body = this.convertDebugVariableToProtocolVariable(variable, 0);
 			this.sendResponse(response);
 			verbose('EvaluateResponse');
+		});
+	}
+
+	protected setVariableRequest(response: DebugProtocol.SetVariableResponse, args: DebugProtocol.SetVariableArguments): void {
+		verbose('SetVariableRequest');
+		const scope = {
+			goroutineID: this.debugState.currentGoroutine.id
+		};
+		const setSymbolArgs = {
+			Scope: scope,
+			Symbol: args.name,
+			Value: args.value
+		};
+		this.delve.call(this.delve.isApiV1 ? 'SetSymbol' : 'Set', [setSymbolArgs], (err) => {
+			if (err) {
+				logError('Failed to set variable: ', err.toString());
+				return this.sendErrorResponse(response, 2010, 'Unable to set variable:', err.toString());
+			}
+			response.body = { value: args.value };
+			this.sendResponse(response);
+			verbose('SetVariableResponse');
 		});
 	}
 


### PR DESCRIPTION
Fixes #1129 
Only supports numerical and pointer variables (because that what delve [supports](https://github.com/derekparker/delve/blob/master/Documentation/cli/README.md#set)).