### PR TITLE
Move comment outside multiline command in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,11 @@ os:
   - linux
 
 before_install:
+  # Call xvfb directly on linux runs and give it time to start
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
     export DISPLAY=:99.0;
     Xvfb :99 &
-    sleep 3; # give xvfb some time to start 
+    sleep 3;
     sudo apt-get update && sudo apt-get install -y libsecret-1-0;
     fi
 


### PR DESCRIPTION
Yaml doesn't support inline comments on multiline strings (#2802), unfortunately. 
Travis can't parse the file correctly and stops running builds. 
I saw it too late, after #2802 already got merged.
This PR should amend this.