### PR TITLE
Improve "generate interface stubs" interface

### DIFF
--- a/src/goImpl.ts
+++ b/src/goImpl.ts
@@ -7,54 +7,251 @@
 
 import vscode = require('vscode');
 import cp = require('child_process');
-import { getBinPath, getToolsEnvVars } from './util';
+import { getBinPath, getToolsEnvVars, byteOffsetAt } from './util';
 import { promptForMissingTool } from './goInstallTools';
 import { dirname } from 'path';
+import { getAllPackages } from './goPackages';
 
-// Supports only passing interface, see TODO in implCursor to finish
-const inputRegex = /^(\w+\ \*?\w+\ )?([\w./]+)$/;
+interface GuruDescribeOutput {
+	type: GuruType;
+}
+
+interface GuruType {
+	type: string;
+}
+
+interface GuruWhatOutput {
+	enclosing: GuruEnclosing[];
+}
+
+interface GuruEnclosing {
+	desc: string;
+	begin: number;
+	end: number;
+}
 
 export function implCursor() {
-	const cursor = vscode.window.activeTextEditor.selection;
-	return vscode.window.showInputBox({
-		placeHolder: 'f *File io.Closer',
-		prompt: 'Enter receiver and interface to implement.'
-	}).then(implInput => {
-		if (typeof implInput === 'undefined') {
-			return;
-		}
-		const matches = implInput.match(inputRegex);
-		if (!matches) {
-			vscode.window.showInformationMessage(`Not parsable input: ${implInput}`);
-			return;
+	let workDir = '';
+	let currentUri: vscode.Uri = null;
+	const editor = vscode.window.activeTextEditor;
+	if (editor) {
+		currentUri = vscode.window.activeTextEditor.document.uri;
+		workDir = dirname(currentUri.fsPath);
+	} else if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length === 1) {
+		currentUri = vscode.workspace.workspaceFolders[0].uri;
+		workDir = currentUri.fsPath;
+	}
+
+	showAllPackages(workDir);
+}
+
+function showAllPackages(workDir: string) {
+	getAllPackages(workDir).then(pkgMap => {
+		const pkgs: string[] = Array.from(pkgMap.keys());
+		if (pkgs.length === 0) {
+			return vscode.window.showErrorMessage(
+				'Could not find packages. Ensure `gopkgs -format {{.Name}};{{.ImportPath}}` runs successfully.'
+			);
 		}
 
-		// TODO: automatically detect type name at cursor
-		// if matches[1] is undefined then detect receiver type
-		// take first character and use as receiver name
+		vscode.window.showQuickPick(pkgs.sort(), {
+			placeHolder: 'Select a package to browse'
+		}).then(showSelectedPackageInterfaces);
+	});
+}
 
-		runGoImpl([matches[1], matches[2]], cursor.start);
+function showSelectedPackageInterfaces(pkg: string) {
+	getPackageDir(pkg)
+		.then(runGoInterface)
+		.then(interfaces => {
+			vscode.window.showQuickPick(interfaces, {
+				placeHolder: 'Select interface'
+			}).then(chooseReceiverName);
+		});
+}
+
+function chooseReceiverName(intrfc: string) {
+	if (!intrfc) {
+		return;
+	}
+
+	getTypeAtCursor().then(selectedType => {
+		let defaultReceiverName = '';
+		if (selectedType) {
+			defaultReceiverName = selectedType[0].toLowerCase() + ' *' + selectedType;
+		}
+		goToEndOfDeclaration();
+		vscode.window.showInputBox({
+			placeHolder: 'f *File',
+			prompt: 'Enter receiver.',
+			value: defaultReceiverName
+		}).then(implInput => {
+			if (!implInput) {
+				return;
+			}
+			runGoImpl(
+				[implInput, intrfc],
+				vscode.window.activeTextEditor.selection.start
+			);
+		});
+	});
+}
+
+function runGoInterface(dir: string): Promise<string[]> {
+	return new Promise((resolve, reject) => {
+		const gointerface = getBinPath('gointerfaces');
+		cp.execFile(
+			gointerface,
+			[dir],
+			{
+				env: getToolsEnvVars(),
+				cwd: dirname(vscode.window.activeTextEditor.document.fileName)
+			},
+			(err, stdout, stderr) => {
+				if (err) {
+					if ((<any>err).code === 'ENOENT') {
+						promptForMissingTool('gointerfaces');
+						return;
+					}
+					vscode.window.showInformationMessage(
+						`Cannot find interfaces: ${stderr}`
+					);
+				}
+				resolve(
+					stdout.toString().split('\n').filter(l => l.trim().length !== 0)
+				);
+			}
+		);
 	});
 }
 
 function runGoImpl(args: string[], insertPos: vscode.Position) {
 	const goimpl = getBinPath('impl');
-	const p = cp.execFile(goimpl, args, { env: getToolsEnvVars(), cwd: dirname(vscode.window.activeTextEditor.document.fileName) }, (err, stdout, stderr) => {
-		if (err && (<any>err).code === 'ENOENT') {
-			promptForMissingTool('impl');
-			return;
-		}
+	const p = cp.execFile(
+		goimpl,
+		args,
+		{
+			env: getToolsEnvVars(),
+			cwd: dirname(vscode.window.activeTextEditor.document.fileName)
+		},
+		(err, stdout, stderr) => {
+			if (err && (<any>err).code === 'ENOENT') {
+				promptForMissingTool('impl');
+				return;
+			}
 
-		if (err) {
-			vscode.window.showInformationMessage(`Cannot stub interface: ${stderr}`);
-			return;
-		}
+			if (err) {
+				vscode.window.showInformationMessage(
+					`Cannot stub interface: ${stderr}`
+				);
+				return;
+			}
 
-		vscode.window.activeTextEditor.edit(editBuilder => {
-			editBuilder.insert(insertPos, stdout);
-		});
-	});
+			vscode.window.activeTextEditor.edit(editBuilder => {
+				editBuilder.insert(insertPos, '\n' + stdout);
+			});
+		}
+	);
 	if (p.pid) {
 		p.stdin.end();
 	}
+}
+
+/**
+ * Return the directory of the given package
+ */
+function getPackageDir(pkg: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const goRuntimePath = getBinPath('go');
+		if (!goRuntimePath) {
+			return [];
+		}
+		cp.execFile(
+			goRuntimePath,
+			['list', '-f', '{{.Dir}}', pkg],
+			null,
+			(err, stdout, stderr) => {
+				if (!stdout) {
+					return;
+				}
+				resolve(stdout.toString().trim());
+			}
+		);
+	});
+}
+
+/**
+ * Return the name of type at the cursor position
+ */
+function getTypeAtCursor(): Promise<string> {
+	return new Promise((resolve, reason) => {
+		const position = vscode.window.activeTextEditor.selection.start;
+		const filename = vscode.window.activeTextEditor.document.fileName;
+		const offset = byteOffsetAt(
+			vscode.window.activeTextEditor.document,
+			position
+		);
+
+		const goGuru = getBinPath('guru');
+		cp.execFile(
+			goGuru,
+			['-json', 'describe', `${filename}:#${offset.toString()}`],
+			null,
+			(err, stdout, stderr) => {
+				if (!stdout) {
+					resolve('');
+					return;
+				}
+				const guruOutput = <GuruDescribeOutput>(
+					JSON.parse(stdout.toString())
+				);
+
+				const resType = guruOutput.type.type;
+				if (!resType.startsWith('struct{')) {
+					resolve(guruOutput.type.type);
+					return;
+				}
+				resolve('');
+			}
+		);
+	});
+}
+
+/**
+ * If the cursor is on a type declaration, move it after the declaration
+ */
+function goToEndOfDeclaration() {
+
+	const position = vscode.window.activeTextEditor.selection.start;
+	const filename = vscode.window.activeTextEditor.document.fileName;
+	const offset = byteOffsetAt(
+		vscode.window.activeTextEditor.document,
+		position
+	);
+
+	const goGuru = getBinPath('guru');
+	cp.execFile(
+		goGuru,
+		['-json', 'what', `${filename}:#${offset.toString()}`],
+		null,
+		(err, stdout, stderr) => {
+			if (!stdout) {
+				return;
+			}
+			const guruOutput = <GuruWhatOutput>JSON.parse(stdout.toString());
+			for (const enclosing of guruOutput.enclosing) {
+				if (enclosing.desc === 'type declaration') {
+					let newPosition = vscode.window.activeTextEditor.document.positionAt(
+						enclosing.end
+					);
+					newPosition = newPosition.with(newPosition.line + 1);
+					const newSelection = new vscode.Selection(
+						newPosition,
+						newPosition
+					);
+					vscode.window.activeTextEditor.selection = newSelection;
+				}
+			}
+		}
+	);
 }

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -44,6 +44,7 @@ const allToolsWithImportPaths: { [key: string]: string } = {
 	'dlv': 'github.com/go-delve/delve/cmd/dlv',
 	'fillstruct': 'github.com/davidrjenni/reftools/cmd/fillstruct',
 	'godoctor': 'github.com/godoctor/godoctor',
+	'gointerfaces': 'github.com/ackar/gointerfaces',
 };
 
 function getToolImportPath(tool: string, goVersion: SemVersion) {
@@ -136,7 +137,8 @@ function getTools(goVersion: SemVersion): string[] {
 		'impl',
 		'fillstruct',
 		'goplay',
-		'godoctor'
+		'godoctor',
+		'gointerfaces'
 	);
 
 	return tools;
@@ -170,7 +172,8 @@ export function installAllTools(updateExistingToolsOnly: boolean = false) {
 		'gopls': '\t\t(Language Server from Google)',
 		'dlv': '\t\t\t(Debugging)',
 		'fillstruct': '\t\t(Fill structs with defaults)',
-		'godoctor': '\t\t(Extract to functions and variables)'
+		'godoctor': '\t\t(Extract to functions and variables)',
+		'gointerfaces': '\t\t(Extract package interfaces)'
 	};
 
 	getGoVersion().then((goVersion) => {


### PR DESCRIPTION
This improves the interface for the "generate interface stubs" command as per https://github.com/microsoft/vscode-go/issues/1823.
This adds a way to select a package and interface as well as automatic receiver name generation.

Example usage:
![out](https://user-images.githubusercontent.com/1406778/59748690-c0150780-92cf-11e9-83f6-5ff67a3594f7.gif)

I couldn't find a way to list interfaces from a package with the current tools so I added my own, but I'd be happy to change that if I missed something.
