### PR TITLE
Use tsconfig.json to determine which typescript files to lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "compile": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test",
-    "lint": "node ./node_modules/tslint/bin/tslint ./src/*.ts ./src/debugAdapter/*.ts ./test/*.ts",
-    "fix-lint": "node ./node_modules/tslint/bin/tslint --fix ./src/*.ts ./src/debugAdapter/*.ts ./test/*.ts",
+    "lint": "node ./node_modules/tslint/bin/tslint --project tsconfig.json",
+    "fix-lint": "node ./node_modules/tslint/bin/tslint --fix --project tsconfig.json",
     "unit-test": "node ./node_modules/mocha/bin/_mocha -u tdd --timeout 5000 --colors ./out/test/unit"
   },
   "extensionDependencies": [],

--- a/test/unit/NNDict.test.ts
+++ b/test/unit/NNDict.test.ts
@@ -8,8 +8,8 @@ import { Node, NearestNeighborDict } from '../../src/avlTree';
 
 suite('NearestNeighborDict Tests', () => {
 	test('basic insert/get: random', () => {
-		let dict = new NearestNeighborDict(new Node(0, 0), NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
-		let entries = [5, 2, 9, 23, 3, 0, 1, -4, -2];
+		const dict = new NearestNeighborDict(new Node(0, 0), NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
+		const entries = [5, 2, 9, 23, 3, 0, 1, -4, -2];
 		entries.forEach(x => dict.insert(x));
 		assert(dict.height() < 4);
 
@@ -23,8 +23,8 @@ suite('NearestNeighborDict Tests', () => {
 	});
 
 	test('basic insert/get: increasing', () => {
-		let dict = new NearestNeighborDict(new Node(0, 0), NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
-		let entries = [-10, -5, -4, -1, 0, 1, 5, 10, 23];
+		const dict = new NearestNeighborDict(new Node(0, 0), NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
+		const entries = [-10, -5, -4, -1, 0, 1, 5, 10, 23];
 		entries.forEach(x => dict.insert(x));
 		assert(dict.height() < 4);
 
@@ -38,8 +38,8 @@ suite('NearestNeighborDict Tests', () => {
 	});
 
 	test('basic insert/get: decreasing', () => {
-		let dict = new NearestNeighborDict(new Node(0, 0), NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
-		let entries = [-10, -5, -4, -1, 0, 1, 5, 10, 23].reverse();
+		const dict = new NearestNeighborDict(new Node(0, 0), NearestNeighborDict.NUMERIC_DISTANCE_FUNCTION);
+		const entries = [-10, -5, -4, -1, 0, 1, 5, 10, 23].reverse();
 		entries.forEach(x => dict.insert(x));
 		assert(dict.height() < 4);
 


### PR DESCRIPTION
I noticed that the `npm run lint` command was not covering all the typescript files in the repo and was therefore missing some linting errors. I have changed this command and the `npm run fix-lint` command so that they use the tsconfig.json file to determine which files will be linted. I have also used the fix-lint command to fix the errors which my change had uncovered.