### PR TITLE
Set presentation.reveal=never for the watch task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,9 +17,9 @@
 	// the command is a shell script
 	"type": "shell",
 
-	// show the output window only if unrecognized errors occur.
+	// don't show the output window, rely on the problem matcher.
 	"presentation": {
-		"reveal": "silent"
+		"reveal": "never"
 	},
 
 	// we run the custom script "compile" as defined in package.json


### PR DESCRIPTION
`presentation.reveal=silent` shows the console on any error, this is annoying for a watch task that runs in the background.

This is a default for newly generated VS Code extension projects: [Microsoft/vscode-generator-code/generators/app/templates/ext-command-ts/vscode/tasks.json](https://github.com/Microsoft/vscode-generator-code/blob/6a062e042b5d02ea17810cb8e9d7ecbe09f71ad0/generators/app/templates/ext-command-ts/vscode/tasks.json).