### PR TITLE
 Fix expression name mapping on debug views

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1157,7 +1157,7 @@ class GoDebugSession extends LoggingDebugSession {
 		} else {
 			variablesPromise = Promise.all(vari.children.map((v) => {
 				if (v.fullyQualifiedName === undefined) {
-					v.fullyQualifiedName = vari.name + '.' + v.name;
+					v.fullyQualifiedName = vari.fullyQualifiedName + '.' + v.name;
 				}
 				return loadChildren(`*(*"${v.type}")(${v.addr})`, v).then((): DebugProtocol.Variable => {
 					let { result, variablesReference } = this.convertDebugVariableToProtocolVariable(v);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -938,7 +938,7 @@ class GoDebugSession extends LoggingDebugSession {
 					}
 				}
 				let scopes = new Array<Scope>();
-				let localVariables = {
+				let localVariables: DebugVariable = {
 					name: 'Local',
 					addr: 0,
 					type: '',
@@ -989,7 +989,7 @@ class GoDebugSession extends LoggingDebugSession {
 						}
 						log('global vars', globals);
 
-						const globalVariables = {
+						const globalVariables: DebugVariable = {
 							name: 'Global',
 							addr: 0,
 							type: '',

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1117,10 +1117,14 @@ class GoDebugSession extends LoggingDebugSession {
 			variablesPromise = Promise.all(vari.children.map((v, i) => {
 				return loadChildren(`*(*${this.removeRepoFromTypeName(v.type)})(${v.addr})`, v).then((): DebugProtocol.Variable => {
 					let { result, variablesReference } = this.convertDebugVariableToProtocolVariable(v);
+					let fullName = vari.fullyQualifiedName;
+					if (vari.fullyQualifiedName === undefined) {
+						fullName = vari.name;
+					}
 					return {
 						name: '[' + i + ']',
 						value: result,
-						evaluateName: vari.fullyQualifiedName + '[' + i + ']',
+						evaluateName: fullName + '[' + i + ']',
 						variablesReference
 					};
 				});
@@ -1133,10 +1137,14 @@ class GoDebugSession extends LoggingDebugSession {
 					let mapKey = this.convertDebugVariableToProtocolVariable(vari.children[i]);
 					return loadChildren(`${vari.fullyQualifiedName}.${vari.name}[${mapKey.result}]`, vari.children[i + 1]).then(() => {
 						let mapValue = this.convertDebugVariableToProtocolVariable(vari.children[i + 1]);
+						let fullName = vari.fullyQualifiedName;
+						if (vari.fullyQualifiedName === undefined) {
+							fullName = vari.name;
+						}
 						return {
 							name: mapKey.result,
 							value: mapValue.result,
-							evaluateName: vari.fullyQualifiedName + '[' + mapKey.result + ']',
+							evaluateName: fullName + '[' + mapKey.result + ']',
 							variablesReference: mapValue.variablesReference
 						};
 					});
@@ -1340,6 +1348,11 @@ class GoDebugSession extends LoggingDebugSession {
 				Scope: scope,
 				Cfg: this.delve.loadConfig
 			};
+
+		// if (args.context === "Copy") {
+			
+		// }
+		
 		const returnValue = this.delve.callPromise<EvalOut | DebugVariable>(this.delve.isApiV1 ? 'EvalSymbol' : 'Eval', [evalSymbolArgs]).then(val => val,
 			err => {
 				logError('Failed to eval expression: ', JSON.stringify(evalSymbolArgs, null, ' '), '\n\rEval error:', err.toString());

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1157,7 +1157,7 @@ class GoDebugSession extends LoggingDebugSession {
 		} else {
 			variablesPromise = Promise.all(vari.children.map((v) => {
 				if (v.fullyQualifiedName === undefined) {
-					v.fullyQualifiedName = vari.fullyQualifiedName + '.' + v.name;
+					v.fullyQualifiedName = vari.name + '.' + v.name;
 				}
 				return loadChildren(`*(*"${v.type}")(${v.addr})`, v).then((): DebugProtocol.Variable => {
 					let { result, variablesReference } = this.convertDebugVariableToProtocolVariable(v);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1059,6 +1059,7 @@ class GoDebugSession extends LoggingDebugSession {
 				};
 			} else {
 				if (v.children[0].children.length > 0) {
+					// Generate correct fullyQualified names for variable expressions
 					v.children[0].fullyQualifiedName = v.fullyQualifiedName;
 					v.children[0].children.forEach(child => {
 						child.fullyQualifiedName = v.fullyQualifiedName + '.' + child.name;
@@ -1095,6 +1096,13 @@ class GoDebugSession extends LoggingDebugSession {
 				variablesReference: 0
 			};
 		} else {
+			// Default case - structs
+			if (v.children.length > 0) {
+				// Generate correct fullyQualified names for variable expressions
+				v.children.forEach(child => {
+					child.fullyQualifiedName = v.fullyQualifiedName + '.' + child.name;
+				});
+			}
 			return {
 				result: v.value || ('<' + v.type + '>'),
 				variablesReference: v.children.length > 0 ? this._variableHandles.create(v) : 0
@@ -1148,11 +1156,9 @@ class GoDebugSession extends LoggingDebugSession {
 			}));
 		} else {
 			variablesPromise = Promise.all(vari.children.map((v) => {
-				if (v.fullyQualifiedName === undefined) {
-					v.fullyQualifiedName = vari.fullyQualifiedName + '.' + v.name;
-				}
 				return loadChildren(`*(*"${v.type}")(${v.addr})`, v).then((): DebugProtocol.Variable => {
 					let { result, variablesReference } = this.convertDebugVariableToProtocolVariable(v);
+
 					return {
 						name: v.name,
 						value: result,

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1121,14 +1121,10 @@ class GoDebugSession extends LoggingDebugSession {
 			variablesPromise = Promise.all(vari.children.map((v, i) => {
 				return loadChildren(`*(*"${v.type}")(${v.addr})`, v).then((): DebugProtocol.Variable => {
 					let { result, variablesReference } = this.convertDebugVariableToProtocolVariable(v);
-					let fullName = vari.fullyQualifiedName;
-					if (vari.fullyQualifiedName === undefined) {
-						fullName = vari.name;
-					}
 					return {
 						name: '[' + i + ']',
 						value: result,
-						evaluateName: fullName + '[' + i + ']',
+						evaluateName: vari.fullyQualifiedName + '[' + i + ']',
 						variablesReference
 					};
 				});
@@ -1141,14 +1137,10 @@ class GoDebugSession extends LoggingDebugSession {
 					let mapKey = this.convertDebugVariableToProtocolVariable(vari.children[i]);
 					return loadChildren(`${vari.fullyQualifiedName}.${vari.name}[${mapKey.result}]`, vari.children[i + 1]).then(() => {
 						let mapValue = this.convertDebugVariableToProtocolVariable(vari.children[i + 1]);
-						let fullName = vari.fullyQualifiedName;
-						if (vari.fullyQualifiedName === undefined) {
-							fullName = vari.name;
-						}
 						return {
 							name: mapKey.result,
 							value: mapValue.result,
-							evaluateName: fullName + '[' + mapKey.result + ']',
+							evaluateName: vari.fullyQualifiedName + '[' + mapKey.result + ']',
 							variablesReference: mapValue.variablesReference
 						};
 					});
@@ -1314,6 +1306,8 @@ class GoDebugSession extends LoggingDebugSession {
 		log('EvaluateRequest');
 		this.evaluateRequestImpl(args).then(out => {
 			const variable = this.delve.isApiV1 ? <DebugVariable>out : (<EvalOut>out).Variable;
+			// #2326: Set the fully qualified name for variable mapping
+			variable.fullyQualifiedName = variable.name;
 			response.body = this.convertDebugVariableToProtocolVariable(variable);
 			this.sendResponse(response);
 			log('EvaluateResponse');

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1348,11 +1348,6 @@ class GoDebugSession extends LoggingDebugSession {
 				Scope: scope,
 				Cfg: this.delve.loadConfig
 			};
-
-		// if (args.context === "Copy") {
-			
-		// }
-		
 		const returnValue = this.delve.callPromise<EvalOut | DebugVariable>(this.delve.isApiV1 ? 'EvalSymbol' : 'Eval', [evalSymbolArgs]).then(val => val,
 			err => {
 				logError('Failed to eval expression: ', JSON.stringify(evalSymbolArgs, null, ' '), '\n\rEval error:', err.toString());


### PR DESCRIPTION
@ramya-rao-a PTAL. I found this while examining #2205
Maybe this was partially related to the issue @jhendrixMSFT saw on #2288

Repro code:
```go
package main

import "fmt"

func helloworld() string {
	return "Hello World!!"
}

func main() {
	a := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaasdeefea"
	b := []byte(a)
	m := map[string]int{"1": 1, "2": 2, "3": 3}
	fmt.Println(helloworld() + a + string(b) + fmt.Sprintf("%v", m))
}
```
Without these changes, the Copy Value action will fail on the watch view for all children of b and m

