### PR TITLE
feat: allow workspaceFolder substition in go.alternateTools

### DIFF
--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -11,6 +11,7 @@
 import fs = require('fs');
 import path = require('path');
 import os = require('os');
+import util = require('./util');
 
 let binPathCache: { [bin: string]: string; } = {};
 
@@ -33,7 +34,7 @@ export function getBinPathFromEnvVar(toolName: string, envVarValue: string, appe
 export function getBinPathWithPreferredGopath(toolName: string, preferredGopaths: string[], alternateTools?: { [key: string]: string; }) {
 	if (binPathCache[toolName]) return binPathCache[toolName];
 
-	const alternateTool = (alternateTools && alternateTools[toolName]) ? resolveHomeDir(alternateTools[toolName]) : null;
+	const alternateTool = (alternateTools && alternateTools[toolName]) ? util.resolvePath(alternateTools[toolName]) : null;
 	if (alternateTool && path.isAbsolute(alternateTool) && fileExists(alternateTool)) {
 		binPathCache[toolName] = alternateTool;
 		return alternateTool;

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -11,7 +11,6 @@
 import fs = require('fs');
 import path = require('path');
 import os = require('os');
-import util = require('./util');
 
 let binPathCache: { [bin: string]: string; } = {};
 

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -34,7 +34,7 @@ export function getBinPathFromEnvVar(toolName: string, envVarValue: string, appe
 export function getBinPathWithPreferredGopath(toolName: string, preferredGopaths: string[], alternateTools?: { [key: string]: string; }) {
 	if (binPathCache[toolName]) return binPathCache[toolName];
 
-	const alternateTool = (alternateTools && alternateTools[toolName]) ? util.resolvePath(alternateTools[toolName]) : null;
+	const alternateTool = (alternateTools && alternateTools[toolName]) || null;
 	if (alternateTool && path.isAbsolute(alternateTool) && fileExists(alternateTool)) {
 		binPathCache[toolName] = alternateTool;
 		return alternateTool;

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -31,10 +31,9 @@ export function getBinPathFromEnvVar(toolName: string, envVarValue: string, appe
 	return null;
 }
 
-export function getBinPathWithPreferredGopath(toolName: string, preferredGopaths: string[], alternateTools?: { [key: string]: string; }) {
+export function getBinPathWithPreferredGopath(toolName: string, preferredGopaths: string[], alternateTool?: string) {
 	if (binPathCache[toolName]) return binPathCache[toolName];
 
-	const alternateTool = (alternateTools && alternateTools[toolName]) || null;
 	if (alternateTool && path.isAbsolute(alternateTool) && fileExists(alternateTool)) {
 		binPathCache[toolName] = alternateTool;
 		return alternateTool;

--- a/src/util.ts
+++ b/src/util.ts
@@ -371,7 +371,13 @@ function resolveToolsGopath(): string {
 }
 
 export function getBinPath(tool: string): string {
-	return getBinPathWithPreferredGopath(tool, (tool === 'go') ? [] : [getToolsGopath(), getCurrentGoPath()], vscode.workspace.getConfiguration('go', null).get('alternateTools'));
+	const alternateTools: { [key: string]: string; } = vscode.workspace.getConfiguration('go', null).get('alternateTools');
+
+	return getBinPathWithPreferredGopath(
+		tool,
+		(tool === 'go') ? [] : [getToolsGopath(), getCurrentGoPath()],
+		resolveObjectPaths(alternateTools),
+	);
 }
 
 export function getFileArchive(document: vscode.TextDocument): string {
@@ -499,6 +505,21 @@ export function timeout(millis: number): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
 		setTimeout(() => resolve(), millis);
 	});
+}
+
+
+/**
+ * Given an object with path attributes, resolve the paths of all attributes and return the new object.
+ */
+export function resolveObjectPaths(obj: {
+	[key: string]: string;
+}): {
+	[key: string]: string;
+} {
+	return Object.keys(obj).reduce(
+		(acc, key, idx) => ({ ...acc, [key]: resolvePath(obj[key]) }),
+		{}
+	);
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -371,12 +371,13 @@ function resolveToolsGopath(): string {
 }
 
 export function getBinPath(tool: string): string {
-	const alternateTools: { [key: string]: string; } = vscode.workspace.getConfiguration('go', null).get('alternateTools');
+	const alternateTools: {[key: string]: string} = vscode.workspace.getConfiguration('go', null).get('alternateTools');
+	const alternateToolPath: string = alternateTools[tool];
 
 	return getBinPathWithPreferredGopath(
 		tool,
 		(tool === 'go') ? [] : [getToolsGopath(), getCurrentGoPath()],
-		resolveObjectPaths(alternateTools),
+		resolvePath(alternateToolPath),
 	);
 }
 
@@ -505,21 +506,6 @@ export function timeout(millis: number): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
 		setTimeout(() => resolve(), millis);
 	});
-}
-
-
-/**
- * Given an object with path attributes, resolve the paths of all attributes and return the new object.
- */
-export function resolveObjectPaths(obj: {
-	[key: string]: string;
-}): {
-	[key: string]: string;
-} {
-	return Object.keys(obj).reduce(
-		(acc, key, idx) => ({ ...acc, [key]: resolvePath(obj[key]) }),
-		{}
-	);
 }
 
 /**


### PR DESCRIPTION
This is a feature I'd like, raised an issue describing it [here](https://github.com/microsoft/vscode-go/issues/2543)

