### PR TITLE
Fix 'Debug: Start Without Debugging' to use current file and include buildFlags/args

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -320,7 +320,15 @@ class Delve {
 			if (!!launchArgs.noDebug) {
 				if (mode === 'debug' && !isProgramDirectory) {
 					this.noDebug = true;
-					this.debugProcess = spawn(getBinPathWithPreferredGopath('go', []), ['run', program], { env });
+					let runArgs = ['run'];
+					if (launchArgs.buildFlags) {
+						runArgs.push(launchArgs.buildFlags);
+					}
+					runArgs.push(program);
+					if (launchArgs.args) {
+						runArgs.push(...launchArgs.args);
+					}
+					this.debugProcess = spawn(getBinPathWithPreferredGopath('go', []), runArgs, { env });
 					this.debugProcess.stderr.on('data', chunk => {
 						let str = chunk.toString();
 						if (this.onstderr) { this.onstderr(str); }

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -89,7 +89,7 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 		if (debugConfiguration['mode'] === 'auto') {
 			debugConfiguration['mode'] = (activeEditor && activeEditor.document.fileName.endsWith('_test.go')) ? 'test' : 'debug';
 		}
-		debugConfiguration['currentFile'] = activeEditor && activeEditor.document.fileName;
+		debugConfiguration['currentFile'] = activeEditor && activeEditor.document.languageId === 'go' && activeEditor.document.fileName;
 
 		return debugConfiguration;
 	}

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -89,6 +89,7 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 		if (debugConfiguration['mode'] === 'auto') {
 			debugConfiguration['mode'] = (activeEditor && activeEditor.document.fileName.endsWith('_test.go')) ? 'test' : 'debug';
 		}
+		debugConfiguration['currentFile'] = activeEditor && activeEditor.document.fileName;
 
 		return debugConfiguration;
 	}


### PR DESCRIPTION
Include buildFlags and args when running without debugging. Use current file (if there is one) when 'running without debugging'.

Fixes #2086 and #2085 