### PR TITLE
Fix default value for showGlobalVariables

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -592,7 +592,9 @@ class GoDebugSession extends LoggingDebugSession {
 		const logPath = this.logLevel !== Logger.LogLevel.Error ? path.join(os.tmpdir(), 'vscode-go-debug.txt') : undefined;
 		logger.setup(this.logLevel, logPath);
 
-		this.showGlobalVariables = args.showGlobalVariables === true;
+		if (typeof(args.showGlobalVariables) === 'boolean') {
+			this.showGlobalVariables = args.showGlobalVariables;
+		}
 
 		if (!args.program) {
 			this.sendErrorResponse(response, 3000, 'Failed to continue: The program attribute is missing in the debug configuration in launch.json');


### PR DESCRIPTION
Only read from args.showGlobalVariables if it has a boolean value.