### PR TITLE
Add go.buildEnvVars

### DIFF
--- a/package.json
+++ b/package.json
@@ -817,6 +817,12 @@
           "description": "Specifies the timeout for go test in ParseDuration format.",
           "scope": "resource"
         },
+        "go.buildEnvVars": {
+          "type": "object",
+          "default": {},
+          "description": "Environment variables that will passed to the process that runs the Go build",
+          "scope": "resource"
+        },
         "go.testEnvVars": {
           "type": "object",
           "default": {},

--- a/src/goBuild.ts
+++ b/src/goBuild.ts
@@ -78,7 +78,7 @@ export async function goBuild(fileUri: vscode.Uri, isMod: boolean, goConfig: vsc
 		return [];
 	}
 
-	const buildEnv = Object.assign({}, getToolsEnvVars());
+	const buildEnv = Object.assign({}, getToolsEnvVars(), goConfig.get('buildEnvVars', {}));
 	const tmpPath = getTempFilePath('go-code-check');
 	const isTestFile = fileUri && fileUri.fsPath.endsWith('_test.go');
 	const buildFlags: string[] = isTestFile ? getTestFlags(goConfig) : (Array.isArray(goConfig['buildFlags']) ? [...goConfig['buildFlags']] : []);

--- a/src/goBuild.ts
+++ b/src/goBuild.ts
@@ -125,9 +125,9 @@ export async function goBuild(fileUri: vscode.Uri, isMod: boolean, goConfig: vsc
 	if (currentGoWorkspace && !isMod) {
 		importPath = cwd.substr(currentGoWorkspace.length + 1);
 	} else {
-		outputChannel.appendLine(`Not able to determine import path of current package by using cwd: ${cwd} and Go workspace: ${currentGoWorkspace}`)
+		outputChannel.appendLine(`Not able to determine import path of current package by using cwd: ${cwd} and Go workspace: ${currentGoWorkspace}`);
 	}
-	
+
 	running = true;
 	return runTool(
 		buildArgs.concat('-o', tmpPath, importPath),


### PR DESCRIPTION
Add `go.buildEnvVars` to support adding `GO111MODULE=on` as env. variables to support go mod in `go build` in vscode.