### PR TITLE
go.mod: allow no space before comment, do not allow double slash in unqouted string

### DIFF
--- a/syntaxes/go.mod.tmGrammar.json
+++ b/syntaxes/go.mod.tmGrammar.json
@@ -6,6 +6,9 @@
 		},
 		{
 			"include": "#directive"
+		},
+		{
+			"include": "#invalid"
 		}
 	],
 	"repository": {
@@ -13,7 +16,7 @@
 			"patterns": [
 				{
 					"comment": "Multi-Line directive",
-					"begin": "(\\w+)\\s+\\(",
+					"begin": "(\\w+)\\s*\\(",
 					"beginCaptures": {
 						"1": {
 							"name": "keyword.go.mod"
@@ -28,7 +31,7 @@
 				},
 				{
 					"comment": "Single-Line directive",
-					"match": "(\\w+)\\s+(.*)",
+					"match": "(\\w+)\\s*(.*)",
 					"captures": {
 						"1": {
 							"name": "keyword.go.mod"
@@ -86,7 +89,7 @@
 		},
 		"unquoted_string": {
 			"comment": "Unquoted string",
-			"match": "[^\\s]+",
+			"match": "([^\\s/]|/(?!/))+",
 			"name": "string.unquoted.go.mod"
 		},
 		"double_quoted_string": {
@@ -158,6 +161,11 @@
 					"name": "constant.other.placeholder.go.mod"
 				}
 			]
+		},
+		"invalid": {
+			"comment": "invalid",
+			"match": ".*",
+			"name": "invalid.illegal.unknown.go.mod"
 		}
 	}
 }


### PR DESCRIPTION
I believe this will fix the issues identified in #2423 .

A space is no longer required after the directive, so both

```require// this is now a comment```

and

```require(```

should be matched.

Comments will also be detected within unquoted strings:

```
    module k8s.io/kubernetes// this is now a comment
```

Which I believe replicates this line from the parser: https://github.com/golang/go/blob/master/src/cmd/go/internal/modfile/read.go#L546.

Finally anything unmatched is marked as invalid.