### PR TITLE
Added a check to prevent installing Delve in most unsupported platforms.

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -81,9 +81,15 @@ function getTools(goVersion: SemVersion): string[] {
 		'go-outline',
 		'go-symbols',
 		'guru',
-		'gorename',
-		'dlv'
+		'gorename'
 	];
+
+	// Check if the system supports dlv (e.g. is 64-bit)
+	// There doesn't seem to be a good way to check if the mips and s390
+	// families are 64-bit, so just try to install it and hope for the best
+	if (process.arch.match(/^(arm64|mips|mipsel|ppc64|s390|s390x|x64)$/)) {
+		tools.push('dlv');
+	}
 
 	// gocode-gomod needed in go 1.11 & higher
 	if (!goVersion || (goVersion.major === 1 && goVersion.minor >= 11)) {


### PR DESCRIPTION
This will prevent Delve from being installed in 32-bit machines (e.g. arm, i686) where is not supported.
The mips, mipsel, s390 and s390x entries are there because Node defines them as possible values and it's not clear if they are 64-bit or not, so the extension will try to install it anyway.