### PR TITLE
Added configuration for alternate gopls path.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1500,6 +1500,11 @@
               "default": "gopkgs",
               "description": "Alternate tool to use instead of the gopkgs binary or alternate path to use for the gopkgs binary."
             },
+            "gopls": {
+              "type": "string",
+              "default": "gopls",
+              "description": "Alternate tool to use instead of the gopls binary or alternate path to use for the gopls binary."
+            },
             "go-outline": {
               "type": "string",
               "default": "go-outline",


### PR DESCRIPTION
This is to allow configuring an alternate path for gopls as well. Everything else in the extension is ready for this configuration, but the configuration feature itself is missing. By "ready" I mean these lines:
https://github.com/microsoft/vscode-go/blob/4b516f9a872f3a3086d6d56f8e346d4b5a7e53ef/src/goInstallTools.ts#L559
https://github.com/microsoft/vscode-go/blob/4b516f9a872f3a3086d6d56f8e346d4b5a7e53ef/src/util.ts#L375