### PR TITLE
Default stackTraceDepth to the value from package.json

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -271,7 +271,7 @@ class Delve {
 		} else if (typeof launchArgs['useApiV1'] === 'boolean') {
 			this.isApiV1 = launchArgs['useApiV1'];
 		}
-		this.stackTraceDepth = launchArgs.stackTraceDepth;
+		this.stackTraceDepth = launchArgs.stackTraceDepth || 50;
 		let mode = launchArgs.mode;
 		let dlvCwd = dirname(program);
 		let isProgramDirectory = false;


### PR DESCRIPTION
It seems that defaults from the debugger `configurationAttributes` in package.json are only used for auto-complete, and won't be filled in automatically if not given.

Fixes #2187, and fixes #2196 