### PR TITLE
Fix display of shadowed variables while debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,7 @@ install:
   - go get -u -v github.com/cweill/gotests/...
   - go get -u -v github.com/haya14busa/goplay/cmd/goplay
   - go get -u -v github.com/davidrjenni/reftools/cmd/fillstruct
-  - go get -u -v github.com/alecthomas/gometalinter
-  - gometalinter --install
+  - curl -fsSL https://git.io/vp6lP | sh -s -- -b $GOPATH/bin
 
 script:
   - npm run lint

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -45,14 +45,6 @@ enum GoReflectKind {
 	UnsafePointer
 }
 
-enum GoVariableFlags {
-	VariableEscaped = 1,
-	VariableShadowed = 2,
-	VariableConstant = 4,
-	VariableArgument = 8,
-	VariableReturnArgument = 16
-}
-
 // These types should stay in sync with:
 // https://github.com/derekparker/delve/blob/master/service/api/types.go
 
@@ -149,6 +141,14 @@ interface ListFunctionArgsOut {
 
 interface EvalOut {
 	Variable: DebugVariable;
+}
+
+enum GoVariableFlags {
+	VariableEscaped = 1,
+	VariableShadowed = 2,
+	VariableConstant = 4,
+	VariableArgument = 8,
+	VariableReturnArgument = 16
 }
 
 interface DebugVariable {


### PR DESCRIPTION
Ensure that shadowed variables have a unique name so they are properly
displayed in the variables pane.  Each nested scope will enclose the
variable name in a pair of parentheses.