### PR TITLE
fix: #2309 use goimports instead of goreturns when using modules

### DIFF
--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -21,10 +21,9 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 
 		let filename = document.fileName;
 		let goConfig = vscode.workspace.getConfiguration('go', document.uri);
-		let formatTool = goConfig['formatTool'] || 'goreturns';
 		let formatFlags = goConfig['formatFlags'].slice() || [];
 
-		this.getFormatTool(goConfig, document.uri)
+		return this.getFormatTool(goConfig, document.uri)
 		.then((formatTool) => {
 			// We ignore the -w flag that updates file on disk because that would break undo feature
 			if (formatFlags.indexOf('-w') > -1) {

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -8,6 +8,7 @@
 import vscode = require('vscode');
 import cp = require('child_process');
 import path = require('path');
+import { isModSupported } from './goModules';
 import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
 import { sendTelemetryEvent, getBinPath, getToolsEnvVars, killTree } from './util';
 
@@ -20,7 +21,7 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 
 		let filename = document.fileName;
 		let goConfig = vscode.workspace.getConfiguration('go', document.uri);
-		let formatTool = goConfig['formatTool'] || 'goreturns';
+		let formatTool = isModSupported(filename) ? 'goimports' : 'goreturns';
 		let formatFlags = goConfig['formatFlags'].slice() || [];
 
 		// We ignore the -w flag that updates file on disk because that would break undo feature


### PR DESCRIPTION
Closes #2309
* Updated `goFormat.ts` to use `goimports` if user's choice is `goreturns` in module mode