### PR TITLE
support disabling document links, enable diagnostics by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -980,8 +980,13 @@
             },
             "diagnostics": {
               "type": "boolean",
-              "default": false,
+              "default": true,
               "description": "If true, the language server will provide build, vet errors and the extension will ignore the `buildOnSave`, `vetOnSave` settings."
+            },
+            "documentLink": {
+              "type": "boolean",
+              "default": true,
+              "description": "If true, the language server's document link feature will be enabled."
             },
             "incrementalSync": {
               "type": "boolean",
@@ -1001,7 +1006,8 @@
             "documentSymbols": true,
             "workspaceSymbols": true,
             "findReferences": true,
-            "diagnostics": false
+            "diagnostics": true,
+            "documentLink": true
           },
           "description": "Use this setting to enable/disable experimental features from the language server."
         },

--- a/package.json
+++ b/package.json
@@ -986,7 +986,7 @@
             "documentLink": {
               "type": "boolean",
               "default": true,
-              "description": "If true, the language server's document link feature will be enabled."
+              "description": "If true, the language server will provide clickable Godoc links for import statements."
             },
             "incrementalSync": {
               "type": "boolean",

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -36,7 +36,8 @@ import {
 import {
 	LanguageClient, RevealOutputChannelOn, FormattingOptions, ProvideDocumentFormattingEditsSignature,
 	ProvideCompletionItemsSignature, ProvideRenameEditsSignature, ProvideDefinitionSignature, ProvideHoverSignature,
-	ProvideReferencesSignature, ProvideSignatureHelpSignature, ProvideDocumentSymbolsSignature, ProvideWorkspaceSymbolsSignature, HandleDiagnosticsSignature
+	ProvideReferencesSignature, ProvideSignatureHelpSignature, ProvideDocumentSymbolsSignature, ProvideWorkspaceSymbolsSignature,
+	HandleDiagnosticsSignature, ProvideDocumentLinksSignature,
 } from 'vscode-languageclient';
 import { clearCacheForTools, fixDriveCasingInWindows, getToolFromToolPath } from './goPath';
 import { addTags, removeTags } from './goModifytags';
@@ -221,6 +222,12 @@ export function activate(ctx: vscode.ExtensionContext): void {
 						handleDiagnostics: (uri: vscode.Uri, diagnostics: vscode.Diagnostic[], next: HandleDiagnosticsSignature) => {
 							if (languageServerExperimentalFeatures['diagnostics'] === true) {
 								return next(uri, diagnostics);
+							}
+							return null;
+						},
+						provideDocumentLinks: (document: vscode.TextDocument, token: vscode.CancellationToken, next: ProvideDocumentLinksSignature) => {
+							if (languageServerExperimentalFeatures['documentLink'] === true) {
+								return next(document, token);
 							}
 							return null;
 						}


### PR DESCRIPTION
The issue of stuck diagnostics seems to be solved, so we can now enable diagnostics by default.
Also, adds configurability for documentLink, which seems to have been requested by a few people, both on the issue tracker and on Slack.