### PR TITLE
Clear code coverage upon file save

### DIFF
--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -259,7 +259,7 @@ export function applyCodeCoverage(editor: vscode.TextEditor) {
  * Listener for file save
  * A change in a Go file means the coverage data is stale. Therefore it should be cleared.
  * Instead of clearing it on every edit this clears code coverage on every save.
- * @param e TextDocumentChangeEvent
+ * @param e TextDocument
  */
 export function removeCodeCoverageOnFileSave(e: vscode.TextDocument) {
 	if (e.languageId !== 'go'  || !isCoverageApplied) {

--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -256,6 +256,27 @@ export function applyCodeCoverage(editor: vscode.TextEditor) {
 }
 
 /**
+ * Listener for file save
+ * A change in a Go file means the coverage data is stale. Therefore it should be cleared.
+ * Instead of clearing it on every edit this clears code coverage on every save.
+ * @param e TextDocumentChangeEvent
+ */
+export function removeCodeCoverageOnFileSave(e: vscode.TextDocument) {
+	if (e.languageId !== 'go'  || !isCoverageApplied) {
+		return;
+	}
+
+	if (vscode.window.visibleTextEditors.every(editor => editor.document !== e)) {
+		return;
+	}
+
+	clearCoverage();
+}
+
+
+
+
+/**
  * Listener for change in the editor.
  * A change in a Go file means the coverage data is stale. Therefore it should be cleared.
  * @param e TextDocumentChangeEvent

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -23,7 +23,7 @@ import { check, removeTestStatus, notifyIfGeneratedFile } from './goCheck';
 import { updateGoPathGoRootFromConfig, offerToInstallTools, promptForMissingTool, installTools } from './goInstallTools';
 import { GO_MODE } from './goMode';
 import { showHideStatus } from './goStatus';
-import { initCoverageDecorators, toggleCoverageCurrentPackage, applyCodeCoverage, removeCodeCoverageOnFileChange, updateCodeCoverageDecorators } from './goCover';
+import { initCoverageDecorators, toggleCoverageCurrentPackage, applyCodeCoverage, removeCodeCoverageOnFileSave, updateCodeCoverageDecorators } from './goCover';
 import { testAtCursor, testCurrentPackage, testCurrentFile, testPrevious, testWorkspace } from './goTest';
 import { showTestOutput, cancelRunningTests } from './testUtils';
 import * as goGenerateTests from './goGenerateTests';
@@ -336,7 +336,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 	ctx.subscriptions.push(lintDiagnosticCollection);
 	vetDiagnosticCollection = vscode.languages.createDiagnosticCollection('go-vet');
 	ctx.subscriptions.push(vetDiagnosticCollection);
-	vscode.workspace.onDidChangeTextDocument(removeCodeCoverageOnFileChange, null, ctx.subscriptions);
+	vscode.workspace.onDidSaveTextDocument(removeCodeCoverageOnFileSave, null, ctx.subscriptions);
 	vscode.workspace.onDidChangeTextDocument(removeTestStatus, null, ctx.subscriptions);
 	vscode.window.onDidChangeActiveTextEditor(showHideStatus, null, ctx.subscriptions);
 	vscode.window.onDidChangeActiveTextEditor(applyCodeCoverage, null, ctx.subscriptions);


### PR DESCRIPTION
PR for  [#2551](https://github.com/microsoft/vscode-go/issues/2551https://github.com/microsoft/vscode-go/issues/2551)

Update `goMain.ts` 

Added a new function to `goCover.ts` , `removeCodeCoverageOnFileSave` to handle File Save for clearing code coverage.