### PR TITLE
debug: fix 'pause' command

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1077,6 +1077,9 @@ class GoDebugSession extends LoggingDebugSession {
 				}
 				const goroutines = this.delve.isApiV1 ? <DebugGoroutine[]>out : (<ListGoroutinesOut>out).Goroutines;
 				this.updateThreads(goroutines);
+				if (!this.debugState.currentGoroutine && goroutines.length > 0) {
+					this.debugState.currentGoroutine = goroutines[0];
+				}
 
 				let stoppedEvent = new StoppedEvent(reason, this.debugState.currentGoroutine.id);
 				(<any>stoppedEvent.body).allThreadsStopped = true;

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -759,7 +759,7 @@ class GoDebugSession extends LoggingDebugSession {
 		}
 		log('ThreadsRequest');
 		this.delve.call<DebugGoroutine[] | ListGoroutinesOut>('ListGoroutines', [], (err, out) => {
-			if (this.debugState.exited) {
+			if (this.debugState && this.debugState.exited) {
 				// If the program exits very quickly, the initial threadsRequest will complete after it has exited.
 				// A TerminatedEvent has already been sent. Ignore the err returned in this case.
 				response.body = { threads: [] };

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -774,7 +774,7 @@ class GoDebugSession extends LoggingDebugSession {
 	protected threadsRequest(response: DebugProtocol.ThreadsResponse): void {
 		if (this.continueRequestRunning) {
 			// Thread request to delve is syncronous and will block if a previous async continue request didn't return
-			response.body = { threads: [] };
+			response.body = { threads: [new Thread(1, 'Dummy')] };
 			return this.sendResponse(response);
 		}
 		log('ThreadsRequest');

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1165,9 +1165,11 @@ class GoDebugSession extends LoggingDebugSession {
 			}
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			log('pause state', state);
-			this.sendResponse(response);
-			log('PauseResponse');
+			this.debugState = state;
+			this.handleReenterDebug('pause');
 		});
+		this.sendResponse(response);
+		log('PauseResponse');
 	}
 
 	protected evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): void {


### PR DESCRIPTION
Fixes #978 

**Addressed issues**
* Should maintain alive threads list and update it on 'ThreadsRequest'
* Should update `debugState` and `threads` on 'PauseRequest'
* Returning an empty array on `threads` request. VS Code expects that a process consists of at least one thread
* Unhandled exception in `handleReenterDebug` in case of `this.debugState.currentGoroutine` is unitialized
* Unhandled exception in `threadsRequest` when `this.debugState` is unitialized