### PR TITLE
Turn on the "no-consecutive-blank-lines" linting rule

### DIFF
--- a/src/goBaseCodelens.ts
+++ b/src/goBaseCodelens.ts
@@ -5,7 +5,6 @@ export abstract class GoBaseCodeLensProvider implements vscode.CodeLensProvider 
 	protected enabled: boolean = true;
 	private onDidChangeCodeLensesEmitter = new vscode.EventEmitter<void>();
 
-
 	public get onDidChangeCodeLenses(): vscode.Event<void> {
 		return this.onDidChangeCodeLensesEmitter.event;
 	}

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -439,7 +439,6 @@ export function updateGoPathGoRootFromConfig(): Promise<void> {
 		process.env[pathEnvVar] += path.delimiter + goRuntimeBasePath;
 	}
 
-
 	return new Promise<void>((resolve, reject) => {
 		cp.execFile(goRuntimePath, ['env', 'GOPATH', 'GOROOT'], (err, stdout, stderr) => {
 			if (err) {
@@ -501,7 +500,6 @@ export function offerToInstallTools() {
 				});
 		}
 	});
-
 
 	function promptForInstall(missing: string[], goVersion: SemVersion) {
 		const installItem = {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -325,7 +325,6 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	const testCodeLensProvider = new GoRunTestCodeLensProvider();
 	const referencesCodeLensProvider = new GoReferencesCodeLensProvider();
 
-
 	ctx.subscriptions.push(vscode.languages.registerCodeActionsProvider(GO_MODE, new GoCodeActionProvider()));
 	ctx.subscriptions.push(vscode.languages.registerCodeLensProvider(GO_MODE, testCodeLensProvider));
 	ctx.subscriptions.push(vscode.languages.registerCodeLensProvider(GO_MODE, referencesCodeLensProvider));
@@ -503,7 +502,6 @@ export function activate(ctx: vscode.ExtensionContext): void {
 				}
 			});
 		}
-
 
 		if (updatedGoConfig['enableCodeLens']) {
 			testCodeLensProvider.setEnabled(updatedGoConfig['enableCodeLens']['runtest']);

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -74,7 +74,6 @@ export async function getModFolderPath(fileuri: vscode.Uri): Promise<string> {
 	return goModEnvResult;
 }
 
-
 let moduleUsageLogged = false;
 function logModuleUsage() {
 	if (moduleUsageLogged) {

--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -119,7 +119,6 @@ const goKindToCodeKind: { [key: string]: vscode.SymbolKind } = {
 	'struct': vscode.SymbolKind.Struct,
 };
 
-
 function convertToCodeSymbols(
 	document: vscode.TextDocument,
 	decls: GoOutlineDeclaration[],
@@ -129,7 +128,6 @@ function convertToCodeSymbols(
 	const symbols: vscode.DocumentSymbol[] = [];
 	(decls || []).forEach(decl => {
 		if (!includeImports && decl.type === 'import') return;
-
 
 		if (decl.label === '_' && decl.type === 'variable') return;
 

--- a/src/stateUtils.ts
+++ b/src/stateUtils.ts
@@ -19,4 +19,3 @@ export function updateGlobalState(key: string, value: any) {
 export function setGlobalState(state: vscode.Memento) {
 	globalState = state;
 }
-

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -13,7 +13,6 @@ import { getNonVendorPackages } from './goPackages';
 import { getCurrentGoWorkspaceFromGOPATH, parseEnvFile } from './goPath';
 import { getBinPath, getCurrentGoPath, getGoVersion, getToolsEnvVars, LineBuffer, resolvePath } from './util';
 
-
 const sendSignal = 'SIGKILL';
 const outputChannel = vscode.window.createOutputChannel('Go Tests');
 const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);

--- a/src/util.ts
+++ b/src/util.ts
@@ -371,7 +371,7 @@ function resolveToolsGopath(): string {
 }
 
 export function getBinPath(tool: string): string {
-	const alternateTools: {[key: string]: string} = vscode.workspace.getConfiguration('go', null).get('alternateTools');
+	const alternateTools: { [key: string]: string } = vscode.workspace.getConfiguration('go', null).get('alternateTools');
 	const alternateToolPath: string = alternateTools[tool];
 
 	return getBinPathWithPreferredGopath(

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -62,4 +62,3 @@ suite('GuessPackageNameFromFile Tests', () => {
 			.then(() => done(), done);
 	});
 });
-

--- a/tslint.json
+++ b/tslint.json
@@ -70,7 +70,7 @@
 		"new-parens": true,
 		"no-arg": true,
 		"no-conditional-assignment": true,
-		// "no-consecutive-blank-lines": true,
+		"no-consecutive-blank-lines": true,
 		"no-construct": true,
 		"no-debugger": true,
 		"no-duplicate-super": true,


### PR DESCRIPTION
This enables one of the commented out linting rules and fixes all the new linting failures by using `npm run fix-lint`.