### PR TITLE
Added showGlobalVariables as a workspace level parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Go",
-  "version": "0.8.0",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1225,11 +1225,6 @@
                   "type": "number",
                   "description": "MaxStructFields is the maximum number of fields read from a struct, -1 will read all fields",
                   "default": -1
-                },
-                "showGlobalVariables": {
-                  "type": "boolean",
-                  "description": "Boolean value to indicate whether global package variables should be shown in the variables pane or not.",
-                  "default": true
                 }
               },
               "description": "LoadConfig describes to delve, how to load values from target's memory",
@@ -1238,8 +1233,7 @@
                 "maxVariableRecurse": 1,
                 "maxStringLen": 64,
                 "maxArrayValues": 64,
-                "maxStructFields": -1,
-                "showGlobalVariables": false
+                "maxStructFields": -1
               }
             },
             "apiVersion": {
@@ -1250,6 +1244,11 @@
               ],
               "description": "Delve Api Version to use. Default value is 2.",
               "default": 2
+            },
+            "showGlobalVariables": {
+              "type": "boolean",
+              "description": "Boolean value to indicate whether global package variables should be shown in the variables pane or not.",
+              "default": true
             }
           },
           "scope": "resource"

--- a/package.json
+++ b/package.json
@@ -1225,6 +1225,11 @@
                   "type": "number",
                   "description": "MaxStructFields is the maximum number of fields read from a struct, -1 will read all fields",
                   "default": -1
+                },
+                "showGlobalVariables": {
+                  "type": "boolean",
+                  "description": "Boolean value to indicate whether global package variables should be shown in the variables pane or not.",
+                  "default": true
                 }
               },
               "description": "LoadConfig describes to delve, how to load values from target's memory",
@@ -1233,7 +1238,8 @@
                 "maxVariableRecurse": 1,
                 "maxStringLen": 64,
                 "maxArrayValues": 64,
-                "maxStructFields": -1
+                "maxStructFields": -1,
+                "showGlobalVariables": false
               }
             },
             "apiVersion": {

--- a/package.json
+++ b/package.json
@@ -1251,6 +1251,18 @@
               "default": true
             }
           },
+          "default": {
+            "dlvLoadConfig": {
+              "followPointers": true,
+              "maxVariableRecurse": 1,
+              "maxStringLen": 64,
+              "maxArrayValues": 64,
+              "maxStructFields": -1
+            },
+            "apiVersion": 2,
+            "showGlobalVariables": true
+          },
+          "description": "Delve settings that applies to all debugging sessions. Debug configuration in the launch.json file will override these values.",
           "scope": "resource"
         },
         "go.alternateTools": {

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -562,7 +562,7 @@ class GoDebugSession extends LoggingDebugSession {
 	private logLevel: Logger.LogLevel = Logger.LogLevel.Error;
 	private readonly initdone = 'initdone·';
 
-	private showGlobalVariables: boolean = true;
+	private showGlobalVariables: boolean = false;
 	public constructor(debuggerLinesStartAt1: boolean, isServer: boolean = false) {
 		super('', debuggerLinesStartAt1, isServer);
 		this._variableHandles = new Handles<DebugVariable>();

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -79,6 +79,9 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 		if (!debugConfiguration.hasOwnProperty('dlvLoadConfig') && dlvConfig.hasOwnProperty('dlvLoadConfig')) {
 			debugConfiguration['dlvLoadConfig'] = dlvConfig['dlvLoadConfig'];
 		}
+		if (!debugConfiguration.hasOwnProperty('showGlobalVariables') && dlvConfig.hasOwnProperty('showGlobalVariables')) {
+			debugConfiguration['showGlobalVariables'] = dlvConfig['showGlobalVariables'];
+		}
 
 		debugConfiguration['dlvToolPath'] = getBinPath('dlv');
 		if (!path.isAbsolute(debugConfiguration['dlvToolPath'])) {


### PR DESCRIPTION
Before, this option was only available in `launch.json` but this PR makes `showGlobalVariables` as a workspace level setting so that things like the debug and run test actions can use this setting.