### PR TITLE
Fix module enabled gocode

### DIFF
--- a/package.json
+++ b/package.json
@@ -806,8 +806,7 @@
           },
           "default": [
             "-builtin",
-            "-ignore-case",
-            "-unimported-packages"
+            "-ignore-case"
           ],
           "description": "Additional flags to pass to gocode.",
           "scope": "resource"

--- a/package.json
+++ b/package.json
@@ -806,7 +806,8 @@
           },
           "default": [
             "-builtin",
-            "-ignore-case"
+            "-ignore-case",
+            "-unimported-packages"
           ],
           "description": "Additional flags to pass to gocode.",
           "scope": "resource"

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -222,8 +222,12 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 			let stdout = '';
 			let stderr = '';
 
+			const flags = [...this.gocodeFlags];
+			if (gocodeName == 'gocode') {
+				flags.push('-unimported-packages');
+			}
 			// Spawn `gocode` process
-			let p = cp.spawn(gocode, [...this.gocodeFlags, 'autocomplete', filename, '' + offset], { env });
+			let p = cp.spawn(gocode, [...flags, 'autocomplete', filename, '' + offset], { env });
 			p.stdout.on('data', data => stdout += data);
 			p.stderr.on('data', data => stderr += data);
 			p.on('error', err => {

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -223,8 +223,13 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 			let stderr = '';
 
 			const flags = [...this.gocodeFlags];
-			if (gocodeName == 'gocode') {
-				flags.push('-unimported-packages');
+			// stamblerre/gocode does not support -unimported-packages flags.
+			if (this.isGoMod) {
+				const upflag = '-unimported-packages';
+				const idx = flags.indexOf(upflag);
+				if (idx >= 0) {
+					flags.splice(idx, 1);
+				}
 			}
 			// Spawn `gocode` process
 			let p = cp.spawn(gocode, [...flags, 'autocomplete', filename, '' + offset], { env });

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -222,17 +222,16 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 			let stdout = '';
 			let stderr = '';
 
-			const flags = [...this.gocodeFlags];
 			// stamblerre/gocode does not support -unimported-packages flags.
 			if (this.isGoMod) {
 				const upflag = '-unimported-packages';
-				const idx = flags.indexOf(upflag);
+				const idx = this.gocodeFlags.indexOf(upflag);
 				if (idx >= 0) {
-					flags.splice(idx, 1);
+					this.gocodeFlags.splice(idx, 1);
 				}
 			}
 			// Spawn `gocode` process
-			let p = cp.spawn(gocode, [...flags, 'autocomplete', filename, '' + offset], { env });
+			let p = cp.spawn(gocode, [...this.gocodeFlags, 'autocomplete', filename, '' + offset], { env });
 			p.stdout.on('data', data => stdout += data);
 			p.stderr.on('data', data => stderr += data);
 			p.on('error', err => {


### PR DESCRIPTION
A recent addition broke module-enabled gocode (gocode-gomod binary which is the github.com/stamblerre/gocode fork) 

Unrecognized flags cause errors, so this change only adds this flag to the binary that recognizes it (mdempsky/gocode) 