### PR TITLE
Remove deprecated gometalinter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
     fi
 
 install:
-  - TRAVIS_NODE_VERSION="6"; GOMETALINTER_RELEASE_TAG="v2.0.12"; GOMETALIMTER_INSTALL_SCRIPT_COMMIT="83891259ab664a6d96066685f7f07431375ca8e5";
+  - TRAVIS_NODE_VERSION="6";
   # Clear out whatever version of NVM Travis has as it is old.
   - rm -rf ~/.nvm;
     # Grab NVM.
@@ -49,8 +49,6 @@ install:
   - go get -u -v github.com/cweill/gotests/...
   - go get -u -v github.com/haya14busa/goplay/cmd/goplay
   - go get -u -v github.com/davidrjenni/reftools/cmd/fillstruct
-  # The latest script at https://git.io/vp6lP seems to have broken us as some checkers have been removed. Locking to previous version.
-  - curl -fsSL https://raw.githubusercontent.com/alecthomas/gometalinter/$GOMETALIMTER_INSTALL_SCRIPT_COMMIT/scripts/install.sh | sh -s $GOMETALINTER_RELEASE_TAG -- -b $GOPATH/bin
 
 script:
   - npm run lint

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Read the [Changelog](https://github.com/Microsoft/vscode-go/blob/master/CHANGELO
 
 ### Testing
 
-- Run Tests under the cursor, in current file, in current package, in the whole workspace using either commands or codelens 
+- Run Tests under the cursor, in current file, in current package, in the whole workspace using either commands or codelens
 - Run Benchmarks under the cursor using either commands or codelens
 - Show code coverage either on demand or after running tests in the package.
 - Generate unit tests skeleton (using `gotests`)
@@ -91,7 +91,7 @@ You will see `Analysis Tools Missing` in the bottom right, clicking this will of
 
 **Note 1**: Read [GOPATH in the VS Code Go extension](https://github.com/Microsoft/vscode-go/wiki/GOPATH-in-the-VS-Code-Go-extension) to learn about the different ways you can get the extension to set GOPATH.
 
-**Note 2**: The `Format on save` feature has a timeout of 750ms after which the formatting is aborted. You can change this timeout using the setting `editor.formatOnSaveTimeout`. This feature gets disabled when you have enabled the `Auto Save` feature in Visual Studio Code. 
+**Note 2**: The `Format on save` feature has a timeout of 750ms after which the formatting is aborted. You can change this timeout using the setting `editor.formatOnSaveTimeout`. This feature gets disabled when you have enabled the `Auto Save` feature in Visual Studio Code.
 
 **Note 3**:  This extension uses `gocode` to provide completion lists as you type. If you have disabled the `go.buildOnSave` setting, then you may not get fresh results from not-yet-built dependencies. Therefore, ensure you have built your dependencies manually in such cases.
 
@@ -102,7 +102,7 @@ The Go extension is ready to use on the get go. If you want to customize the fea
 
 ### Go Language Server
 
-The Go extension uses a host of [Go tools](https://github.com/Microsoft/vscode-go/wiki/Go-tools-that-the-Go-extension-depends-on) to provide the various language features. An alternative is to use a single language server that provides the same features using the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) 
+The Go extension uses a host of [Go tools](https://github.com/Microsoft/vscode-go/wiki/Go-tools-that-the-Go-extension-depends-on) to provide the various language features. An alternative is to use a single language server that provides the same features using the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/)
 
 Previously, we added support to use `go-langserver`, the [language server from Sourcegraph](https://github.com/sourcegraph/go-langserver). There is no active development for it anymore and it doesn't support Go modules. Therefore, we are now switching to use `gopls`, the [language server from Google](https://github.com/golang/go/wiki/gopls) which is currently in active development.
 
@@ -152,26 +152,8 @@ If you find any problems using the `gopls` language server, please first check t
 A linter is a tool giving coding style feedback and suggestions.
 By default this extension uses the official [golint](https://github.com/golang/lint) as a linter.
 
-You can change the default linter and use the more advanced [Go Meta Linter](https://github.com/alecthomas/gometalinter)
-by setting `go.lintTool` to "gometalinter" in your settings.
-
-Go Meta Linter uses a collection of various linters which will be installed for you by the extension.
-
-Some of the very useful linter tools:
-* [errcheck](https://github.com/kisielk/errcheck) checks for unchecked errors in your code.
-* [varcheck](https://github.com/opennota/check) finds unused global variables and constants.
-* [deadcode](https://github.com/tsenart/deadcode) finds unused code.
-
-If you want to run only specific linters (some linters are slow), you can modify your configuration to specify them:
-
-```javascript
-  "go.lintFlags": ["--disable=all", "--enable=errcheck"],
-```
-
-Alternatively, you can use [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) which 
-may have significantly better performance than `gometalinter`, while only supporting a subset of the tools.
-
-Another alternative is [golangci-lint](https://github.com/golangci/golangci-lint) which shares some of the performance
+You can change the default linter and use the more advanced [golangci-lint](https://github.com/golangci/golangci-lint)
+by setting `go.lintTool` to "golangci-lint" in your settings. It shares some of the performance
 characteristics of megacheck, but supports a broader range of tools.
 You can configure golangci-lint with `go.lintFlags`, for example to show issues only in new code and to enable all linters:
 
@@ -179,7 +161,9 @@ You can configure golangci-lint with `go.lintFlags`, for example to show issues 
   "go.lintFlags": ["--enable-all", "--new"],
 ```
 
-An alternative of golint is [revive](https://github.com/mgechev/revive). It is extensible, configurable, provides superset of the rules of golint, and has significantly better performance.
+You can also use [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck).
+
+Another alternative of golint is [revive](https://github.com/mgechev/revive). It is extensible, configurable, provides superset of the rules of golint, and has significantly better performance.
 
 To configure revive, use:
 
@@ -245,7 +229,7 @@ Please see our wiki on [Frequently Asked Questions](https://github.com/Microsoft
 
 ## Contributing
 
-This project welcomes contributions and suggestions. Please go through our [Contributing Guide](https://github.com/Microsoft/vscode-go/blob/master/CONTRIBUTING.md) 
+This project welcomes contributions and suggestions. Please go through our [Contributing Guide](https://github.com/Microsoft/vscode-go/blob/master/CONTRIBUTING.md)
 to learn how you can contribute. It also includes details on the Contributor License Agreement.
 
 ## Code of Conduct

--- a/package.json
+++ b/package.json
@@ -775,10 +775,10 @@
           "scope": "resource",
           "enum": [
             "golint",
-            "gometalinter",
             "golangci-lint",
             "revive",
-            "staticcheck"
+            "staticcheck",
+            "gometalinter"
           ]
         },
         "go.lintFlags": {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -148,22 +148,7 @@ export function installTools(missing: Tool[], goVersion: SemVersion): Promise<vo
 					resolve([...sofar, failureReason]);
 				} else {
 					outputChannel.appendLine('Installing ' + getImportPath(tool, goVersion) + ' SUCCEEDED');
-					if (tool.name === 'gometalinter') {
-						// Gometalinter needs to install all the linters it uses.
-						outputChannel.appendLine('Installing all linters used by gometalinter....');
-						const gometalinterBinPath = getBinPath('gometalinter');
-						cp.execFile(gometalinterBinPath, ['--install'], { env: envForTools }, (err, stdout, stderr) => {
-							if (!err) {
-								outputChannel.appendLine('Installing all linters used by gometalinter SUCCEEDED.');
-								resolve([...sofar, null]);
-							} else {
-								const failureReason = `Error while running gometalinter --install;; ${stderr}`;
-								resolve([...sofar, failureReason]);
-							}
-						});
-					} else {
-						resolve([...sofar, null]);
-					}
+					resolve([...sofar, null]);
 				}
 			};
 
@@ -247,7 +232,7 @@ export function promptForMissingTool(toolName: string) {
 			let outdatedErrorMsg;
 			switch (tool.name) {
 				case 'golint':
-					outdatedErrorMsg = 'golint no longer supports go1.8 or below, update your settings to use gometalinter as go.lintTool and install gometalinter';
+					outdatedErrorMsg = 'golint no longer supports go1.8 or below, update your settings to use golangci-lint as go.lintTool and install golangci-lint';
 					break;
 				case 'gotests':
 					outdatedErrorMsg = 'Generate unit tests feature is not supported as gotests tool needs go1.9 or higher.';

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -358,47 +358,6 @@ It returns the number of bytes written and any write error encountered.
 		}).then(() => done(), done);
 	});
 
-	test('Gometalinter error checking', (done) => {
-		getGoVersion().then(async version => {
-			const config = Object.create(vscode.workspace.getConfiguration('go'), {
-				'lintOnSave': { value: 'package' },
-				'lintTool': { value: 'gometalinter' },
-				'lintFlags': { value: ['--disable-all', '--enable=varcheck', '--enable=errcheck'] },
-				'vetOnSave': { value: 'off' },
-				'buildOnSave': { value: 'off' }
-			});
-			const expected = [
-				{ line: 11, severity: 'warning', msg: 'error return value not checked (undeclared name: prin) (errcheck)' },
-				{ line: 11, severity: 'warning', msg: 'unused variable or constant undeclared name: prin (varcheck)' },
-			];
-			const errorsTestPath = path.join(fixturePath, 'errorsTest', 'errors.go');
-			const diagnostics = await check(vscode.Uri.file(errorsTestPath), config);
-			const allDiagnostics = ([] as ICheckResult[]).concat.apply([], diagnostics.map(x => x.errors));
-			const sortedDiagnostics = allDiagnostics.sort((a: any, b: any) => {
-				if (a.msg < b.msg)
-					return -1;
-				if (a.msg > b.msg)
-					return 1;
-				return 0;
-			});
-			assert.equal(sortedDiagnostics.length > 0, true, `Failed to get linter results`);
-			let matchCount = 0;
-			for (const i in expected) {
-				if (expected.hasOwnProperty(i)) {
-					for (const j in sortedDiagnostics) {
-						if ((expected[i].line === sortedDiagnostics[j].line)
-							&& (expected[i].severity === sortedDiagnostics[j].severity)
-							&& (expected[i].msg === sortedDiagnostics[j].msg)) {
-							matchCount++;
-						}
-					}
-				}
-			}
-			assert.equal(matchCount >= expected.length, true, `Failed to match expected errors`);
-			return Promise.resolve();
-		}).then(() => done(), done);
-	});
-
 	test('Test diffUtils.getEditsFromUnifiedDiffStr', (done) => {
 		const file1path = path.join(fixturePath, 'diffTest1Data', 'file1.go');
 		const file2path = path.join(fixturePath, 'diffTest1Data', 'file2.go');


### PR DESCRIPTION
`gometalinter` is deprecated and the suggested replacement is `golangci-lint`, I followed the steps told by @ramya-rao-a in https://github.com/microsoft/vscode-go/issues/2509#issuecomment-526040863 (thank you).