### PR TITLE
add a gocodeFlags field to goConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -800,6 +800,19 @@
           "description": "Environment variables that will passed to the processes that run the Go tools (e.g. CGO_CFLAGS)",
           "scope": "resource"
         },
+        "go.gocodeFlags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "-builtin",
+            "-ignore-case",
+            "-unimported-packages"
+          ],
+          "description": "Additional flags to pass to gocode.",
+          "scope": "resource"
+        },
         "go.gocodeAutoBuild": {
           "type": "boolean",
           "default": false,

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -242,9 +242,11 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 
 			let goCodeFlags = ['-f=json'];
 			if (!this.setGocodeOptions) {
-				goCodeFlags.push('-builtin');
+				let goConfig = vscode.workspace.getConfiguration('go', vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document.uri : null);
+				goConfig['gocodeFlags'].forEach(element => {
+					goCodeFlags.push(element);
+				});
 			}
-
 			// Spawn `gocode` process
 			let p = cp.spawn(gocode, [...goCodeFlags, 'autocomplete', filename, '' + offset], { env });
 			p.stdout.on('data', data => stdout += data);


### PR DESCRIPTION
As more flags are being added to gocode, it is useful to have a field that allows a user to manually customize the flags being passed to gocode.