### PR TITLE
Add line comment language configuration for go.mod

### DIFF
--- a/languages/go.mod.language-configuration.json
+++ b/languages/go.mod.language-configuration.json
@@ -1,0 +1,5 @@
+{
+	"comments": {
+		"lineComment": "//"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
         ],
         "aliases": [
           "Go Module File"
-        ]
+        ],
+        "configuration": "./languages/go.mod.language-configuration.json"
       },
       {
         "id": "go.sum",


### PR DESCRIPTION
`go.mod` files support "//" line comments, but not "/*" block comments.

This will enable the "Toggle Line Comment" command for example.