### PR TITLE
Revert "Attempt to fix the debugger jumping to gopark (#2207)"

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1090,10 +1090,10 @@ class GoDebugSession extends LoggingDebugSession {
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('continue state', state);
 			this.debugState = state;
-			this.sendResponse(response);
-			verbose('ContinueResponse');
 			this.handleReenterDebug('breakpoint');
 		});
+		this.sendResponse(response);
+		verbose('ContinueResponse');
 	}
 
 	protected nextRequest(response: DebugProtocol.NextResponse): void {
@@ -1105,10 +1105,10 @@ class GoDebugSession extends LoggingDebugSession {
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('next state', state);
 			this.debugState = state;
-			this.sendResponse(response);
-			verbose('NextResponse');
 			this.handleReenterDebug('step');
 		});
+		this.sendResponse(response);
+		verbose('NextResponse');
 	}
 
 	protected stepInRequest(response: DebugProtocol.StepInResponse): void {
@@ -1120,10 +1120,10 @@ class GoDebugSession extends LoggingDebugSession {
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('stop state', state);
 			this.debugState = state;
-			this.sendResponse(response);
-			verbose('StepInResponse');
 			this.handleReenterDebug('step');
 		});
+		this.sendResponse(response);
+		verbose('StepInResponse');
 	}
 
 	protected stepOutRequest(response: DebugProtocol.StepOutResponse): void {
@@ -1135,10 +1135,10 @@ class GoDebugSession extends LoggingDebugSession {
 			const state = this.delve.isApiV1 ? <DebuggerState>out : (<CommandOut>out).State;
 			verbose('stepout state', state);
 			this.debugState = state;
-			this.sendResponse(response);
-			verbose('StepOutResponse');
 			this.handleReenterDebug('step');
 		});
+		this.sendResponse(response);
+		verbose('StepOutResponse');
 	}
 
 	protected pauseRequest(response: DebugProtocol.PauseResponse): void {


### PR DESCRIPTION
Whoops, vscode-go was actually already sending the response first. This PR was wrong and should be reverted. It probably caused the gopark issue to happen less because VS Code got stuck on the continue/next/etc taking a long time waiting for the actual break to happen.

This reverts commit 456fdab49f3e211ddb310c1abb4443c5dadd6c0f.

@ramya-rao-a 