### PR TITLE
Expand nested content only for non array, maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
     * Use unique stack frame ids to be compliant with Debug Adapter Protocol. [PR 2130](https://github.com/Microsoft/vscode-go/pull/2130)
 
 * [Joel Hendrix (@jhendrixMSFT)](https://github.com/jhendrixMSFT)
-    * Display nested content in variables pane. Fixes [Bug 1010](https://github.com/Microsoft/vscode-go/issues/1010) with [PR 2198](https://github.com/Microsoft/vscode-go/pull/2198)
+    * Display nested content of structs in variables pane. Fixes [Bug 1010](https://github.com/Microsoft/vscode-go/issues/1010) with [PR 2198](https://github.com/Microsoft/vscode-go/pull/2198)
     * Display shadowed variables in variables pane. Fixes [Bug 1974](https://github.com/Microsoft/vscode-go/issues/1974) with [PR 2254](https://github.com/Microsoft/vscode-go/pull/2254)
 
 * [Segev Finer (@segevfiner)](https://github.com/segevfiner) 

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -592,7 +592,7 @@ class GoDebugSession extends LoggingDebugSession {
 		const logPath = this.logLevel !== Logger.LogLevel.Error ? path.join(os.tmpdir(), 'vscode-go-debug.txt') : undefined;
 		logger.setup(this.logLevel, logPath);
 
-		if (typeof(args.showGlobalVariables) === 'boolean') {
+		if (typeof (args.showGlobalVariables) === 'boolean') {
 			this.showGlobalVariables = args.showGlobalVariables;
 		}
 
@@ -1103,8 +1103,7 @@ class GoDebugSession extends LoggingDebugSession {
 		let variablesPromise: Promise<DebugProtocol.Variable[]>;
 		const loadChildren = async (exp: string, v: DebugVariable) => {
 			// from https://github.com/go-delve/delve/blob/master/Documentation/api/ClientHowto.md#looking-into-variables
-			if (((v.kind === GoReflectKind.Array || v.kind === GoReflectKind.Slice || v.kind === GoReflectKind.Struct) && v.len > v.children.length) ||
-				(v.kind === GoReflectKind.Map && v.len > v.children.length / 2) ||
+			if ((v.kind === GoReflectKind.Struct && v.len > v.children.length) ||
 				(v.kind === GoReflectKind.Interface && v.children.length > 0 && v.children[0].onlyAddr === true)) {
 				await this.evaluateRequestImpl({ 'expression': exp }).then(result => {
 					const variable = this.delve.isApiV1 ? <DebugVariable>result : (<EvalOut>result).Variable;
@@ -1115,16 +1114,16 @@ class GoDebugSession extends LoggingDebugSession {
 		// expressions passed to loadChildren defined per https://github.com/derekparker/delve/blob/master/Documentation/api/ClientHowto.md#loading-more-of-a-variable
 		if (vari.kind === GoReflectKind.Array || vari.kind === GoReflectKind.Slice) {
 			variablesPromise = Promise.all(vari.children.map((v, i) => {
-					return loadChildren(`*(*${this.removeRepoFromTypeName(v.type)})(${v.addr})`, v).then((): DebugProtocol.Variable => {
-						let { result, variablesReference } = this.convertDebugVariableToProtocolVariable(v);
-						return {
-							name: '[' + i + ']',
-							value: result,
-							evaluateName: vari.fullyQualifiedName + '[' + i + ']',
-							variablesReference
-						};
-					});
-				})
+				return loadChildren(`*(*${this.removeRepoFromTypeName(v.type)})(${v.addr})`, v).then((): DebugProtocol.Variable => {
+					let { result, variablesReference } = this.convertDebugVariableToProtocolVariable(v);
+					return {
+						name: '[' + i + ']',
+						value: result,
+						evaluateName: vari.fullyQualifiedName + '[' + i + ']',
+						variablesReference
+					};
+				});
+			})
 			);
 		} else if (vari.kind === GoReflectKind.Map) {
 			variablesPromise = Promise.all(vari.children.map((_, i) => {
@@ -1339,13 +1338,13 @@ class GoDebugSession extends LoggingDebugSession {
 				Expr: args.expression,
 				Scope: scope,
 				Cfg: this.delve.loadConfig
-		};
+			};
 		const returnValue = this.delve.callPromise<EvalOut | DebugVariable>(this.delve.isApiV1 ? 'EvalSymbol' : 'Eval', [evalSymbolArgs]).then(val => val,
-		err => {
-			logError('Failed to eval expression: ', JSON.stringify(evalSymbolArgs, null, ' '), '\n\rEval error:', err.toString());
-			return Promise.reject(err);
-		});
-		return  returnValue;
+			err => {
+				logError('Failed to eval expression: ', JSON.stringify(evalSymbolArgs, null, ' '), '\n\rEval error:', err.toString());
+				return Promise.reject(err);
+			});
+		return returnValue;
 	}
 
 	protected setVariableRequest(response: DebugProtocol.SetVariableResponse, args: DebugProtocol.SetVariableArguments): void {


### PR DESCRIPTION
Delve doesn't load strings or arrays or slices whose length is greater than 64. This value can be changed by using the setting `dlvLoadConfig` whose default values are as follows

```
	"go.delveConfig": {
		"dlvLoadConfig": {
			"followPointers": true,
			"maxVariableRecurse": 1,
			"maxStringLen": 64,
			"maxArrayValues": 64,
			"maxStructFields": -1
		}
	}
```

In https://github.com/Microsoft/vscode-go/pull/2198, we added the ability to expand nested content in the variables pane to fix https://github.com/Microsoft/vscode-go/issues/1010.

But while providing the feature to expand nested content, we also ended up expanding arrays and strings that have length > 64 if the said arrays/strings are children of one of the variable.

This PR restricts such expansion to just structs and interfaces




