### PR TITLE
Differentiate between interfaces and structs in outline

### DIFF
--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -158,7 +158,7 @@ function convertToCodeSymbols(
 			range = new vscode.Range(document.positionAt(start), document.positionAt(end));
 			if (decl.type === 'type') {
 				let line = document.lineAt(document.positionAt(start));
-				let regex = new RegExp('type .* struct');
+				let regex = new RegExp(`^\\s*type\\s*${decl.label}\\s*struct\\b`);
 				decl.type = regex.test(line.text) ? 'struct' : 'type';
 			}
 		}

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -159,7 +159,7 @@ function convertToCodeSymbols(
 			if (decl.type === 'type') {
 				let line = document.lineAt(document.positionAt(start));
 				let regex = new RegExp('\\bstruct\\b');
-				decl.type = line.text.match(regex) ? 'struct' : 'type';
+				decl.type = regex.test(line.text) ? 'struct' : 'type';
 			}
 		}
 

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -126,7 +126,8 @@ const goKindToCodeKind: { [key: string]: vscode.SymbolKind } = {
 	'import': vscode.SymbolKind.Namespace,
 	'variable': vscode.SymbolKind.Variable,
 	'type': vscode.SymbolKind.Interface,
-	'function': vscode.SymbolKind.Function
+	'function': vscode.SymbolKind.Function,
+	'struct': vscode.SymbolKind.Struct,
 };
 
 
@@ -149,13 +150,16 @@ function convertToCodeSymbols(
 			label = '(' + decl.receiverType + ').' + label;
 		}
 
+
 		let range = null;
 		if (document && byteOffsetToDocumentOffset) {
 			let start = byteOffsetToDocumentOffset(decl.start - 1);
 			let end = byteOffsetToDocumentOffset(decl.end - 1);
 			range = new vscode.Range(document.positionAt(start), document.positionAt(end));
 		}
-
+		if (decl.type === 'type') {
+			decl.type = document.getText(range).includes('struct') ? 'struct' : 'type';
+		}
 		let symbolInfo = new vscode.SymbolInformation(
 			label,
 			goKindToCodeKind[decl.type],

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -158,7 +158,7 @@ function convertToCodeSymbols(
 			range = new vscode.Range(document.positionAt(start), document.positionAt(end));
 			if (decl.type === 'type') {
 				let line = document.lineAt(document.positionAt(start));
-				let regex = new RegExp(`^\\s*type\\s*${decl.label}\\s*struct\\b`);
+				let regex = new RegExp(`^\\s*type\\s+${decl.label}\\s+struct\\b`);
 				decl.type = regex.test(line.text) ? 'struct' : 'type';
 			}
 		}

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -158,7 +158,7 @@ function convertToCodeSymbols(
 			range = new vscode.Range(document.positionAt(start), document.positionAt(end));
 			if (decl.type === 'type') {
 				let line = document.lineAt(document.positionAt(start));
-				let regex = new RegExp('\\bstruct\\b');
+				let regex = new RegExp('type .* struct');
 				decl.type = regex.test(line.text) ? 'struct' : 'type';
 			}
 		}

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -156,10 +156,13 @@ function convertToCodeSymbols(
 			let start = byteOffsetToDocumentOffset(decl.start - 1);
 			let end = byteOffsetToDocumentOffset(decl.end - 1);
 			range = new vscode.Range(document.positionAt(start), document.positionAt(end));
+			if (decl.type === 'type') {
+				let line = document.lineAt(document.positionAt(start));
+				let regex = new RegExp('\\bstruct\\b');
+				decl.type = line.text.match(regex) ? 'struct' : 'type';
+			}
 		}
-		if (decl.type === 'type') {
-			decl.type = document.getText(range).includes('struct') ? 'struct' : 'type';
-		}
+
 		let symbolInfo = new vscode.SymbolInformation(
 			label,
 			goKindToCodeKind[decl.type],

--- a/test/fixtures/outlineTest/test.go
+++ b/test/fixtures/outlineTest/test.go
@@ -12,3 +12,7 @@ func print(txt string) {
 func main() {
 	print("Hello")
 }
+
+type foo struct {
+	bar int
+}

--- a/test/go.test.ts
+++ b/test/go.test.ts
@@ -599,11 +599,13 @@ It returns the number of bytes written and any write error encountered.
 				let packageNames = groupedSymbolNames[vscode.SymbolKind.Package];
 				let variableNames = groupedSymbolNames[vscode.SymbolKind.Variable];
 				let functionNames = groupedSymbolNames[vscode.SymbolKind.Function];
-
+				let structs = groupedSymbolNames[vscode.SymbolKind.Struct];
 				assert.equal(packageNames[0], 'main');
 				assert.equal(variableNames, undefined);
 				assert.equal(functionNames[0], 'print');
 				assert.equal(functionNames[1], 'main');
+				assert.equal(structs.length, 1);
+				assert.equal(structs[0], 'foo');
 			});
 		}).then(() => done(), done);
 	});


### PR DESCRIPTION
This PR fixes the code outline from erroneously displaying structs as interfaces.

Before 
<img width="718" alt="screenshot 2018-11-11 at 00 29 59" src="https://user-images.githubusercontent.com/3783410/48307268-9598ea00-e549-11e8-8cee-5a4899f07d86.png">

After
<img width="791" alt="screenshot 2018-11-11 at 00 31 02" src="https://user-images.githubusercontent.com/3783410/48307271-af3a3180-e549-11e8-80ab-f221cb407e31.png">

