### PR TITLE
Fix "Cancel Running Tests" option

### DIFF
--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -6,6 +6,7 @@ import cp = require('child_process');
 import path = require('path');
 import util = require('util');
 import vscode = require('vscode');
+import process = require('process');
 
 import { getCurrentPackage } from './goModules';
 import { GoDocumentSymbolProvider } from './goOutline';
@@ -260,7 +261,7 @@ export function goTest(testconfig: TestConfig): Thenable<boolean> {
 			// ensure that user provided flags are appended last (allow use of -args ...)
 			args.push(...testconfig.flags);
 
-			let tp = cp.spawn(goRuntimePath, args, { env: testEnvVars, cwd: testconfig.dir });
+			let tp = cp.spawn(goRuntimePath, args, { env: testEnvVars, cwd: testconfig.dir, detached: true });
 			const outBuf = new LineBuffer();
 			const errBuf = new LineBuffer();
 
@@ -349,7 +350,7 @@ export function showTestOutput() {
 export function cancelRunningTests(): Thenable<boolean> {
 	return new Promise<boolean>((resolve, reject) => {
 		runningTestProcesses.forEach(tp => {
-			tp.kill(sendSignal);
+			process.kill(-tp.pid, sendSignal);
 		});
 		// All processes are now dead. Empty the array to prepare for the next run.
 		runningTestProcesses.splice(0, runningTestProcesses.length);

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -14,7 +14,7 @@ import { getCurrentGoWorkspaceFromGOPATH, parseEnvFile } from './goPath';
 import { getBinPath, getCurrentGoPath, getGoVersion, getToolsEnvVars, LineBuffer, resolvePath } from './util';
 
 
-const sendSignal = 'SIGKILL';
+const sendSignal = 'SIGTERM';
 const outputChannel = vscode.window.createOutputChannel('Go Tests');
 const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 statusBarItem.command = 'go.test.cancel';


### PR DESCRIPTION
The original issue is: 
on _Linux_ machine when a user presses 'Cancel Running Tests' to stop a test that was running through 'run test' button in the code editor, the go-test process is orphaned and stays alive because runningTestProcesses.kill(...) kills the parent process only.

To fix this I suggest to kill spawned process by group (with 'minus PID' notation).

One more notice: may be killing the spawned processes with SIGKILL is too hard because SIGKILL cannot be handled. I think we can let them to have a chance to handle the interruption. So I suggest kill them with SIGTERM.

