### PR TITLE
Use go doc instead of godoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Read the [Release Notes](https://github.com/Microsoft/vscode-go/wiki/Release-Not
 ### IntelliSense
 
 - Auto Completion of symbols as you type (using `gocode`)
-- Signature Help for functions as you type (using `gogetdoc` or `godef`+`godoc`)
-- Quick Info on the symbol as you hover over it (using `gogetdoc` or `godef`+`godoc`)
+- Signature Help for functions as you type (using `gogetdoc` or `godef`+`go doc`)
+- Quick Info on the symbol as you hover over it (using `gogetdoc` or `godef`+`go doc`)
 
 ### Code Navigation
 
-- Go to or Peek Definition of symbols (using `gogetdoc` or `godef`+`godoc`)
+- Go to or Peek Definition of symbols (using `gogetdoc` or `godef`+`go doc`)
 - Find References of symbols and Implementations of interfaces (using `guru`)
 - Go to symbol in file or see the file outline (using `go-outline`)
 - Go to symbol in workspace (using `go-symbols`)

--- a/package.json
+++ b/package.json
@@ -1194,11 +1194,6 @@
               "default": "gopkgs",
               "description": "Alternate tool to use instead of the gopkgs binary or alternate path to use for the gopkgs binary."
             },
-            "godoc": {
-              "type": "string",
-              "default": "godoc",
-              "description": "Alternate tool to use instead of the godoc binary or alternate path to use for the godoc binary."
-            },
             "go-outline": {
               "type": "string",
               "default": "go-outline",

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -66,6 +66,7 @@ export function definitionLocation(document: vscode.TextDocument, position: vsco
 	});
 }
 
