### PR TITLE
Attempt to fix the debugger jumping to gopark

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1093,9 +1093,9 @@ class GoDebugSession extends DebugSession {
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('continue state', state);
 			this.debugState = state;
+			this.sendResponse(response);
 			this.handleReenterDebug('breakpoint');
 		});
-		this.sendResponse(response);
 		verbose('ContinueResponse');
 	}
 
@@ -1108,9 +1108,9 @@ class GoDebugSession extends DebugSession {
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('next state', state);
 			this.debugState = state;
+			this.sendResponse(response);
 			this.handleReenterDebug('step');
 		});
-		this.sendResponse(response);
 		verbose('NextResponse');
 	}
 
@@ -1123,9 +1123,9 @@ class GoDebugSession extends DebugSession {
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('stop state', state);
 			this.debugState = state;
+			this.sendResponse(response);
 			this.handleReenterDebug('step');
 		});
-		this.sendResponse(response);
 		verbose('StepInResponse');
 	}
 
@@ -1138,9 +1138,9 @@ class GoDebugSession extends DebugSession {
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('stepout state', state);
 			this.debugState = state;
+			this.sendResponse(response);
 			this.handleReenterDebug('step');
 		});
-		this.sendResponse(response);
 		verbose('StepOutResponse');
 	}
 

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1094,9 +1094,9 @@ class GoDebugSession extends DebugSession {
 			verbose('continue state', state);
 			this.debugState = state;
 			this.sendResponse(response);
+			verbose('ContinueResponse');
 			this.handleReenterDebug('breakpoint');
 		});
-		verbose('ContinueResponse');
 	}
 
 	protected nextRequest(response: DebugProtocol.NextResponse): void {
@@ -1109,9 +1109,9 @@ class GoDebugSession extends DebugSession {
 			verbose('next state', state);
 			this.debugState = state;
 			this.sendResponse(response);
+			verbose('NextResponse');
 			this.handleReenterDebug('step');
 		});
-		verbose('NextResponse');
 	}
 
 	protected stepInRequest(response: DebugProtocol.StepInResponse): void {
@@ -1124,9 +1124,9 @@ class GoDebugSession extends DebugSession {
 			verbose('stop state', state);
 			this.debugState = state;
 			this.sendResponse(response);
+			verbose('StepInResponse');
 			this.handleReenterDebug('step');
 		});
-		verbose('StepInResponse');
 	}
 
 	protected stepOutRequest(response: DebugProtocol.StepOutResponse): void {
@@ -1139,9 +1139,9 @@ class GoDebugSession extends DebugSession {
 			verbose('stepout state', state);
 			this.debugState = state;
 			this.sendResponse(response);
+			verbose('StepOutResponse');
 			this.handleReenterDebug('step');
 		});
-		verbose('StepOutResponse');
 	}
 
 	protected pauseRequest(response: DebugProtocol.PauseResponse): void {


### PR DESCRIPTION
According to the spec you are first supposed to acknowledge the command and only than send the stopped event. Changing this seems to have fixed the jumping to `gopark`/`proc.go` for me. Please test that this works.

Debugging is still really slow, but that's a different issue, VS Code is simply requesting, and receiving, way too much information from delve on each step.

See: [Debug Adapter Protocol Specification - Next Request](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Next).

Possible fix for #2133