### PR TITLE
fix stopOnEntry

### DIFF
--- a/package.json
+++ b/package.json
@@ -592,11 +592,6 @@
                 "description": "Indicates local or remote debugging.  Local maps to the dlv 'attach' command, remote maps to 'connect'.",
                 "default": "local"
               },
-              "stopOnEntry": {
-                "type": "boolean",
-                "description": "Automatically stop program after launch.",
-                "default": false
-              },
               "showLog": {
                 "type": "boolean",
                 "description": "Show log output from the delve debugger.",

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -823,9 +823,8 @@ class GoDebugSession extends LoggingDebugSession {
 
 	protected async configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): Promise<void> {
 		log('ConfigurationDoneRequest');
-
 		if (this.stopOnEntry) {
-			this.sendEvent(new StoppedEvent('breakpoint', 0));
+			this.sendEvent(new StoppedEvent('breakpoint', 1));
 			log('StoppedEvent("breakpoint")');
 			this.sendResponse(response);
 		} else {
@@ -1003,6 +1002,9 @@ class GoDebugSession extends LoggingDebugSession {
 					goroutine.userCurrentLoc.function ? goroutine.userCurrentLoc.function.name : (goroutine.userCurrentLoc.file + '@' + goroutine.userCurrentLoc.line)
 				)
 			);
+			if (threads.length === 0) {
+				threads.push(new Thread(1, 'Dummy'));
+			}
 			response.body = { threads };
 			this.sendResponse(response);
 			log('ThreadsResponse', threads);


### PR DESCRIPTION
Send a dummy thread to vscode when stopped on entry as there are no
threads in the process yet.
Send the stop event with the same dummy thread ID.