### PR TITLE
Updated the dlv repository link

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -39,7 +39,7 @@ const _allTools: { [key: string]: string } = {
 	'golangci-lint': 'github.com/golangci/golangci-lint/cmd/golangci-lint',
 	'revive': 'github.com/mgechev/revive',
 	'go-langserver': 'github.com/sourcegraph/go-langserver',
-	'dlv': 'github.com/derekparker/delve/cmd/dlv',
+	'dlv': 'github.com/go-delve/delve/cmd/dlv',
 	'fillstruct': 'github.com/davidrjenni/reftools/cmd/fillstruct',
 };
 


### PR DESCRIPTION
Seems like the repository link of `dlv` has changed and the plugin is unable to download it, this should fix it, probably. :smile: 