### PR TITLE
Gate the check for gopls updates using a setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1169,10 +1169,10 @@
           },
           "description": "Use this setting to enable/disable experimental features from the language server."
         },
-        "go.languageServerCheckForUpdates": {
+        "go.useGoProxyToCheckForToolUpdates": {
           "type": "boolean",
           "default": true,
-          "description": "When enabled, the extension automatically checks if there is an update available for the language server each time the VS Code window is loaded and prompts user to update."
+          "description": "When enabled, the extension automatically checks the Go proxy if there are updates available for the Go tools (at present, only gopls) it depends on and prompts the user accordingly"
         },
         "go.gotoSymbol.includeImports": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1169,6 +1169,11 @@
           },
           "description": "Use this setting to enable/disable experimental features from the language server."
         },
+        "go.languageServerCheckForUpdates": {
+          "type": "boolean",
+          "default": false,
+          "description": "When enabled, the extension automatically checks if there is an update available for the language server each time the VS Code window is loaded and prompts user to update."
+        },
         "go.gotoSymbol.includeImports": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -1171,7 +1171,7 @@
         },
         "go.languageServerCheckForUpdates": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "When enabled, the extension automatically checks if there is an update available for the language server each time the VS Code window is loaded and prompts user to update."
         },
         "go.gotoSymbol.includeImports": {

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -56,7 +56,7 @@ interface LanguageServerConfig {
 		implementation: boolean;
 		documentLink: boolean;
 	};
-	checkForUpdates: boolean
+	checkForUpdates: boolean;
 }
 
 // registerLanguageFeatures registers providers for all the language features.

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -56,6 +56,7 @@ interface LanguageServerConfig {
 		implementation: boolean;
 		documentLink: boolean;
 	};
+	checkForUpdates: boolean
 }
 
 // registerLanguageFeatures registers providers for all the language features.
@@ -79,7 +80,7 @@ export async function registerLanguageFeatures(ctx: vscode.ExtensionContext) {
 
 	// The user may not have the most up-to-date version of the language server.
 	const tool = getTool(toolName);
-	const update = await shouldUpdateLanguageServer(tool, path);
+	const update = await shouldUpdateLanguageServer(tool, path, config.checkForUpdates);
 	if (update) {
 		promptForUpdatingTool(toolName);
 	}
@@ -312,6 +313,7 @@ export function parseLanguageServerConfig(): LanguageServerConfig {
 			implementation: goConfig['languageServerExperimentalFeatures']['implementation'],
 			documentLink: goConfig['languageServerExperimentalFeatures']['documentLink'],
 		},
+		checkForUpdates: goConfig['languageServerCheckForUpdates']
 	};
 	return config;
 }
@@ -397,7 +399,7 @@ function registerUsualProviders(ctx: vscode.ExtensionContext) {
 
 const defaultLatestVersion = semver.coerce('0.1.7');
 const defaultLatestVersionTime = moment('2019-09-18', 'YYYY-MM-DD');
-async function shouldUpdateLanguageServer(tool: Tool, path: string): Promise<boolean> {
+async function shouldUpdateLanguageServer(tool: Tool, path: string, makeProxyCall: boolean): Promise<boolean> {
 	// Only support updating gopls for now.
 	if (tool.name !== 'gopls') {
 		return false;
@@ -417,24 +419,23 @@ async function shouldUpdateLanguageServer(tool: Tool, path: string): Promise<boo
 	}
 
 	// Get the latest gopls version.
-	const latestVersion = defaultLatestVersion;
-	// const latestVersion = await latestGopls(tool);
+	let latestVersion = makeProxyCall ? await latestGopls(tool) : defaultLatestVersion;
 
-	// // If we failed to get the gopls version, assume the user does not need to update.
-	// if (!latestVersion) {
-	// 	return false;
-	// }
+	// If we failed to get the gopls version, pick the one we know to be latest at the time of this extension's last update
+	if (!latestVersion) {
+		latestVersion = defaultLatestVersion;
+	}
 
 	// The user may have downloaded golang.org/x/tools/gopls@master,
 	// which means that they have a pseudoversion.
 	const usersTime = parsePseudoversionTimestamp(usersVersion);
 	// If the user has a pseudoversion, get the timestamp for the latest gopls version and compare.
 	if (usersTime) {
-		return usersTime.isBefore(defaultLatestVersionTime);
-		// const latestTime = await goplsVersionTimestamp(tool.importPath, latestVersion);
-		// if (latestTime) {
-		// 	return usersTime.isBefore(latestTime);
-		// }
+		let latestTime = makeProxyCall ? await goplsVersionTimestamp(tool.importPath, latestVersion) : defaultLatestVersionTime;
+		if (!latestTime) {
+			latestTime = defaultLatestVersionTime;
+		}
+		return usersTime.isBefore(latestTime);
 	}
 
 	// If the user's version does not contain a timestamp,

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -313,7 +313,7 @@ export function parseLanguageServerConfig(): LanguageServerConfig {
 			implementation: goConfig['languageServerExperimentalFeatures']['implementation'],
 			documentLink: goConfig['languageServerExperimentalFeatures']['documentLink'],
 		},
-		checkForUpdates: goConfig['languageServerCheckForUpdates']
+		checkForUpdates: goConfig['useGoProxyToCheckForToolUpdates']
 	};
 	return config;
 }

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -448,6 +448,7 @@ function sendTelemetryEventForConfig(goConfig: vscode.WorkspaceConfiguration) {
 		  "liveErrors": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
 		  "codeLens": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
 		  "alternateTools": { "classification": "CustomerContent", "purpose": "FeatureInsight" }
+		  "useGoProxyToCheckForToolUpdates": { "classification": "CustomerContent", "purpose": "FeatureInsight" }
 	   }
 	 */
 	sendTelemetryEvent('goConfig', {
@@ -487,7 +488,8 @@ function sendTelemetryEventForConfig(goConfig: vscode.WorkspaceConfiguration) {
 		editorContextMenuCommands: JSON.stringify(goConfig['editorContextMenuCommands']),
 		liveErrors: JSON.stringify(goConfig['liveErrors']),
 		codeLens: JSON.stringify(goConfig['enableCodeLens']),
-		alternateTools: JSON.stringify(goConfig['alternateTools'])
+		alternateTools: JSON.stringify(goConfig['alternateTools']),
+		useGoProxyToCheckForToolUpdates: goConfig['useGoProxyToCheckForToolUpdates'] + '',
 	});
 }
 


### PR DESCRIPTION
As seen in #2768 and #2767, the implicit calls to https://proxy.golang.org/golang.org/x/tools/gopls/@v/list can fail in multiple scenarios.

In VS Code, we also want to follow the guideline of not making any outgoing calls over the network unless it is done as part of a feature resulting from an explicit user action which the user is aware of.

Exceptions to this rule should be documented and a setting should be provided for the user to opt in/out.

Keeping this in mind, the recent feature of making calls to https://proxy.golang.org/golang.org is being updated as follows in this PR
- Provide a setting to opt in to the automatic update check. This is similar to the `extensions.autoCheckUpdates` setting in VS Code
- If the above is not enabled, then hard-code the latest known latest version of `gopls` in the extension 