### PR TITLE
optimize godef-gomod cache, better support one workspace for multi go…

### DIFF
--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -53,7 +53,7 @@ export function definitionLocation(document: vscode.TextDocument, position: vsco
 				position,
 				word,
 				includeDocs,
-				isMod: modPath != "",
+				isMod: modPath !== '',
 				modPath,
 			};
 			if (toolForDocs === 'godoc' || (ver && (ver.major < 1 || (ver.major === 1 && ver.minor < 6)))) {
@@ -94,9 +94,9 @@ function definitionLocation_godef(input: GoDefinitionInput, token: vscode.Cancel
 		token.onCancellationRequested(() => killProcess(p));
 	}
 
-	let cwd: string
+	let cwd: string;
 	if (input.isMod) {
-		cwd = input.modPath
+		cwd = input.modPath;
 	} else {
 		cwd = getWorkspaceFolderPath(input.document.uri);
 	}

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -155,6 +155,9 @@ function definitionLocation_godef(input: GoDefinitionInput, token: vscode.Cancel
 				reject(e);
 			}
 		});
+		if (p.pid) {
+			p.stdin.end(input.document.getText());
+		}
 	});
 }
 

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -22,12 +22,12 @@ export function getModPath(fileuri: vscode.Uri): Promise<string> {
 		return Promise.resolve(hit);
 	}
 
-	workspaceModCache.forEach((v, k) => {
+	for (let k of Array.from(workspaceModCache.keys())) {
 		if (folderPath.startsWith(k)) {
 			folderModCache.set(folderPath, k);
 			return Promise.resolve(k);
 		}
-	});
+	}
 
 	return getGoVersion().then(value => {
 		if (value && (value.major !== 1 || value.minor < 11)) {
@@ -40,9 +40,9 @@ export function getModPath(fileuri: vscode.Uri): Promise<string> {
 			if (!goExecutable) {
 				return Promise.reject(new Error('Cannot find "go" binary. Update PATH or GOROOT appropriately.'));
 			}
-			cp.execFile(goExecutable, ['env', 'GOMOD'], { cwd: folderPath, env: getToolsEnvVars() }, (err, stdout) => {
+			cp.execFile(goExecutable, ['list', '-m', '-f', '{{.GoMod}}'], { cwd: folderPath, env: getToolsEnvVars() }, (err, stdout) => {
 				if (err) {
-					console.warn(`Error when running go env GOMOD: ${err}`);
+					console.warn(`Error when running go list -m -f {{.GoMod}}: ${err}`);
 					resolve('');
 				}
 				let [goMod] = stdout.split('\n');

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -10,65 +10,65 @@ const folderModCache = new Map<string, string>();
 
 export function isModSupported(fileuri: vscode.Uri): Promise<boolean> {
 	return getModPath(fileuri).then(modPath => {
-		return modPath != ""
-	})
+		return modPath !== '';
+	});
 }
 
 export function getModPath(fileuri: vscode.Uri): Promise<string> {
-	const folderPath = path.dirname(fileuri.fsPath)
+	const folderPath = path.dirname(fileuri.fsPath);
 
-	const hit = folderModCache.get(folderPath)
-	if (hit != undefined) {
-		return Promise.resolve(hit)
+	const hit = folderModCache.get(folderPath);
+	if (hit !== undefined) {
+		return Promise.resolve(hit);
 	}
 
 	workspaceModCache.forEach((v, k) => {
 		if (folderPath.startsWith(k)) {
-			folderModCache.set(folderPath, k)
-			return Promise.resolve(k)
+			folderModCache.set(folderPath, k);
+			return Promise.resolve(k);
 		}
-	})
+	});
 
 	return getGoVersion().then(value => {
 		if (value && (value.major !== 1 || value.minor < 11)) {
-			folderModCache.set(folderPath, "")
-			return ""
+			folderModCache.set(folderPath, '');
+			return '';
 		}
 
 		return new Promise<string>(resolve => {
-			let goExecutable = getBinPath('go')
+			let goExecutable = getBinPath('go');
 			if (!goExecutable) {
-				return Promise.reject(new Error('Cannot find "go" binary. Update PATH or GOROOT appropriately.'))
+				return Promise.reject(new Error('Cannot find "go" binary. Update PATH or GOROOT appropriately.'));
 			}
 			cp.execFile(goExecutable, ['env', 'GOMOD'], { cwd: folderPath, env: getToolsEnvVars() }, (err, stdout) => {
 				if (err) {
-					console.warn(`Error when running go env GOMOD: ${err}`)
-					resolve("")
+					console.warn(`Error when running go env GOMOD: ${err}`);
+					resolve('');
 				}
-				let [goMod] = stdout.split('\n')
-				resolve(goMod)
+				let [goMod] = stdout.split('\n');
+				resolve(goMod);
 			});
 		}).then(result => {
-			let modPath: string
-			if (result != "") {
-				const goConfig = vscode.workspace.getConfiguration('go', fileuri)
+			let modPath: string;
+			if (result !== '') {
+				const goConfig = vscode.workspace.getConfiguration('go', fileuri);
 				if (goConfig['inferGopath'] === true) {
-					goConfig.update('inferGopath', false, vscode.ConfigurationTarget.WorkspaceFolder)
-					alertDisablingInferGopath()
+					goConfig.update('inferGopath', false, vscode.ConfigurationTarget.WorkspaceFolder);
+					alertDisablingInferGopath();
 				}
-				logModuleUsage(true)
-				modPath = path.dirname(result)
-				workspaceModCache.set(modPath, true)
+				logModuleUsage(true);
+				modPath = path.dirname(result);
+				workspaceModCache.set(modPath, true);
 			} else {
-				modPath = ""
+				modPath = '';
 			}
 
-			folderModCache.set(folderPath, modPath)
-			return modPath
-		})
+			folderModCache.set(folderPath, modPath);
+			return modPath;
+		});
 	}).catch(() => {
-		return ""
-	})
+		return '';
+	});
 }
 
 export function updateWorkspaceModCache() {
@@ -76,9 +76,9 @@ export function updateWorkspaceModCache() {
 		return;
 	}
 	const promises = vscode.workspace.workspaceFolders.map(folder => {
-		return getModPath(folder.uri)
+		return getModPath(folder.uri);
 	});
-	Promise.all(promises)
+	Promise.all(promises);
 }
 
 function alertDisablingInferGopath() {

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -42,7 +42,6 @@ export function getModPath(fileuri: vscode.Uri): Promise<string> {
 			}
 			cp.execFile(goExecutable, ['list', '-m', '-f', '{{.GoMod}}'], { cwd: folderPath, env: getToolsEnvVars() }, (err, stdout) => {
 				if (err) {
-					console.warn(`Error when running go list -m -f {{.GoMod}}: ${err}`);
 					resolve('');
 				}
 				let [goMod] = stdout.split('\n');


### PR DESCRIPTION
see this [issue](https://github.com/Microsoft/vscode-go/issues/2222)

**ChangeLog**
1. Now workspaceModCache stands for a workspace's `go.mod`'s path.
2. Rm pkgModCache, use folderModCache instead.
3. Add function `getModPath` to detect file's mod path. If `getModPath` returns none empty string, then `isModSupported` returns true.

**Known Problems**
1. If you are working with GO111MODULE projects and legacy GOPATH projects at the same time, you'd better set GO111MODULE to `auto`. Because we use `go env GOMOD` to find `go.mod`, if may fail when you're under GOPATH project.
2. Godef for gomod is slower than expect now.






