### PR TITLE
Refactor some of the installation code that calls the go command

### DIFF
--- a/src/goCommand.ts
+++ b/src/goCommand.ts
@@ -1,6 +1,6 @@
 import util = require('util');
 import cp = require('child_process');
-import { getBinPath } from "./util";
+import { getBinPath } from './util';
 
 const execFile = util.promisify(cp.execFile);
 
@@ -33,7 +33,7 @@ async function goCommand(cmd: string, path: string, flags: string[], opts: any):
 	let err: Error;
 
 	try {
-		let result = await execFile(goRuntimePath, args, opts);
+		const result = await execFile(goRuntimePath, args, opts);
 		stdout = result.stdout.toString();
 		stderr = result.stderr.toString();
 	} catch (e) {

--- a/src/goCommand.ts
+++ b/src/goCommand.ts
@@ -19,12 +19,18 @@ export async function goBuild(path: string, flags: string[], opts: any): Promise
 async function goCommand(cmd: string, path: string, flags: string[], opts: any): Promise<GoCommandResult> {
 	const goRuntimePath = getBinPath('go');
 	if (!goRuntimePath) {
-		return null;
+		return new Promise<GoCommandResult>(resolve => {
+			resolve({
+				stdout: '',
+				stderr: '',
+				err: new Error('failed to determine path to `go` binary'),
+			})
+		});
 	}
 
 	const args = [cmd, ...flags, path];
 
-	return new Promise<GoCommandResult>((resolve) => {
+	return new Promise<GoCommandResult>(resolve => {
 		cp.execFile(goRuntimePath, args, opts, (err, stdout, stderr) => {
 			resolve({
 				stdout: stdout.toString(),

--- a/src/goCommand.ts
+++ b/src/goCommand.ts
@@ -1,0 +1,14 @@
+import { getBinPath } from "./util";
+
+export function goGet() {
+	const goRuntimePath = getBinPath('go');
+
+}
+
+export function goList() {
+	const goRuntimePath = getBinPath('go');
+}
+
+export function goEnv() {
+	const goRuntimePath = getBinPath('go');
+}

--- a/src/goCommand.ts
+++ b/src/goCommand.ts
@@ -1,14 +1,43 @@
+import util = require('util');
+import cp = require('child_process');
 import { getBinPath } from "./util";
 
-export function goGet() {
-	const goRuntimePath = getBinPath('go');
+const execFile = util.promisify(cp.execFile);
 
+export class GoCommandResult {
+	stderr: string;
+	stdout: string;
+	err: Error;
 }
 
-export function goList() {
-	const goRuntimePath = getBinPath('go');
+export async function goGet(path: string, flags: string[], opts: any): Promise<GoCommandResult> {
+	return goCommand('get', path, flags, opts);
 }
 
-export function goEnv() {
+export async function goBuild(path: string, flags: string[], opts: any): Promise<GoCommandResult> {
+	return goCommand('build', path, flags, opts);
+}
+
+async function goCommand(cmd: string, path: string, flags: string[], opts: any): Promise<GoCommandResult> {
 	const goRuntimePath = getBinPath('go');
+	if (!goRuntimePath) {
+		return null;
+	}
+
+	let args: string[] = [cmd];
+	args = args.concat(flags);
+	args.push(path);
+
+	let stdout: string;
+	let stderr: string;
+	let err: Error;
+
+	try {
+		let result = await execFile(goRuntimePath, args, opts);
+		stdout = result.stdout.toString();
+		stderr = result.stderr.toString();
+	} catch (e) {
+		err = e;
+	}
+	return { stdout: stdout, stderr: stderr, err: err };
 }

--- a/src/goGetPackage.ts
+++ b/src/goGetPackage.ts
@@ -23,8 +23,8 @@ export async function goGetPackage() {
 	}
 
 	const env = Object.assign({}, process.env, { GOPATH: getCurrentGoPath() });
+	const result = await goGet(importPath, ['-v'], { env });
 
-	let result = await goGet(importPath, ['-v'], { env });
 	// go get -v doesn't write anything when the package already exists
 	if (result.stderr === '') {
 		vscode.window.showInformationMessage(`Package already exists: ${importPath}`);

--- a/src/goGetPackage.ts
+++ b/src/goGetPackage.ts
@@ -24,6 +24,10 @@ export async function goGetPackage() {
 
 	const env = Object.assign({}, process.env, { GOPATH: getCurrentGoPath() });
 	const result = await goGet(importPath, ['-v'], { env });
+	if (result.err) {
+		vscode.window.showErrorMessage(`failed to get ${importPath}: ${result.err.message}`);
+		return;
+	}
 
 	// go get -v doesn't write anything when the package already exists
 	if (result.stderr === '') {

--- a/src/goGetPackage.ts
+++ b/src/goGetPackage.ts
@@ -28,11 +28,11 @@ export async function goGetPackage() {
 	// go get -v doesn't write anything when the package already exists
 	if (result.stderr === '') {
 		vscode.window.showInformationMessage(`Package already exists: ${importPath}`);
+		return;
 	}
 
 	outputChannel.show();
 	outputChannel.clear();
 	outputChannel.appendLine(result.stderr);
 	buildCode();
-	return;
 }


### PR DESCRIPTION
I'm hoping to refactor some of the code that calls the `go` command, since it gets called in many different places and there's a fair amount of duplication. This is the first of the changes that will do this refactoring.