### PR TITLE
debug: fix updating breakpoints while debuggee is running

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -766,6 +766,7 @@ class GoDebugSession extends LoggingDebugSession {
 					});
 				});
 			}, err => {
+				this.skipStopEventOnce = false;
 				logError(err);
 				return this.sendErrorResponse(response, 2008, 'Failed to halt delve before attempting to set breakpoint: "{e}"', { e: err.toString() });
 			});

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -761,8 +761,7 @@ class GoDebugSession extends LoggingDebugSession {
 			this.delve.callPromise('Command', [{ name: 'halt' }]).then(() => {
 				return this.setBreakPoints(response, args).then(() => {
 					return this.continue(true).then(null, err => {
-						logError(err);
-						this.sendErrorResponse(response, 2009, 'Failed to continue delve after halting it to set breakpoints: "{e}"', { e: err.toString() });
+						logError(`Failed to continue delve after halting it to set breakpoints: "${err.toString()}"`);
 					});
 				});
 			}, err => {
@@ -1131,6 +1130,7 @@ class GoDebugSession extends LoggingDebugSession {
 				logError('Failed to continue - ' + err.toString());
 			}
 			this.handleReenterDebug('breakpoint');
+			throw err;
 		};
 
 		return this.delve.callPromise('Command', [{ name: 'continue' }]).then(callback, errorCallback);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1125,7 +1125,12 @@ class GoDebugSession extends LoggingDebugSession {
 		};
 
 		// If called when setting breakpoint internally, we want the error to bubble up.
-		const errorCallback = calledWhenSettingBreakpoint ? null : callback;
+		const errorCallback = calledWhenSettingBreakpoint ? null : (err) => {
+			if (err) {
+				logError('Failed to continue - ' + err.toString());
+			}
+			this.handleReenterDebug('breakpoint');
+		};
 
 		return this.delve.callPromise('Command', [{ name: 'continue' }]).then(callback, errorCallback);
 	}

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -534,7 +534,7 @@ class GoDebugSession extends LoggingDebugSession {
 
 	private _variableHandles: Handles<DebugVariable>;
 	private breakpoints: Map<string, DebugBreakpoint[]>;
-	private skipStopEventOnce: boolean;
+	private skipStopEventOnce: boolean; // Editing breakpoints requires halting delve, skip sending Stop Event to VS Code in such cases
 	private threads: Set<number>;
 	private debugState: DebuggerState;
 	private delve: Delve;
@@ -760,10 +760,10 @@ class GoDebugSession extends LoggingDebugSession {
 			this.skipStopEventOnce = true;
 			this.delve.callPromise('Command', [{ name: 'halt' }]).then(() => {
 				return this.setBreakPoints(response, args).then(() => {
-					return this.continue();
-				}, err => {
-					logError(err);
-					return this.sendErrorResponse(response, 2009, 'Failed to continue delve after setting the breakpoint: "{e}"', { e: err.toString() });
+					return this.continue(true).then(null, err => {
+						logError(err);
+						this.sendErrorResponse(response, 2009, 'Failed to continue delve after halting it to set breakpoints: "{e}"', { e: err.toString() });
+					});
 				});
 			}, err => {
 				logError(err);
@@ -1109,27 +1109,39 @@ class GoDebugSession extends LoggingDebugSession {
 
 	private continueEpoch = 0;
 	private continueRequestRunning = false;
-	private continue(): void {
+	private continue(calledWhenSettingBreakpoint?: boolean): Thenable<void> {
 		this.continueEpoch++;
 		let closureEpoch = this.continueEpoch;
 		this.continueRequestRunning = true;
-		this.delve.call<DebuggerState | CommandOut>('Command', [{ name: 'continue' }], (err, out) => {
+
+		const callback = (out) => {
+			if (closureEpoch === this.continueEpoch) {
+				this.continueRequestRunning = false;
+			}
+			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
+			log('continue state', state);
+			this.debugState = state;
+		};
+
+		// If called when setting breakpoint internally, we want the error to bubble up.
+		if (calledWhenSettingBreakpoint) {
+			return this.delve.callPromise('Command', [{ name: 'continue' }]).then(callback);
+		}
+		return this.delve.callPromise('Command', [{ name: 'continue' }]).then(callback, err => {
 			if (closureEpoch === this.continueEpoch) {
 				this.continueRequestRunning = false;
 			}
 			if (err) {
 				logError('Failed to continue - ' + err.toString());
 			}
-			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
-			log('continue state', state);
-			this.debugState = state;
-			this.handleReenterDebug('breakpoint');
 		});
 	}
 
 	protected continueRequest(response: DebugProtocol.ContinueResponse): void {
 		log('ContinueRequest');
-		this.continue();
+		this.continue().then(() => {
+			this.handleReenterDebug('breakpoint');
+		});
 		this.sendResponse(response);
 		log('ContinueResponse');
 	}

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -534,7 +534,7 @@ class GoDebugSession extends LoggingDebugSession {
 
 	private _variableHandles: Handles<DebugVariable>;
 	private breakpoints: Map<string, DebugBreakpoint[]>;
-	private skipStopEventOnce: boolean;
+	private skipStopEventOnce: boolean; // Editing breakpoints requires halting delve, skip sending Stop Event to VS Code in such cases
 	private threads: Set<number>;
 	private debugState: DebuggerState;
 	private delve: Delve;
@@ -760,10 +760,10 @@ class GoDebugSession extends LoggingDebugSession {
 			this.skipStopEventOnce = true;
 			this.delve.callPromise('Command', [{ name: 'halt' }]).then(() => {
 				return this.setBreakPoints(response, args).then(() => {
-					return this.continue();
-				}, err => {
-					logError(err);
-					return this.sendErrorResponse(response, 2009, 'Failed to continue delve after setting the breakpoint: "{e}"', { e: err.toString() });
+					return this.continue(true).then(null, err => {
+						logError(err);
+						this.sendErrorResponse(response, 2009, 'Failed to continue delve after halting it to set breakpoints: "{e}"', { e: err.toString() });
+					});
 				});
 			}, err => {
 				logError(err);
@@ -1109,22 +1109,25 @@ class GoDebugSession extends LoggingDebugSession {
 
 	private continueEpoch = 0;
 	private continueRequestRunning = false;
-	private continue(): void {
+	private continue(calledWhenSettingBreakpoint?: boolean): Thenable<void> {
 		this.continueEpoch++;
 		let closureEpoch = this.continueEpoch;
 		this.continueRequestRunning = true;
-		this.delve.call<DebuggerState | CommandOut>('Command', [{ name: 'continue' }], (err, out) => {
+
+		const callback = (out) => {
 			if (closureEpoch === this.continueEpoch) {
 				this.continueRequestRunning = false;
-			}
-			if (err) {
-				logError('Failed to continue - ' + err.toString());
 			}
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			log('continue state', state);
 			this.debugState = state;
 			this.handleReenterDebug('breakpoint');
-		});
+		};
+
+		// If called when setting breakpoint internally, we want the error to bubble up.
+		const errorCallback = calledWhenSettingBreakpoint ? null : callback;
+
+		return this.delve.callPromise('Command', [{ name: 'continue' }]).then(callback, errorCallback);
 	}
 
 	protected continueRequest(response: DebugProtocol.ContinueResponse): void {


### PR DESCRIPTION
**Issue**
Can't set/remove breakpoints while debuggee is running

**Details**
Implemented **stop-breakpoint-start** approach to resolve the issue as described in https://github.com/Microsoft/vscode-go/issues/978#issuecomment-361015995.
Take a look at #978 for details, @muravjov's comments contain detailed description what's going wrong in that case.

Fixes #2002 