### PR TITLE
Use folder containing go.mod file as cwd when running godef, gogetdoc, go doc

### DIFF
--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -54,7 +54,7 @@ export function definitionLocation(document: vscode.TextDocument, position: vsco
 				word,
 				includeDocs,
 				isMod: !!modFolderPath,
-				cwd: (modFolderPath && modFolderPath !== getModuleCache()) 
+				cwd: (modFolderPath && modFolderPath !== getModuleCache())
 				? modFolderPath : (getWorkspaceFolderPath(document.uri) || path.dirname(document.fileName))
 			};
 			if (toolForDocs === 'godoc' || (ver && (ver.major < 1 || (ver.major === 1 && ver.minor < 6)))) {

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -54,7 +54,8 @@ export function definitionLocation(document: vscode.TextDocument, position: vsco
 				word,
 				includeDocs,
 				isMod: !!modFolderPath,
-				cwd: (modFolderPath && modFolderPath !== getModuleCache()) ? modFolderPath : getWorkspaceFolderPath(document.uri)
+				cwd: (modFolderPath && modFolderPath !== getModuleCache()) 
+				? modFolderPath : (getWorkspaceFolderPath(document.uri) || path.dirname(document.fileName))
 			};
 			if (toolForDocs === 'godoc' || (ver && (ver.major < 1 || (ver.major === 1 && ver.minor < 6)))) {
 				return definitionLocation_godef(input, token);

--- a/src/goDeclaration.ts
+++ b/src/goDeclaration.ts
@@ -136,7 +136,7 @@ function definitionLocation_godef(input: GoDefinitionInput, token: vscode.Cancel
 					return resolve(definitionInformation);
 				}
 				match = /^\w+ \(\*?(\w+)\)/.exec(lines[1]);
-				runGodoc(pkgPath, match ? match[1] : '', input.word, token).then(doc => {
+				runGodoc(input.cwd, pkgPath, match ? match[1] : '', input.word, token).then(doc => {
 					if (doc) {
 						definitionInformation.doc = doc;
 					}

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -52,7 +52,6 @@ import { lintCode } from './goLint';
 import { vetCode } from './goVet';
 import { buildCode } from './goBuild';
 import { installCurrentPackage } from './goInstall';
-import { updateWorkspaceModCache } from './goModules';
 import { setGlobalState } from './stateUtils';
 import { ProvideTypeDefinitionSignature } from 'vscode-languageclient/lib/typeDefinition';
 import { ProvideImplementationSignature } from 'vscode-languageclient/lib/implementation';
@@ -66,7 +65,6 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	setGlobalState(ctx.globalState);
 
 	updateGoPathGoRootFromConfig().then(() => {
-		updateWorkspaceModCache();
 		const updateToolsCmdText = 'Update tools';
 		const prevGoroot = ctx.globalState.get('goroot');
 		const currentGoroot = process.env['GOROOT'];
@@ -289,11 +287,6 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	vscode.window.onDidChangeActiveTextEditor(applyCodeCoverage, null, ctx.subscriptions);
 	vscode.workspace.onDidChangeTextDocument(parseLiveFile, null, ctx.subscriptions);
 	vscode.workspace.onDidChangeTextDocument(notifyIfGeneratedFile, ctx, ctx.subscriptions);
-	vscode.workspace.onDidChangeWorkspaceFolders(e => {
-		if (e.added.length) {
-			updateWorkspaceModCache();
-		}
-	});
 	startBuildOnSaveWatcher(ctx.subscriptions);
 
 	ctx.subscriptions.push(vscode.commands.registerCommand('go.gopath', () => {

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -1,11 +1,12 @@
-import { getBinPath, getGoVersion, sendTelemetryEvent, getToolsEnvVars, getCurrentGoPath } from './util';
+import { getBinPath, getGoVersion, getToolsEnvVars, getModuleCache } from './util';
 import path = require('path');
 import cp = require('child_process');
 import vscode = require('vscode');
 import { getFromGlobalState, updateGlobalState } from './stateUtils';
 import { installTools } from './goInstallTools';
+import { fixDriveCasingInWindows } from './goPath';
 
-function containsModFile(folderPath: string): Promise<boolean> {
+function runGoModEnv(folderPath: string): Promise<string> {
 	let goExecutable = getBinPath('go');
 	if (!goExecutable) {
 		return Promise.reject(new Error('Cannot find "go" binary. Update PATH or GOROOT appropriately.'));
@@ -14,96 +15,54 @@ function containsModFile(folderPath: string): Promise<boolean> {
 		cp.execFile(goExecutable, ['env', 'GOMOD'], { cwd: folderPath, env: getToolsEnvVars() }, (err, stdout) => {
 			if (err) {
 				console.warn(`Error when running go env GOMOD: ${err}`);
-				return resolve(false);
+				return resolve();
 			}
 			let [goMod] = stdout.split('\n');
-			resolve(!!goMod);
+			resolve(goMod);
 		});
 	});
 }
-const workspaceModCache = new Map<string, boolean>();
-const packageModCache = new Map<string, boolean>();
 
 export function isModSupported(fileuri: vscode.Uri): Promise<boolean> {
+	return getModFolderPath(fileuri).then(modPath => !!modPath);
+}
+
+const packageModCache = new Map<string, string>();
+export function getModFolderPath(fileuri: vscode.Uri): Promise<string> {
+	// We never would be using the path under module cache for anything
+	// So, dont bother finding where exactly is the go.mod file
+	const moduleCache = getModuleCache();
+	if (fixDriveCasingInWindows(fileuri.fsPath).startsWith(moduleCache)) {
+		return Promise.resolve(moduleCache);
+	}
+
 	return getGoVersion().then(value => {
 		if (value && (value.major !== 1 || value.minor < 11)) {
-			return false;
+			return;
 		}
 
-		const workspaceFolder = vscode.workspace.getWorkspaceFolder(fileuri);
-		if (workspaceFolder && workspaceModCache.get(workspaceFolder.uri.fsPath)) {
-			return true;
-		}
 		const pkgPath = path.dirname(fileuri.fsPath);
-		if (packageModCache.get(pkgPath)) {
-			if (workspaceFolder && pkgPath === workspaceFolder.uri.fsPath) {
-				workspaceModCache.set(workspaceFolder.uri.fsPath, true);
-				logModuleUsage(true);
-			} else {
-				logModuleUsage(false);
-			}
-			return true;
+		if (packageModCache.has(pkgPath)) {
+			return packageModCache.get(pkgPath);
 		}
-		return containsModFile(pkgPath).then(result => {
-			packageModCache.set(pkgPath, result);
+		return runGoModEnv(pkgPath).then(result => {
 			if (result) {
+				result = path.dirname(result);
 				const goConfig = vscode.workspace.getConfiguration('go', fileuri);
 				if (goConfig['inferGopath'] === true) {
 					goConfig.update('inferGopath', false, vscode.ConfigurationTarget.WorkspaceFolder);
 					alertDisablingInferGopath();
 				}
-			} else {
-				let currentGopath = getCurrentGoPath();
-				if (currentGopath) {
-					currentGopath = currentGopath.split(path.delimiter)[0];
-					if (fileuri.fsPath.startsWith(path.join(currentGopath, 'pkg', 'mod'))) {
-						return true;
-					}
-				}
 			}
+			packageModCache.set(pkgPath, result);
 			return result;
 		});
 	});
 }
 
-export function updateWorkspaceModCache() {
-	if (!vscode.workspace.workspaceFolders) {
-		return;
-	}
-	let inferGopathUpdated = false;
-	const promises = vscode.workspace.workspaceFolders.map(folder => {
-		return containsModFile(folder.uri.fsPath).then(result => {
-			workspaceModCache.set(folder.uri.fsPath, result);
-			if (result) {
-				logModuleUsage(true);
-				const goConfig = vscode.workspace.getConfiguration('go', folder.uri);
-				if (goConfig['inferGopath'] === true) {
-					return goConfig.update('inferGopath', false, vscode.ConfigurationTarget.WorkspaceFolder)
-						.then(() => inferGopathUpdated = true);
-				}
-			}
-		});
-	});
-	Promise.all(promises).then(() => {
-		if (inferGopathUpdated) {
-			alertDisablingInferGopath();
-		}
-	});
-}
 
 function alertDisablingInferGopath() {
 	vscode.window.showInformationMessage('The "inferGopath" setting is disabled for this workspace because Go modules are being used.');
-}
-
-function logModuleUsage(atroot: boolean) {
-	/* __GDPR__
-		"modules" : {
-			"atroot" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-		}
-	*/
-	sendTelemetryEvent('modules', {
-		atroot: atroot ? 'true' : 'false'
-	});
 }
 
 const promptedToolsForCurrentSession = new Set<string>();

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -122,8 +122,14 @@ export function getCurrentPackage(cwd: string): Promise<string> {
 
 	const moduleCache = getModuleCache();
 	if (cwd.startsWith(moduleCache)) {
-		folderToPackageMapping[cwd] = cwd.substr(moduleCache.length+1);
-		return Promise.resolve(folderToPackageMapping[cwd]);
+		let importPath = cwd.substr(moduleCache.length + 1);
+		const matches = /@v\d+(\.\d+)?(\.\d+)?/.exec(importPath);
+		if (matches) {
+			importPath = importPath.substr(0, matches.index);
+		}
+
+		folderToPackageMapping[cwd] = importPath;
+		return Promise.resolve(importPath);
 	}
 
 	let goRuntimePath = getBinPath('go');

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -120,6 +120,12 @@ export function getCurrentPackage(cwd: string): Promise<string> {
 		return Promise.resolve(folderToPackageMapping[cwd]);
 	}
 
+	const moduleCache = getModuleCache();
+	if (cwd.startsWith(moduleCache)) {
+		folderToPackageMapping[cwd] = cwd.substr(moduleCache.length+1);
+		return Promise.resolve(folderToPackageMapping[cwd]);
+	}
+
 	let goRuntimePath = getBinPath('go');
 
 	if (!goRuntimePath) {

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -96,7 +96,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider, 
 			return;
 		}
 
-		return runGodoc(item.package || path.dirname(item.fileName), item.receiver, item.label, token).then(doc => {
+		return runGodoc(path.dirname(item.fileName), item.package || path.dirname(item.fileName), item.receiver, item.label, token).then(doc => {
 			item.documentation = new vscode.MarkdownString(doc);
 			return item;
 		}).catch(err => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -896,11 +896,12 @@ export function cleanupTempDir() {
 
 /**
  * Runs `go doc` to get documentation for given symbol
+ * @param cwd The cwd where the go doc process will be run
  * @param packagePath Either the absolute path or import path of the package.
  * @param symbol Symbol for which docs need to be found
  * @param token Cancellation token
  */
-export function runGodoc(packagePath: string, receiver: string, symbol: string, token: vscode.CancellationToken) {
+export function runGodoc(cwd: string, packagePath: string, receiver: string, symbol: string, token: vscode.CancellationToken) {
 	if (!packagePath) {
 		return Promise.reject(new Error('Package Path not provided'));
 	}
@@ -923,7 +924,7 @@ export function runGodoc(packagePath: string, receiver: string, symbol: string, 
 
 			const env = getToolsEnvVars();
 			const args = ['doc', '-c', '-cmd', '-u', packageImportPath, symbol];
-			const p = cp.execFile(goRuntimePath, args, { env }, (err, stdout, stderr) => {
+			const p = cp.execFile(goRuntimePath, args, { env, cwd }, (err, stdout, stderr) => {
 				if (err) {
 					return reject(err.message || stderr);
 				}

--- a/src/util.ts
+++ b/src/util.ts
@@ -415,6 +415,7 @@ export function substituteEnv(input: string): string {
 	});
 }
 
+let currentGopath = '';
 export function getCurrentGoPath(workspaceUri?: vscode.Uri): string {
 	let currentFilePath: string;
 	if (vscode.window.activeTextEditor && vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri)) {
@@ -451,7 +452,14 @@ export function getCurrentGoPath(workspaceUri?: vscode.Uri): string {
 	}
 
 	let configGopath = config['gopath'] ? resolvePath(substituteEnv(config['gopath']), currentRoot) : '';
-	return inferredGopath ? inferredGopath : (configGopath || process.env['GOPATH']);
+	currentGopath = inferredGopath ? inferredGopath : (configGopath || process.env['GOPATH']);
+	return currentGopath;
+}
+
+export function getModuleCache(): string {
+	if (currentGopath) {
+		return path.join(currentGopath.split(path.delimiter)[0], 'pkg', 'mod');
+	}
 }
 
 export function getExtensionCommands(): any[] {


### PR DESCRIPTION
Right now, we use the workspace folder as cwd when running godef and gogetdoc for the Go to definition feature. 

This might not be performant if the workspace folder is much higher than where the go.mod file is
This might not give accurate results in case of sub modules

Also, when running `go doc` to get the documentation to show on hover, we don't set any working directory at all. This results in getting no documentation for symbols in the same package.

This PR updates the code that runs `godef`, `gogetdoc` and `go doc` to use the folder corresponding to the right go.mod file as cwd
When operating on files under the module cache, we use the workspace folder as before

Not using the right package import path for packages in module cache, results in no documentation to show on hover for their symbols too. So we update the `getCurrentPackage` function to return the right import path for such packages.


Fixes #2180, #2244 and possibly #2222