+const godefImportDefinitionRegex = /^import \(.* ".*"\)$/;
 function definitionLocation_godef(input: GoDefinitionInput, token: vscode.CancellationToken): Promise<GoDefinitionInformation> {
 	let godefTool = input.isMod ? 'godef-gomod' : 'godef';
 	let godefPath = getBinPath(godefTool);
@@ -108,7 +109,7 @@ function definitionLocation_godef(input: GoDefinitionInput, token: vscode.Cancel
 					doc: null,
 					name: null
 				};
-				if (!input.includeDocs) {
+				if (!input.includeDocs || godefImportDefinitionRegex.test(definitionInformation.declarationlines[0])) {
 					return resolve(definitionInformation);
 				}
 				runGodoc(pkgPath, input.word, token).then(doc => {

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -116,7 +116,8 @@ function definitionLocation_godef(input: GoDefinitionInput, token: vscode.Cancel
 						definitionInformation.doc = doc;
 					}
 					resolve(definitionInformation);
-				}, () => {
+				}).catch(err => {
+					console.log(err);
 					resolve(definitionInformation);
 				});
 			} catch (e) {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -172,7 +172,6 @@ export function installAllTools(updateExistingToolsOnly: boolean = false) {
 		'gotype-live': 'Show errors as you type)',
 		'godef': '\t\t(Go to definition)',
 		'godef-gomod': '\t(Go to definition, works with Modules)',
-		'godoc': '\t\t(For text shown on hover)',
 		'gogetdoc': '\t(Go to definition & text shown on hover)',
 		'goimports': '\t(Formatter)',
 		'goreturns': '\t(Formatter)',

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -94,7 +94,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 		return runGodoc(item.package || path.dirname(item.fileName), item.label, token).then(doc => {
 			item.documentation = new vscode.MarkdownString(doc);
 			return item;
-		}, err => {
+		}).catch(err => {
 			console.log(err);
 			return item;
 		});

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -483,7 +483,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 	}
 
 	/**
-	 * Returns import path for given package. Since there can be multiple matches, 
+	 * Returns import path for given package. Since there can be multiple matches,
 	 * this returns an array of matches
 	 * @param input Package name
 	 */

--- a/src/util.ts
+++ b/src/util.ts
@@ -927,17 +927,31 @@ export function runGodoc(packagePath: string, symbol: string, token: vscode.Canc
 					return reject(err);
 				}
 				const godocLines = stdout.split('\n');
-				let doc = '';
 
-				for (let i = 1; i < godocLines.length && godocLines[i].startsWith('    '); i++) {
-					doc += godocLines[i].substring(4) + '\n';
+				// Skip trailing empty lines
+				let lastLine = godocLines.length - 1;
+				for (; lastLine > 1; lastLine--) {
+					if (godocLines[lastLine].trim()) {
+						break;
+					}
+				}
+
+				let doc = '';
+				for (let i = 1; i <= lastLine; i++) {
+					if (godocLines[i].startsWith('    ')) {
+						doc += godocLines[i].substring(4) + '\n';
+					} else if (!godocLines[i].trim()) {
+						doc += '\n';
+					}
 				}
 				return resolve(doc);
 			});
 
-			token.onCancellationRequested(() => {
-				killTree(p.pid);
-			});
+			if (token) {
+				token.onCancellationRequested(() => {
+					killTree(p.pid);
+				});
+			}
 		});
 	});
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -922,9 +922,9 @@ export function runGodoc(packagePath: string, symbol: string, token: vscode.Canc
 		return new Promise<string>((resolve, reject) => {
 			const env = getToolsEnvVars();
 			const args = ['doc', '-c', '-cmd', '-u', packageImportPath, symbol];
-			const p = cp.execFile(goRuntimePath, args, { env }, (err, stdout) => {
+			const p = cp.execFile(goRuntimePath, args, { env }, (err, stdout, stderr) => {
 				if (err) {
-					return reject(err);
+					return reject(err.message || stderr);
 				}
 				const godocLines = stdout.split('\n');
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -917,8 +917,7 @@ export function runGodoc(packagePath: string, symbol: string, token: vscode.Canc
 		return Promise.reject(new Error('Cannot find "go" binary. Update PATH or GOROOT appropriately'));
 	}
 
-	const cwd = packagePath;
-	const getCurrentPackagePromise = 1 !== 1 ? getCurrentPackage(cwd) : Promise.resolve(cwd);
+	const getCurrentPackagePromise = path.isAbsolute(packagePath) ? getCurrentPackage(packagePath) : Promise.resolve(packagePath);
 	return getCurrentPackagePromise.then(packageImportPath => {
 		return new Promise<string>((resolve, reject) => {
 			const env = getToolsEnvVars();

--- a/test/fixtures/gogetdocTestData/test.go
+++ b/test/fixtures/gogetdocTestData/test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ABC is a struct, you coudn't use Goto Definition or Hover info on this before
-// Now you can due to gogetdoc
+// Now you can due to gogetdoc and go doc
 type ABC struct {
 	a int
 	b int
@@ -15,7 +15,7 @@ type ABC struct {
 }
 
 // This is an unexported function so couldn't get this comment on hover :(
-// Not anymore!! gogetdoc to the rescue
+// Not anymore!!
 func print(txt string) {
 	fmt.Println(txt)
 }
@@ -39,5 +39,12 @@ func (abcd *ABC) Hello(s string, exclaim bool) string {
 // Greetings is an exported function. So all is good.
 func Greetings() string {
 	xyz := ABC{1, 2, int(math.Abs(-1))}
-	return xyz.Hello("World", false)
+	return xyz.Hello("World", false) + EmptyLine("Why")
+}
+
+// EmptyLine has docs
+//
+// with a blank line in the middle
+func EmptyLine(s string) string {
+	return s + "this is not an empty line"
 }

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -127,18 +127,16 @@ suite('Go Extension Tests', () => {
 		return vscode.workspace.openTextDocument(uri).then((textDocument) => {
 			let promises = testCases.map(([position, expectedSignature, expectedDocumentation]) =>
 				provider.provideHover(textDocument, position, null).then(res => {
-					// TODO: Documentation appears to currently be broken on Go 1.7, so disabling these tests for now
-					// if (expectedDocumentation === null) {
-					//  assert.equal(res.contents.length, 1);
-					// } else {
-					// 	assert.equal(res.contents.length, 2);
-					// 	assert.equal(expectedDocumentation, <string>(res.contents[0]));
-					// }
 					if (expectedSignature === null && expectedDocumentation === null) {
 						assert.equal(res, null);
 						return;
 					}
 					assert.equal(expectedSignature, (<{ language: string; value: string }>res.contents[0]).value);
+					if (expectedDocumentation === null) {
+						return;
+					}
+					assert.equal(res.contents.length, 2);
+					assert.equal(expectedDocumentation, <string>(res.contents[1]));
 				})
 			);
 			return Promise.all(promises);
@@ -219,8 +217,8 @@ It returns the number of bytes written and any write error encountered.
 
 	test('Test Hover Provider using godoc', (done) => {
 		let printlnDoc = `Println formats using the default formats for its operands and writes to
-standard output. Spaces are always added between operands and a newline
-is appended. It returns the number of bytes written and any write error
+standard output. Spaces are always added between operands and a newline is
+appended. It returns the number of bytes written and any write error
 encountered.
 `;
 		let testCases: [vscode.Position, string, string][] = [
@@ -257,7 +255,7 @@ It returns the number of bytes written and any write error encountered.
 			[new vscode.Position(28, 16), null, null], // inside a number
 			[new vscode.Position(22, 5), 'func main()', ''],
 			[new vscode.Position(23, 4), 'func print(txt string)', 'This is an unexported function so couldn\'t get this comment on hover :(\nNot anymore!!\n'],
-			[new vscode.Position(40, 23), 'package math', 'Package math provides basic constants and mathematical functions.\n'],
+			[new vscode.Position(40, 23), 'package math', 'Package math provides basic constants and mathematical functions.\n\nThis package does not guarantee bit-identical results across architectures.\n'],
 			[new vscode.Position(19, 6), 'func Println(a ...interface{}) (n int, err error)', printlnDoc],
 			[new vscode.Position(27, 14), 'type ABC struct {\n    a int\n    b int\n    c int\n}', 'ABC is a struct, you coudn\'t use Goto Definition or Hover info on this before\nNow you can due to gogetdoc and go doc\n'],
 			[new vscode.Position(28, 6), 'func CIDRMask(ones, bits int) IPMask', 'CIDRMask returns an IPMask consisting of `ones\' 1 bits\nfollowed by 0s up to a total length of `bits\' bits.\nFor a mask of this form, CIDRMask is the inverse of IPMask.Size.\n']

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -173,14 +173,16 @@ suite('Go Extension Tests', () => {
 
 	test('Test SignatureHelp Provider using godoc', (done) => {
 		let printlnDoc = `Println formats using the default formats for its operands and writes to
-standard output. Spaces are always added between operands and a newline
-is appended. It returns the number of bytes written and any write error
+standard output. Spaces are always added between operands and a newline is
+appended. It returns the number of bytes written and any write error
 encountered.
 `;
+
 		let testCases: [vscode.Position, string, string, string[]][] = [
 			[new vscode.Position(19, 13), 'Println(a ...interface{}) (n int, err error)', printlnDoc, ['a ...interface{}']],
-			[new vscode.Position(23, 7), 'print(txt string)', null, ['txt string']],
-			[new vscode.Position(41, 19), 'Hello(s string, exclaim bool) string', null, ['s string', 'exclaim bool']]
+			[new vscode.Position(23, 7), 'print(txt string)', 'This is an unexported function so couldn\'t get this comment on hover :( Not\nanymore!!\n', ['txt string']],
+			[new vscode.Position(41, 19), 'Hello(s string, exclaim bool) string', 'Hello is a method on the struct ABC. Will signature help understand this\ncorrectly\n', ['s string', 'exclaim bool']],
+			[new vscode.Position(41, 47), 'EmptyLine(s string) string', 'EmptyLine has docs\n\nwith a blank line in the middle\n', ['s string']]
 		];
 		let config = Object.create(vscode.workspace.getConfiguration('go'), {
 			'docsTool': { value: 'godoc' }
@@ -200,8 +202,9 @@ It returns the number of bytes written and any write error encountered.
 `;
 		let testCases: [vscode.Position, string, string, string[]][] = [
 			[new vscode.Position(19, 13), 'Println(a ...interface{}) (n int, err error)', printlnDoc, ['a ...interface{}']],
-			[new vscode.Position(23, 7), 'print(txt string)', 'This is an unexported function so couldn\'t get this comment on hover :(\nNot anymore!! gogetdoc to the rescue\n', ['txt string']],
-			[new vscode.Position(41, 19), 'Hello(s string, exclaim bool) string', 'Hello is a method on the struct ABC. Will signature help understand this correctly\n', ['s string', 'exclaim bool']]
+			[new vscode.Position(23, 7), 'print(txt string)', 'This is an unexported function so couldn\'t get this comment on hover :(\nNot anymore!!\n', ['txt string']],
+			[new vscode.Position(41, 19), 'Hello(s string, exclaim bool) string', 'Hello is a method on the struct ABC. Will signature help understand this correctly\n', ['s string', 'exclaim bool']],
+			[new vscode.Position(41, 47), 'EmptyLine(s string) string', 'EmptyLine has docs\n\nwith a blank line in the middle\n', ['s string']]
 		];
 		let config = Object.create(vscode.workspace.getConfiguration('go'), {
 			'docsTool': { value: 'gogetdoc' }
@@ -253,10 +256,10 @@ It returns the number of bytes written and any write error encountered.
 			[new vscode.Position(20, 0), null, null], // just a }
 			[new vscode.Position(28, 16), null, null], // inside a number
 			[new vscode.Position(22, 5), 'func main()', ''],
-			[new vscode.Position(23, 4), 'func print(txt string)', 'This is an unexported function so couldn\'t get this comment on hover :(\nNot anymore!! gogetdoc to the rescue\n'],
+			[new vscode.Position(23, 4), 'func print(txt string)', 'This is an unexported function so couldn\'t get this comment on hover :(\nNot anymore!!\n'],
 			[new vscode.Position(40, 23), 'package math', 'Package math provides basic constants and mathematical functions.\n'],
 			[new vscode.Position(19, 6), 'func Println(a ...interface{}) (n int, err error)', printlnDoc],
-			[new vscode.Position(27, 14), 'type ABC struct {\n    a int\n    b int\n    c int\n}', 'ABC is a struct, you coudn\'t use Goto Definition or Hover info on this before\nNow you can due to gogetdoc\n'],
+			[new vscode.Position(27, 14), 'type ABC struct {\n    a int\n    b int\n    c int\n}', 'ABC is a struct, you coudn\'t use Goto Definition or Hover info on this before\nNow you can due to gogetdoc and go doc\n'],
 			[new vscode.Position(28, 6), 'func CIDRMask(ones, bits int) IPMask', 'CIDRMask returns an IPMask consisting of `ones\' 1 bits\nfollowed by 0s up to a total length of `bits\' bits.\nFor a mask of this form, CIDRMask is the inverse of IPMask.Size.\n']
 		];
 		let config = Object.create(vscode.workspace.getConfiguration('go'), {


### PR DESCRIPTION
This PR covers the below:
- Replace the use of `godoc` with `go doc` for the hover widget. This will solve issues like #2078 since godoc is no longer go gettable
- Make both the hover widget and the completion widget share the code around the use of `go doc`
- Use `go list` to get package import path given the absolute path

@segevfiner, Can you take a look and let me know your thoughts, since this is close to your work in #2054