### PR TITLE
Cache results of 'go list' when fetching package info to get package variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -500,7 +500,7 @@
               },
               "showGlobalVariables": {
                 "type": "boolean",
-                "default": false,
+                "default": true,
                 "description": "Boolean value to indicate whether global package variables should be shown in the variables pane or not."
               }
             }

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1026,7 +1026,9 @@ class GoDebugSession extends LoggingDebugSession {
 					return resolve();
 				}
 				const spaceIndex = stdout.indexOf(' ');
-				resolve(stdout.substr(0, spaceIndex) === 'main' ? 'main' : stdout.substr(spaceIndex).trim());
+				const result = stdout.substr(0, spaceIndex) === 'main' ? 'main' : stdout.substr(spaceIndex).trim();
+				this.packageInfo.set(dir, result);
+				resolve(result);
 			});
 		});
 	}

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -557,7 +557,7 @@ class GoDebugSession extends LoggingDebugSession {
 	private logLevel: Logger.LogLevel = Logger.LogLevel.Error;
 	private readonly initdone = 'initdone·';
 
-	private showGlobalVariables: boolean = false;
+	private showGlobalVariables: boolean = true;
 	public constructor(debuggerLinesStartAt1: boolean, isServer: boolean = false) {
 		super('', debuggerLinesStartAt1, isServer);
 		this._variableHandles = new Handles<DebugVariable>();


### PR DESCRIPTION
The 'go list' command is expensive so the result should be cached.
There was a cache in place but it wasn't being populated.