### PR TITLE
Close gocode daemon on deactivation

### DIFF
--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -561,5 +561,7 @@ function checkToolExists(tool: string) {
 }
 
 function registerCompletionProvider(ctx: vscode.ExtensionContext) {
-	ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(GO_MODE, new GoCompletionItemProvider(ctx.globalState), '.', '\"'));
+	let provider = new GoCompletionItemProvider(ctx.globalState)
+	ctx.subscriptions.push(provider);
+	ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(GO_MODE, provider, '.', '\"'));
 }

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -561,7 +561,7 @@ function checkToolExists(tool: string) {
 }
 
 function registerCompletionProvider(ctx: vscode.ExtensionContext) {
-	let provider = new GoCompletionItemProvider(ctx.globalState)
+	let provider = new GoCompletionItemProvider(ctx.globalState);
 	ctx.subscriptions.push(provider);
 	ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(GO_MODE, provider, '.', '\"'));
 }

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -55,8 +55,7 @@ const lineCommentRegex = /^\s*\/\/\s+/;
 const exportedMemberRegex = /(const|func|type|var)(\s+\(.*\))?\s+([A-Z]\w*)/;
 const gocodeNoSupportForgbMsgKey = 'dontshowNoSupportForgb';
 
-export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
-
+export class GoCompletionItemProvider implements vscode.CompletionItemProvider, vscode.Disposable {
 	private pkgsList = new Map<string, string>();
 	private killMsgShown: boolean = false;
 	private setGocodeOptions: boolean = true;
@@ -207,6 +206,13 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 				}, reject);
 			});
 		});
+	}
+
+	public dispose() {
+		let gocodeName = this.isGoMod ? 'gocode-gomod' : 'gocode';
+		let gocode = getBinPath(gocodeName);
+		let env = getToolsEnvVars();
+		cp.spawn(gocode, ['close'], { env });
 	}
 
 	private runGoCode(document: vscode.TextDocument, filename: string, inputText: string, offset: number, inString: boolean, position: vscode.Position, lineText: string, currentWord: string, includeUnimportedPkgs: boolean, config: vscode.WorkspaceConfiguration): Thenable<vscode.CompletionItem[]> {

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -211,8 +211,9 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider, 
 	public dispose() {
 		let gocodeName = this.isGoMod ? 'gocode-gomod' : 'gocode';
 		let gocode = getBinPath(gocodeName);
-		let env = getToolsEnvVars();
-		cp.spawn(gocode, ['close'], { env });
+		if (path.isAbsolute(gocode)) {
+			cp.spawn(gocode, ['close'], { env: getToolsEnvVars() });
+		}
 	}
 
 	private runGoCode(document: vscode.TextDocument, filename: string, inputText: string, offset: number, inString: boolean, position: vscode.Position, lineText: string, currentWord: string, includeUnimportedPkgs: boolean, config: vscode.WorkspaceConfiguration): Thenable<vscode.CompletionItem[]> {


### PR DESCRIPTION
Note that the extension doesn't actually start the gocode daemon,
the gocode client itself does that as necessary.

It is safe to close the daemon for the same reason however.
If other clients were using the daemon, it will be restarted
on their next request.

Fixes #2132