### PR TITLE
Changed swapped $2 and $0 position for anonymous go function snippet.

### DIFF
--- a/snippets/go.json
+++ b/snippets/go.json
@@ -197,7 +197,7 @@
 		},
 		"goroutine anonymous function": {
 			"prefix": "go",
-			"body": "go func($1) {\n\t$2\n}($0)",
+			"body": "go func($1) {\n\t$0\n}($2)",
 			"description": "Snippet for anonymous goroutine declaration"
 		},
 		"goroutine function": {


### PR DESCRIPTION
For anonymous go function (the snippet with the prefix "go") I think it will be more convenient if we end snippets in the body instead of the variable field. The function body is the largest of these 3 placeholders and will be in need of completion features more than any other. Therefore, I think, it is reasonable if we give it the $0 place.