### PR TITLE
Hard-code latest version info for gopls

### DIFF
--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -395,6 +395,8 @@ function registerUsualProviders(ctx: vscode.ExtensionContext) {
 	vscode.workspace.onDidChangeTextDocument(parseLiveFile, null, ctx.subscriptions);
 }
 
+const defaultLatestVersion = semver.coerce('0.1.7');
+const defaultLatestVersionTime = moment('2019-09-18', 'YYYY-MM-DD');
 async function shouldUpdateLanguageServer(tool: Tool, path: string): Promise<boolean> {
 	// Only support updating gopls for now.
 	if (tool.name !== 'gopls') {
@@ -415,22 +417,24 @@ async function shouldUpdateLanguageServer(tool: Tool, path: string): Promise<boo
 	}
 
 	// Get the latest gopls version.
-	const latestVersion = await latestGopls(tool);
+	const latestVersion = defaultLatestVersion;
+	// const latestVersion = await latestGopls(tool);
 
-	// If we failed to get the gopls version, assume the user does not need to update.
-	if (!latestVersion) {
-		return false;
-	}
+	// // If we failed to get the gopls version, assume the user does not need to update.
+	// if (!latestVersion) {
+	// 	return false;
+	// }
 
 	// The user may have downloaded golang.org/x/tools/gopls@master,
 	// which means that they have a pseudoversion.
 	const usersTime = parsePseudoversionTimestamp(usersVersion);
 	// If the user has a pseudoversion, get the timestamp for the latest gopls version and compare.
 	if (usersTime) {
-		const latestTime = await goplsVersionTimestamp(tool.importPath, latestVersion);
-		if (latestTime) {
-			return usersTime.isBefore(latestTime);
-		}
+		return usersTime.isBefore(defaultLatestVersionTime);
+		// const latestTime = await goplsVersionTimestamp(tool.importPath, latestVersion);
+		// if (latestTime) {
+		// 	return usersTime.isBefore(latestTime);
+		// }
 	}
 
 	// If the user's version does not contain a timestamp,


### PR DESCRIPTION
Hard-coding latest version info for gopls for now while we explore if using go proxy as the source of truth for the `gopls` version info is the right approach or not

cc @stamblerre 