### PR TITLE
Fix crash in start without debugging scenario

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -493,6 +493,10 @@ class Delve {
 	}
 
 	close(): Thenable<void> {
+		if (this.noDebug) {
+			// delve isn't running so no need to halt
+			return Promise.resolve();
+		}
 		log('HaltRequest');
 
 		return new Promise(resolve => {


### PR DESCRIPTION
In CTRL-F5 scenario delve isn't running so don't try to halt it.