### PR TITLE
Use gopls for language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,24 @@ The Go extension is ready to use on the get go. If you want to customize the fea
 
 ### Go Language Server (Experimental)
 
-The Go extension uses a host of Go tools to provide the various language features. An alternative is to use a single language server that provides the same feature.  
+The Go extension uses a host of [Go tools](https://github.com/Microsoft/vscode-go/wiki/Go-tools-that-the-Go-extension-depends-on) to provide the various language features. An alternative is to use a single language server that provides the same features.  
 
-Set `go.useLanguageServer` to `true` to use the Go language server from [Sourcegraph](https://github.com/sourcegraph/go-langserver) for features like Hover, Definition, Find All References, Signature Help, Go to Symbol in File and Workspace.
-* Since only a single language server is spun up for given VS Code instance, having multi-root setup where the folders have different GOPATH is not supported.
-* If set to true, you will be prompted to install the Go language server. Once installed, you will have to reload VS Code window. The language server will then be run by the Go extension in the background to provide services needed for the above mentioned features.
-* Every time you change the value of the setting `go.useLanguageServer`, you need to reload the VS Code window for it to take effect.
-* To collect traces, set `"go.languageServerFlags": ["-trace"]`
-* To collect errors from language server in a logfile, set `"go.languageServerFlags": ["-trace", "-logfile", "path to a text file that exists"]`
-* Use the new setting `go.languageServerExperimentalFeatures` to opt-in to try new features like Code Completion and Formatting from the language server that might not be feature complete yet. 
+Previously, we added support to use the [language server from Sourcegraph](https://github.com/sourcegraph/go-langserver). Since there is no
+active development for it anymore and because it doesn't support Go modules, we are now switching to use the [language server from Google](https://github.com/golang/go/wiki/gopls). 
+
+- If you are using the language server from Sourcegraph, you can continue to use it as long as you are not using Go modules.
+- Since the language server from Google provides much better support for Go modules, you will be prompted about it when the extension detects that you are working on a project that uses Go modules.
+- If you have never used language server before, and now opt to use it, you will be prompted to install and use the language server from Google.
+
+#### Settings to control the use of the Go language server
+
+Below are the settings you can use to control the use of the language server. You need to reload the VS Code window for any changes in these settings to take effect.
+
+- Set `go.useLanguageServer` to `true` to enable the use of language server
+- Use the setting `go.languageServerExperimentalFeatures` to control which features do you want to be powered by the language server.
+- Set `"go.languageServerFlags": ["-trace"]` to collect traces in the output panel. 
+- Set `"go.languageServerFlags": ["-trace", "-logfile", "path to a text file that exists"]` to collect traces in a log file.
+
 
 ### Linter
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ Below are the settings you can use to control the use of the language server. Yo
 - Set `"go.languageServerFlags": ["-trace"]` to collect traces in the output panel. 
 - Set `"go.languageServerFlags": ["-trace", "-logfile", "path to a text file that exists"]` to collect traces in a log file.
 
+#### Setting to change the language server being used
+
+If you want to try out other language servers, for example, [bingo](https://github.com/saibing/bingo), then install it and add the below setting
+```json
+"go.alternateTools": {
+  "gopls": "bingo"
+}
+```
+This will tell the Go extension to use `bingo` in place of `gopls`.
+
 
 ### Linter
 

--- a/package.json
+++ b/package.json
@@ -904,7 +904,7 @@
         "go.useLanguageServer": {
           "type": "boolean",
           "default": false,
-          "description": "Experimental: Use Go language server from Sourcegraph for Hover, Definition, Find All References, Signature Help, File Outline and Workspace Symbol features instead of tools like guru, godef, go-outline and go-symbol"
+          "description": "Experimental: Use Go language server from Google or Sourcegraph for Hover, Definition, Signature Help, Auto Completion and Formatting features instead of tools like godef, gocode and goreturns"
         },
         "go.languageServerFlags": {
           "type": "array",

--- a/package.json
+++ b/package.json
@@ -983,7 +983,7 @@
             "documentSymbols": true,
             "workspaceSymbols": true,
             "findReferences": true,
-            "diagnostics": true
+            "diagnostics": false
           },
           "description": "Use this setting to enable/disable experimental features from the language server."
         },

--- a/package.json
+++ b/package.json
@@ -963,6 +963,11 @@
               "type": "boolean",
               "default": false,
               "description": "If true, the language server will be used for the Go to Workspace Symbols feature."
+            },
+            "diagnostics": {
+              "type": "boolean",
+              "default": false,
+              "description": "If true, the language server will provide build, vet errors and the extension will ignore the `buildOnSave`, `vetOnSave` settings."
             }
           },
           "default": {
@@ -976,7 +981,8 @@
             "goToImplementation": true,
             "documentSymbols": true,
             "workspaceSymbols": true,
-            "findReferences": true
+            "findReferences": true,
+            "diagnostics": true
           },
           "description": "Use this setting to enable/disable experimental features from the language server."
         },

