### PR TITLE
Show correct placeholder when extracting method

### DIFF
--- a/src/goDoctor.ts
+++ b/src/goDoctor.ts
@@ -42,7 +42,7 @@ async function extract(type: typeOfExtraction): Promise<void> {
 	}
 
 	const newName = await vscode.window.showInputBox({
-		placeHolder: 'Please enter a name for the extracted variable.'
+		placeHolder: `Please enter a name for the extracted ${type === 'var' ? 'variable' : 'method'}.`
 	});
 
 	if (!newName) {


### PR DESCRIPTION
Currently the placeholder text when extracting a function or a variable is

> Please enter a name for the extracted variable.

With this change, in the case of extracting a function, the placeholder text will be

> Please enter a name for the extracted method.