### PR TITLE
Expand functionality of `fileExists` function with executable check

### DIFF
--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -90,7 +90,7 @@ function fileExists(filePath: string): boolean {
 	let flag = true;
 	try {
 		fs.accessSync(filePath, fs.constants.F_OK | fs.constants.X_OK);
-	}	catch	(e)	{
+	} catch (e) {
 		flag = false;
 	}
 	return flag;

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -87,11 +87,13 @@ function correctBinname(toolName: string) {
 }
 
 function fileExists(filePath: string): boolean {
+	let flag = true;
 	try {
-		return fs.statSync(filePath).isFile();
-	} catch (e) {
-		return false;
+		fs.accessSync(filePath, fs.constants.F_OK | fs.constants.X_OK);
+	}	catch	(e)	{
+		flag = false;
 	}
+	return flag;
 }
 
 export function clearCacheForTools() {


### PR DESCRIPTION
- Updates the `fileExists` function to do the additional executable check via [fs.accessSync](https://nodejs.org/docs/latest-v7.x/api/fs.html#fs_fs_accesssync_path_mode) using Node's [file access constants](https://nodejs.org/api/fs.html#fs_file_access_constants).

Potential fix for #2220