### PR TITLE
use TS from dependencies when running in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
 		"**/bower_components": true,
 		"out/": true
 	},
-	"editor.insertSpaces": false
+	"editor.insertSpaces": false,
+	"typescript.tsdk": "node_modules\\typescript\\lib"
 }


### PR DESCRIPTION
- when opening the project in VsCode, use TS that is brought in as a dependency since that is what it will build it