### PR TITLE
Make showHideStatus handle an undefined editor

### DIFF
--- a/src/goStatus.ts
+++ b/src/goStatus.ts
@@ -30,13 +30,17 @@ export function showHideStatus(editor: vscode.TextEditor) {
 		}
 	}
 
-	isModSupported(editor.document.uri).then(isMod => {
-		if (isMod) {
-			statusBarItemModule.show();
-		} else {
-			statusBarItemModule.hide();
-		}
-	});
+	if (editor) {
+		isModSupported(editor.document.uri).then(isMod => {
+			if (isMod) {
+				statusBarItemModule.show();
+			} else {
+				statusBarItemModule.hide();
+			}
+		});
+	} else {
+		statusBarItemModule.hide();
+	}
 }
 
 export function hideGoStatus() {


### PR DESCRIPTION
I saw that Travis has been throwing this error on recent builds:
```
  Go Extension Tests
Activating extension `ms-vscode.Go` failed:  Cannot read property 'document' of undefined
Here is the error stack:  TypeError: Cannot read property 'document' of undefined
    at Object.showHideStatus (/Users/travis/gopath/src/github.com/microsoft/vscode-go/src/goStatus.ts:33:24)
    at activate (/Users/travis/gopath/src/github.com/microsoft/vscode-go/src/goMain.ts:328:2)
    at Function._callActivateOptional (/Users/travis/gopath/src/github.com/microsoft/vscode-go/.vscode-test/vscode-1.36.1/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:748:518)
    at Function._callActivate (/Users/travis/gopath/src/github.com/microsoft/vscode-go/.vscode-test/vscode-1.36.1/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:748:207)
    at define._doActivateExtension.Promise.all.then.e (/Users/travis/gopath/src/github.com/microsoft/vscode-go/.vscode-test/vscode-1.36.1/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:747:245)
```
Also, vscode states that `vscode.window.activeTextEditor` can be undefined. Hence I have tried to make showHideStatus resistant to this. 