### PR TITLE
Fix and reenable linux in travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,13 @@ sudo: false
 
 os:
   - osx
-  # - linux
+  - linux
 
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
     export DISPLAY=:99.0;
-    sh -e /etc/init.d/xvfb start;
+    Xvfb :99 &
+    sleep 3; # give xvfb some time to start 
     sudo apt-get update && sudo apt-get install -y libsecret-1-0;
     fi
 


### PR DESCRIPTION
After travis-ci moved their default linux os from trusty to xenial, `xvfb` has to be started differently.

Closes #2779 