--- a/package.json
+++ b/package.json
@@ -966,8 +966,8 @@
             }
           },
           "default": {
-            "format": false,
-            "autoComplete": false,
+            "format": true,
+            "autoComplete": true,
             "rename": true,
             "goToDefinition": true,
             "hover": true,

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -65,6 +65,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 	}
 	const disableBuild = alternateLS === 'gopls' || (alternateLS === 'bingo'
 		&& languageServerFlags.indexOf('-diagnostics-style=none') === -1);
+	const disableVet = alternateLS === 'gopls';
 
 	if (!goRuntimePath) {
 		vscode.window.showInformationMessage('Cannot find "go" binary. Update PATH or GOROOT appropriately');
@@ -123,7 +124,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 			.then(errors => ({ diagnosticCollection: lintDiagnosticCollection, errors: errors })));
 	}
 
-	if (!!goConfig['vetOnSave'] && goConfig['vetOnSave'] !== 'off') {
+	if (!disableVet && !!goConfig['vetOnSave'] && goConfig['vetOnSave'] !== 'off') {
 		runningToolsPromises.push(goVet(fileUri, goConfig, goConfig['vetOnSave'] === 'workspace')
 			.then(errors => ({ diagnosticCollection: vetDiagnosticCollection, errors: errors })));
 	}

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -67,11 +67,13 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 		languageServerFlags = [];
 	}
 
+	// If diagnostics are enabled via a language server, then we disable running build or vet to avoid duplicate errors & warnings.
 	let disableBuild = languageServerOptions['diagnostics'] === true && (languageServerTool === 'gopls' || languageServerTool === 'bingo');
 	const disableVet = languageServerOptions['diagnostics'] === true && languageServerTool === 'gopls';
 
