### PR TITLE
Exclude .map and test files from vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,3 +4,6 @@ typings/**/*
 tsconfig.json
 .gitignore
 node_modules/fs-extra
+test/
+**/*.map
+**/tslint.json


### PR DESCRIPTION
https://github.com/Microsoft/vscode/issues/62687

Exclude all the `.map` files and the test  directory from the vsix