### PR TITLE
Add support for bingo & golsp language server (#2143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,16 @@ The Go extension is ready to use on the get go. If you want to customize the fea
 
 ### Go Language Server (Experimental)
 
-The Go extension uses a host of Go tools to provide the various language features. An alternative is to use a single language server that provides the same feature.  
+The Go extension uses a host of Go tools to provide the various language features. An alternative is to use an external Go language server that provides the same set of features. The usage of Go language servers are disabled by default (`"go.useLanguageServer": "none"`).
 
-Set `go.useLanguageServer` to `true` to use the Go language server from [Sourcegraph](https://github.com/sourcegraph/go-langserver) for features like Hover, Definition, Find All References, Signature Help, Go to Symbol in File and Workspace.
-* Since only a single language server is spun up for given VS Code instance, having multi-root setup where the folders have different GOPATH is not supported.
-* If set to true, you will be prompted to install the Go language server. Once installed, you will have to reload VS Code window. The language server will then be run by the Go extension in the background to provide services needed for the above mentioned features.
-* Every time you change the value of the setting `go.useLanguageServer`, you need to reload the VS Code window for it to take effect.
-* To collect traces, set `"go.languageServerFlags": ["-trace"]`
-* To collect errors from language server in a logfile, set `"go.languageServerFlags": ["-trace", "-logfile", "path to a text file that exists"]`
-* Use the new setting `go.languageServerExperimentalFeatures` to opt-in to try new features like Code Completion and Formatting from the language server that might not be feature complete yet. 
+To use a Go language server, set `go.useLanguageServer` to either `"go-langserver"` (by [Sourcegraph](https://github.com/sourcegraph/go-langserver)), `"golsp"` (by [Google](https://github.com/golang/tools/tree/master/cmd/golsp)) or `"bingo"` (by [saibing](https://github.com/saibing/bingo)) to enable features like Hover, Definition, Find All References, Signature Help, Go to Symbol in File and Workspace.
+
+* Only one language server is launched for a given VS Code instance hence multi-root workspaces with different GOPATH are not supported.
+* You will be prompted to install the selected language server if it is not installed on your system. After installation, you need to reload VS Code for the extension to launch the server to provide services needed for the above-mentioned features.
+* Changes made to the `go.useLanguageServer` setting requires VS Code to be reloaded to take effect.
+* To collect traces, set `"go.languageServerFlags": ["-trace"]`.
+* To collect errors from the language server in a log file, set `"go.languageServerFlags": ["-trace", "-logfile", "path to a text file that exists"]`.
+* Use the `go.languageServerExperimentalFeatures` setting to opt-in to experimental features such as Code Completion and Code Formatting.
 
 ### Linter
 

--- a/package.json
+++ b/package.json
@@ -864,9 +864,21 @@
           ]
         },
         "go.useLanguageServer": {
-          "type": "boolean",
-          "default": false,
-          "description": "Experimental: Use Go language server from Sourcegraph for Hover, Definition, Find All References, Signature Help, File Outline and Workspace Symbol features instead of tools like guru, godef, go-outline and go-symbol"
+          "type": "string",
+          "enum": [
+            "go-langserver",
+            "golsp",
+            "bingo",
+            "none"
+          ],
+          "enumDescriptions": [
+            "Go language server by Sourcegraph.",
+            "Go language server by Google.",
+            "Go language server by saibing. (requires Go version >= 1.11)",
+            ""
+          ],
+          "default": "none",
+          "description": "Experimental: Use an external Go language server to provide programming language-specific features."
         },
         "go.languageServerFlags": {
           "type": "array",


### PR DESCRIPTION
Hi @ramya-rao-a, here's my attempt to add support for [bingo](https://github.com/saibing/bingo) & [golsp](https://github.com/golang/tools/blob/master/cmd/golsp/main.go) language servers to the extension.

This Closes #2143.

**Additional Notes**

* When testing the extension with [bingo](https://github.com/saibing/bingo) as the language server & I would receive `<MY_PROJECT_DIR>/go.mod does not exist, please use 'go mod init' to create it` errors (since [bingo](https://github.com/saibing/bingo) only supports Go Module based projects).
* Do we want to support any language server specific flags/logic to handle cases like the example above?