### PR TITLE
support Go 1.11 when installing tools in module mode

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -129,6 +129,11 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 	if (!fs.existsSync(toolsTmpDir)) {
 		fs.mkdirSync(toolsTmpDir);
 	}
+	// Write a temporary go.mod file to support Go 1.11.
+	const tmpGoModFile = path.join(toolsTmpDir, 'go.mod');
+	if (!fs.existsSync(tmpGoModFile)) {
+		fs.writeFileSync(tmpGoModFile, 'module tools');
+	}
 
 	return missing.reduce((res: Promise<string[]>, tool: Tool) => {
 		// Disable modules for tools which are installed with the "..." wildcard.

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -130,9 +130,11 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 		fs.mkdirSync(toolsTmpDir);
 	}
 	// Write a temporary go.mod file to support Go 1.11.
-	const tmpGoModFile = path.join(toolsTmpDir, 'go.mod');
-	if (!fs.existsSync(tmpGoModFile)) {
-		fs.writeFileSync(tmpGoModFile, 'module tools');
+	if (goVersion.lt('1.12')) {
+		const tmpGoModFile = path.join(toolsTmpDir, 'go.mod');
+		if (!fs.existsSync(tmpGoModFile)) {
+			fs.writeFileSync(tmpGoModFile, 'module tools');
+		}
 	}
 
 	return missing.reduce((res: Promise<string[]>, tool: Tool) => {


### PR DESCRIPTION
Go 1.11 still requires a `go.mod` file to download in module mode. Support it by adding a fake `go.mod` file to the temporary directory for tool installation.