### PR TITLE
Add stacktrace paging support to debug adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -500,7 +500,7 @@
               "stackTraceDepth": {
                 "type": "number",
                 "description": "Maximum depth of stack trace collected from Delve",
-                "default": 50
+                "default": 20
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -496,6 +496,11 @@
                 ],
                 "description": "Delve Api Version to use. Default value is 2.",
                 "default": 2
+              },
+              "stackTraceDepth": {
+                "type": "number",
+                "description": "Maximum depth of stack trace collected from Delve",
+                "default": 50
               }
             }
           }

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -210,6 +210,8 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	dlvLoadConfig?: LoadConfig;
 	/** Delve Version */
 	apiVersion: number;
+	/** Delve maximum stack trace depth */
+	stackTraceDepth: number;
 }
 
 process.on('uncaughtException', (err: any) => {
@@ -258,6 +260,7 @@ class Delve {
 	noDebug: boolean;
 	isApiV1: boolean;
 	dlvEnv: any;
+	stackTraceDepth: number;
 
 	constructor(remotePath: string, port: number, host: string, program: string, launchArgs: LaunchRequestArguments) {
 		this.program = normalizePath(program);
@@ -268,6 +271,7 @@ class Delve {
 		} else if (typeof launchArgs['useApiV1'] === 'boolean') {
 			this.isApiV1 = launchArgs['useApiV1'];
 		}
+		this.stackTraceDepth = launchArgs.stackTraceDepth;
 		let mode = launchArgs.mode;
 		let dlvCwd = dirname(program);
 		let isProgramDirectory = false;
@@ -771,7 +775,7 @@ class GoDebugSession extends DebugSession {
 	protected stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments): void {
 		verbose('StackTraceRequest');
 		// delve does not support frame paging, so we ask for a large depth
-		let stackTraceIn = { id: args.threadId, depth: 50 };
+		let stackTraceIn = { id: args.threadId, depth: this.delve.stackTraceDepth };
 		if (!this.delve.isApiV1) {
 			Object.assign(stackTraceIn, { full: false, cfg: this.delve.loadConfig });
 		}

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -77,6 +77,9 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 		if (!debugConfiguration.hasOwnProperty('dlvLoadConfig') && dlvConfig.hasOwnProperty('dlvLoadConfig')) {
 			debugConfiguration['dlvLoadConfig'] = dlvConfig['dlvLoadConfig'];
 		}
+		if (!debugConfiguration.hasOwnProperty('stackTraceDepth') && dlvConfig.hasOwnProperty('stackTraceDepth')) {
+			debugConfiguration['stackTraceDepth'] = dlvConfig['stackTraceDepth'];
+		}
 
 		if (debugConfiguration['mode'] === 'auto') {
 			debugConfiguration['mode'] = (activeEditor && activeEditor.document.fileName.endsWith('_test.go')) ? 'test' : 'debug';

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -77,9 +77,6 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 		if (!debugConfiguration.hasOwnProperty('dlvLoadConfig') && dlvConfig.hasOwnProperty('dlvLoadConfig')) {
 			debugConfiguration['dlvLoadConfig'] = dlvConfig['dlvLoadConfig'];
 		}
-		if (!debugConfiguration.hasOwnProperty('stackTraceDepth') && dlvConfig.hasOwnProperty('stackTraceDepth')) {
-			debugConfiguration['stackTraceDepth'] = dlvConfig['stackTraceDepth'];
-		}
 
 		if (debugConfiguration['mode'] === 'auto') {
 			debugConfiguration['mode'] = (activeEditor && activeEditor.document.fileName.endsWith('_test.go')) ? 'test' : 'debug';


### PR DESCRIPTION
Fixes #946

This still has a maximum depth of 50. Delve has no way to specify an infinite max depth, or query the length of the stacktrace.