### PR TITLE
Do not send empty param to delve on empty args

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -431,7 +431,9 @@ class Delve {
 				dlvArgs = dlvArgs.concat(['--output=' + launchArgs.output]);
 			}
 			if (launchArgs.args) {
-				dlvArgs = dlvArgs.concat(['--', ...launchArgs.args]);
+				if (launchArgs.args.length > 0) {
+					dlvArgs = dlvArgs.concat(['--', ...launchArgs.args]);
+				}
 			}
 
 			log(`Current working directory: ${dlvCwd}`);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -430,10 +430,8 @@ class Delve {
 			if (launchArgs.output && mode === 'debug') {
 				dlvArgs = dlvArgs.concat(['--output=' + launchArgs.output]);
 			}
-			if (launchArgs.args) {
-				if (launchArgs.args.length > 0) {
-					dlvArgs = dlvArgs.concat(['--', ...launchArgs.args]);
-				}
+			if (launchArgs.args && (launchArgs.args.length > 0)) {
+				dlvArgs = dlvArgs.concat(['--', ...launchArgs.args]);
 			}
 
 			log(`Current working directory: ${dlvCwd}`);


### PR DESCRIPTION
For cases of `args: []` in launch.json, an empty `--` is sent to delve on the command line. This check fixes any potential issue this may cause in future versions (like setting extra parameters after args in the debug adapter)