+	// Some bingo users have disabled diagnostics using the -diagnostics-style=none flag, so respect that choice
 	if (disableBuild && languageServerTool === 'bingo' && languageServerFlags.indexOf('-diagnostics-style=none') > -1) {
-		disableBuild = true;
+		disableBuild = false;
 	}
 
 	if (!goRuntimePath) {

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -10,12 +10,14 @@ import path = require('path');
 import { applyCodeCoverageToAllEditors } from './goCover';
 import { outputChannel, diagnosticsStatusBarItem } from './goStatus';
 import { goTest, TestConfig, getTestFlags } from './testUtils';
-import { ICheckResult, getBinPath, getTempFilePath, getAlternateLanguageServer } from './util';
+import { ICheckResult, getBinPath, getTempFilePath } from './util';
 import { goLint } from './goLint';
 import { goVet } from './goVet';
 import { goBuild } from './goBuild';
 import { isModSupported } from './goModules';
 import { buildDiagnosticCollection, lintDiagnosticCollection, vetDiagnosticCollection } from './goMain';
+import { getLanguageServerToolPath } from './goInstallTools';
+import { getToolFromToolPath } from './goPath';
 
 let statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 statusBarItem.command = 'go.test.showOutput';
@@ -58,14 +60,14 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 	let runningToolsPromises = [];
 	let cwd = path.dirname(fileUri.fsPath);
 	let goRuntimePath = getBinPath('go');
-	const alternateLS = getAlternateLanguageServer(goConfig);
+	const languageServerTool = getToolFromToolPath(getLanguageServerToolPath());
 	let languageServerFlags: string[] = goConfig.get('languageServerFlags');
 	if (!Array.isArray(languageServerFlags)) {
 		languageServerFlags = [];
 	}
-	const disableBuild = alternateLS === 'gopls' || (alternateLS === 'bingo'
+	const disableBuild = languageServerTool === 'gopls' || (languageServerTool === 'bingo'
 		&& languageServerFlags.indexOf('-diagnostics-style=none') === -1);
-	const disableVet = alternateLS === 'gopls';
+	const disableVet = languageServerTool === 'gopls';
 
 	if (!goRuntimePath) {
 		vscode.window.showInformationMessage('Cannot find "go" binary. Update PATH or GOROOT appropriately');

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -61,13 +61,18 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 	let cwd = path.dirname(fileUri.fsPath);
 	let goRuntimePath = getBinPath('go');
 	const languageServerTool = getToolFromToolPath(getLanguageServerToolPath());
+	const languageServerOptions: any = goConfig.get('languageServerExperimentalFeatures');
 	let languageServerFlags: string[] = goConfig.get('languageServerFlags');
 	if (!Array.isArray(languageServerFlags)) {
 		languageServerFlags = [];
 	}
-	const disableBuild = languageServerTool === 'gopls' || (languageServerTool === 'bingo'
-		&& languageServerFlags.indexOf('-diagnostics-style=none') === -1);
-	const disableVet = languageServerTool === 'gopls';
+
+	let disableBuild = languageServerOptions['diagnostics'] === true && (languageServerTool === 'gopls' || languageServerTool === 'bingo');
+	let disableVet = languageServerOptions['diagnostics'] === true && languageServerTool === 'gopls';
+
+	if (disableBuild && languageServerTool === 'bingo' && languageServerFlags.indexOf('-diagnostics-style=none') > -1) {
+		disableBuild = true;
+	}
 
 	if (!goRuntimePath) {
 		vscode.window.showInformationMessage('Cannot find "go" binary. Update PATH or GOROOT appropriately');

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -457,14 +457,16 @@ export function offerToInstallTools() {
 		const usingSourceGraph = getToolFromToolPath(getLanguageServerToolPath()) === 'go-langserver';
 		if (usingSourceGraph) {
 			const promptMsg = 'The language server from Sourcegraph is no longer under active development and it does not support Go modules as well. Please install and use the language server from Google or disable the use of language servers altogether.';
-			vscode.window.showInformationMessage(promptMsg, 'Install', 'Disable language server')
+			const disableLabel = 'Disable language server';
+			const installLabel = 'Install';
+			vscode.window.showInformationMessage(promptMsg, installLabel, disableLabel)
 				.then(selected => {
-					if (selected === 'Install') {
+					if (selected === installLabel) {
 						installTools(['gopls'], goVersion)
 							.then(() => {
 								vscode.window.showInformationMessage('Reload VS Code window to enable the use of Go language server');
 							});
-					} else if (selected === 'Disable language server') {
+					} else if (selected === disableLabel) {
 						const goConfig = vscode.workspace.getConfiguration('go');
 						const inspectLanguageServerSetting = goConfig.inspect('useLanguageServer');
 						if (inspectLanguageServerSetting.globalValue === true) {
@@ -522,7 +524,7 @@ function getMissingTools(goVersion: SemVersion): Promise<string[]> {
  * This supports the language servers from both Google and Sourcegraph with the
  * former getting a precedence over the latter
  */
-export function getLanguageServerToolPath(): string {
+export function getLanguageServerToolPath(): string | undefined {
 	const latestGoConfig = vscode.workspace.getConfiguration('go');
 	if (!latestGoConfig['useLanguageServer']) return;
 
@@ -537,7 +539,7 @@ export function getLanguageServerToolPath(): string {
 		return goplsBinaryPath;
 	}
 
-	// Get the path to go-langserver or any alternative that the user might have set for gopls
+	// Get the path to go-langserver or any alternative that the user might have set for go-langserver
 	const golangserverBinaryPath = getBinPath('go-langserver');
 	if (path.isAbsolute(golangserverBinaryPath)) {
 		return golangserverBinaryPath;

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -461,9 +461,9 @@ export function offerToInstallTools() {
 				.then(selected => {
 					if (selected === 'Install') {
 						installTools(['gopls'], goVersion)
-						.then(() => {
-							vscode.window.showInformationMessage('Reload VS Code window to enable the use of Go language server');
-						});
+							.then(() => {
+								vscode.window.showInformationMessage('Reload VS Code window to enable the use of Go language server');
+							});
 					} else if (selected === 'Disable language server') {
 						const goConfig = vscode.workspace.getConfiguration('go');
 						const inspectLanguageServerSetting = goConfig.inspect('useLanguageServer');
@@ -531,32 +531,38 @@ export function getLanguageServerToolPath(): string {
 		return;
 	}
 
+	// Get the path to gopls or any alternative that the user might have set for gopls
 	const goplsBinaryPath = getBinPath('gopls');
-	const golangserverBinaryPath = getBinPath('go-langserver');
-
 	if (path.isAbsolute(goplsBinaryPath)) {
 		return goplsBinaryPath;
-	} else if (path.isAbsolute(golangserverBinaryPath)) {
+	}
+
+	// Get the path to go-langserver or any alternative that the user might have set for gopls
+	const golangserverBinaryPath = getBinPath('go-langserver');
+	if (path.isAbsolute(golangserverBinaryPath)) {
 		return golangserverBinaryPath;
-	} else {
-		let languageServerOfChoice = 'gopls';
-		if (latestGoConfig['alternateTools']) {
-			const goplsAlternate = latestGoConfig['alternateTools']['gopls'];
-			const golangserverAlternate = latestGoConfig['alternateTools']['go-langserver'];
-			if (typeof goplsAlternate === 'string') {
-				languageServerOfChoice = getToolFromToolPath(goplsAlternate);
-			} else if (typeof golangserverAlternate === 'string') {
-				languageServerOfChoice = getToolFromToolPath(golangserverAlternate);
-			}
+	}
+
+	// Notify the user about the unavailability of the language server
+	let languageServerOfChoice = 'gopls';
+	if (latestGoConfig['alternateTools']) {
+		const goplsAlternate = latestGoConfig['alternateTools']['gopls'];
+		const golangserverAlternate = latestGoConfig['alternateTools']['go-langserver'];
+		if (typeof goplsAlternate === 'string') {
+			languageServerOfChoice = getToolFromToolPath(goplsAlternate);
+		} else if (typeof golangserverAlternate === 'string') {
+			languageServerOfChoice = getToolFromToolPath(golangserverAlternate);
 		}
 
 		if (languageServerOfChoice !== 'gopls' && languageServerOfChoice !== 'go-langserver') {
 			vscode.window.showErrorMessage(`Cannot find the language server ${languageServerOfChoice}. Please install it and reload this VS Code window`);
-		} else {
-			promptForMissingTool(languageServerOfChoice);
-			vscode.window.showInformationMessage('Reload VS Code window after installing the Go language server');
+			return;
 		}
 	}
+
+	promptForMissingTool(languageServerOfChoice);
+	vscode.window.showInformationMessage('Reload VS Code window after installing the Go language server');
+
 }
 
 function allFoldersHaveSameGopath(): boolean {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -449,7 +449,7 @@ export function offerToInstallTools() {
 		const goConfig = vscode.workspace.getConfiguration('go');
 		const usingSourceGraph = goConfig['useLanguageServer'] === true && !getAlternateLanguageServer(goConfig);
 		if (usingSourceGraph) {
-			const promptMsg = 'The language server from Sourcegraph is no longer under active development. Please update to use the language server from Google or disable the use of language servers altogether.';
+			const promptMsg = 'The language server from Sourcegraph is no longer under active development and it does not support Go modules as well. Please update to use the language server from Google or disable the use of language servers altogether.';
 			vscode.window.showInformationMessage(promptMsg, 'Update', 'Later')
 				.then(selected => {
 					if (selected === 'Update') {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -36,7 +36,7 @@ import {
 import {
 	LanguageClient, RevealOutputChannelOn, FormattingOptions, ProvideDocumentFormattingEditsSignature,
 	ProvideCompletionItemsSignature, ProvideRenameEditsSignature, ProvideDefinitionSignature, ProvideHoverSignature,
-	ProvideReferencesSignature, ProvideSignatureHelpSignature, ProvideDocumentSymbolsSignature, ProvideWorkspaceSymbolsSignature
+	ProvideReferencesSignature, ProvideSignatureHelpSignature, ProvideDocumentSymbolsSignature, ProvideWorkspaceSymbolsSignature, HandleDiagnosticsSignature
 } from 'vscode-languageclient';
 import { clearCacheForTools, fixDriveCasingInWindows, getToolFromToolPath } from './goPath';
 import { addTags, removeTags } from './goModifytags';
@@ -192,6 +192,12 @@ export function activate(ctx: vscode.ExtensionContext): void {
 							}
 							return null;
 						},
+						handleDiagnostics: (uri: vscode.Uri, diagnostics: vscode.Diagnostic[], next: HandleDiagnosticsSignature) => {
+							if (languageServerExperimentalFeatures['diagnostics'] === true) {
+								return next(uri, diagnostics);
+							}
+							return null;
+						}
 					}
 				}
 			);

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -672,10 +672,6 @@ function sendTelemetryEventForConfig(goConfig: vscode.WorkspaceConfiguration) {
 	});
 }
 
-function didLangServerConfigChange(e: vscode.ConfigurationChangeEvent): boolean {
-	return e.affectsConfiguration('go.useLanguageServer') || e.affectsConfiguration('go.languageServerFlags') || e.affectsConfiguration('go.languageServerExperimentalFeatures');
-}
-
 function checkToolExists(tool: string) {
 	if (tool === getBinPath(tool)) {
 		promptForMissingTool(tool);

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -41,8 +41,8 @@ export function getModFolderPath(fileuri: vscode.Uri): Promise<string> {
 		return Promise.resolve(moduleCache);
 	}
 
-	return getGoVersion().then(value => {
-		if (value && (value.major !== 1 || value.minor < 11)) {
+	return getGoVersion().then(goVersion => {
+		if (goVersion && (goVersion.major !== 1 || goVersion.minor < 11)) {
 			return;
 		}
 
@@ -63,10 +63,11 @@ export function getModFolderPath(fileuri: vscode.Uri): Promise<string> {
 					const promptMsg = 'To get better performance during code completion, please update to use the language server from Google';
 					promptToUpdateToolForModules('gopls', promptMsg).then(choseToUpdate => {
 						if (choseToUpdate) {
-							const alternateTools: any = goConfig['alternateTools'] || {};
-							alternateTools['go-langserver'] = 'gopls';
-							goConfig.update('alternateTools', alternateTools, vscode.ConfigurationTarget.Global);
-							goConfig.update('useLanguageServer', true, vscode.ConfigurationTarget.Global);
+							installTools(['gopls'], goVersion)
+								.then(() => {
+									goConfig.update('useLanguageServer', true, vscode.ConfigurationTarget.Global);
+									vscode.window.showInformationMessage('Reload VS Code window to enable the use of Go language server');
+								});
 						}
 					});
 				}

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -196,7 +196,7 @@ export function fixDriveCasingInWindows(pathToFix: string): string {
  * Returns the tool name from the given path to the tool
  * @param toolPath
  */
-export function getToolFromToolPath(toolPath: string): string {
+export function getToolFromToolPath(toolPath: string): string | undefined {
 	if (!toolPath) {
 		return;
 	}

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -191,3 +191,18 @@ export function getCurrentGoWorkspaceFromGOPATH(gopath: string, currentFileDirPa
 export function fixDriveCasingInWindows(pathToFix: string): string {
 	return (process.platform === 'win32' && pathToFix) ? pathToFix.substr(0, 1).toUpperCase() + pathToFix.substr(1) : pathToFix;
 }
+
+/**
+ * Returns the tool name from the given path to the tool
+ * @param toolPath
+ */
+export function getToolFromToolPath(toolPath: string): string {
+	if (!toolPath) {
+		return;
+	}
+	let tool = path.basename(toolPath);
+	if (process.platform === 'win32' && tool.endsWith('.exe')) {
+		tool = tool.substr(0, tool.length - 4);
+	}
+	return tool;
+}

--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -256,7 +256,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider, 
 					}
 					const results = <[number, GoCodeSuggestion[]]>JSON.parse(stdout.toString());
 					let suggestions: vscode.CompletionItem[] = [];
-					const packageSuggestions = [];
+					const packageSuggestions: string[] = [];
 
 					const wordAtPosition = document.getWordRangeAtPosition(position);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -954,23 +954,3 @@ export function runGodoc(cwd: string, packagePath: string, receiver: string, sym
 		});
 	});
 }
-
-/**
- * Returns the alternate language server being used
- * @param goConfig Workspace configuration
- */
-export function getAlternateLanguageServer(goConfig: vscode.WorkspaceConfiguration): string {
-	if (goConfig['useLanguageServer'] === true
-		&& goConfig['alternateTools']
-		&& goConfig['alternateTools']['go-langserver']
-		&& typeof goConfig['alternateTools']['go-langserver'] === 'string') {
-		let alternateTool: string = goConfig['alternateTools']['go-langserver'];
-		if (path.isAbsolute(alternateTool)) {
-			alternateTool = path.basename(alternateTool);
-		}
-		if (alternateTool.endsWith('.exe') && process.platform === 'win32') {
-			alternateTool = alternateTool.substr(0, alternateTool.length - 4);
-		}
-		return alternateTool;
-	}
-}

--- a/src/util.ts
+++ b/src/util.ts
@@ -954,3 +954,23 @@ export function runGodoc(cwd: string, packagePath: string, receiver: string, sym
 		});
 	});
 }
+
+/**
+ * Returns the alternate language server being used
+ * @param goConfig Workspace configuration
+ */
+export function getAlternateLanguageServer(goConfig: vscode.WorkspaceConfiguration): string {
+	if (goConfig['useLanguageServer'] === true
+		&& goConfig['alternateTools']
+		&& goConfig['alternateTools']['go-langserver']
+		&& typeof goConfig['alternateTools']['go-langserver'] === 'string') {
+		let alternateTool: string = goConfig['alternateTools']['go-langserver'];
+		if (path.isAbsolute(alternateTool)) {
+			alternateTool = path.basename(alternateTool);
+		}
+		if (alternateTool.endsWith('.exe') && process.platform === 'win32') {
+			alternateTool = alternateTool.substr(0, alternateTool.length - 4);
+		}
+		return alternateTool;
+	}
+}


### PR DESCRIPTION
Now that the language server from Google is ready for use, there are some changes needed in the Go extension to ensure good user experience

- Allow installing of the gopls language server using `Go: Install/Update Tools`
- Prompt users who use the language server from Sourcegraph to switch to the one from Google
- Disable build on save feature when using gopls or bingo to avoid duplicate errors
- Enable format and auto-completion features from the language servers

_Edit as per latest commits:_
- If using modules but not any language server, users will now be prompted to install and use `gopls`
- If using Sourcegraph, users will now be prompted to install and use `gopls` or stop disable the `go.useLanguageServer` setting
- For anyone setting `go.useLanguageServer` for the first time, `gopls` will be installed and used
- `diagnostics` is added to `go.languageServerExperimentalFeatures` setting so that user can control if they want the language server to return build/vet errors. Set to `true` by default. When enabled, the build and vet on save features of the extension will not be run to avoid duplicate errors
- README updated

cc @stamblerre, @ianthehat