### PR TITLE
Clean up the signature help test

### DIFF
--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -106,7 +106,7 @@ suite('Go Extension Tests', () => {
 		try {
 			const textDocument = await vscode.workspace.openTextDocument(uri);
 			const promises = testCases.map(([position, expected, expectedDoc, expectedParams]) => provider.provideSignatureHelp(textDocument, position, null).then(sigHelp => {
-				assert.ok(sigHelp, `No signature for gogetdocTestData/test.go:${position.line+1}:${position.character+1}`);
+				assert.ok(sigHelp, `No signature for gogetdocTestData/test.go:${position.line + 1}:${position.character + 1}`);
 				assert.equal(sigHelp.signatures.length, 1, 'unexpected number of overloads');
 				assert.equal(sigHelp.signatures[0].label, expected);
 				assert.equal(sigHelp.signatures[0].documentation, expectedDoc);
@@ -921,7 +921,7 @@ encountered.
 			const editor = await vscode.window.showTextDocument(textDocument);
 			const promises = testCases.map(([position, expected]) => provider.provideCompletionItems(editor.document, position, null).then(items => {
 				const labels = items.items.map(x => x.label);
-				assert.equal(expected.length, labels.length, `expected number of completions: ${expected.length} Actual: ${labels.length} at position(${position.line+1},${position.character+1}) ${labels}`);
+				assert.equal(expected.length, labels.length, `expected number of completions: ${expected.length} Actual: ${labels.length} at position(${position.line + 1},${position.character + 1}) ${labels}`);
 				expected.forEach((entry, index) => {
 					assert.equal(entry, labels[index], `mismatch in comment completion list Expected: ${entry} Actual: ${labels[index]}`);
 				});

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -14,6 +14,7 @@ import { GoDefinitionProvider } from '../../src/goDeclaration';
 import { getWorkspaceSymbols } from '../../src/goSymbol';
 import { check } from '../../src/goCheck';
 import cp = require('child_process');
+import os = require('os');
 import { getEditsFromUnifiedDiffStr, getEdits, FilePatch } from '../../src/diffUtils';
 import { testCurrentFile } from '../../src/goTest';
 import { getBinPath, getGoVersion, isVendorSupported, getToolsGopath, getCurrentGoPath, ICheckResult } from '../../src/util';
@@ -26,7 +27,7 @@ import { goPlay } from '../../src/goPlayground';
 import { runFillStruct } from '../../src/goFillStruct';
 
 suite('Go Extension Tests', () => {
-	const gopath = process.env['GOPATH'];
+	const gopath = process.env['GOPATH'] || path.join(os.homedir(), 'go');
 	if (!gopath) {
 		assert.ok(gopath, 'Cannot run tests if GOPATH is not set as environment variable');
 		return;

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -14,7 +14,6 @@ import { GoDefinitionProvider } from '../../src/goDeclaration';
 import { getWorkspaceSymbols } from '../../src/goSymbol';
 import { check } from '../../src/goCheck';
 import cp = require('child_process');
-import os = require('os');
 import { getEditsFromUnifiedDiffStr, getEdits, FilePatch } from '../../src/diffUtils';
 import { testCurrentFile } from '../../src/goTest';
 import { getBinPath, getGoVersion, isVendorSupported, getToolsGopath, getCurrentGoPath, ICheckResult } from '../../src/util';

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -27,7 +27,7 @@ import { goPlay } from '../../src/goPlayground';
 import { runFillStruct } from '../../src/goFillStruct';
 
 suite('Go Extension Tests', () => {
-	const gopath = process.env['GOPATH'] || path.join(os.homedir(), 'go');
+	const gopath = getCurrentGoPath();
 	if (!gopath) {
 		assert.ok(gopath, 'Cannot run tests if GOPATH is not set as environment variable');
 		return;

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -107,7 +107,7 @@ suite('Go Extension Tests', () => {
 		try {
 			const textDocument = await vscode.workspace.openTextDocument(uri);
 			const promises = testCases.map(([position, expected, expectedDoc, expectedParams]) => provider.provideSignatureHelp(textDocument, position, null).then(sigHelp => {
-				assert.ok(sigHelp, `No signature for gogetdocTestData/test.go:${position}`);
+				assert.ok(sigHelp, `No signature for gogetdocTestData/test.go:${position.line+1}:${position.character+1}`);
 				assert.equal(sigHelp.signatures.length, 1, 'unexpected number of overloads');
 				assert.equal(sigHelp.signatures[0].label, expected);
 				assert.equal(sigHelp.signatures[0].documentation, expectedDoc);
@@ -922,7 +922,7 @@ encountered.
 			const editor = await vscode.window.showTextDocument(textDocument);
 			const promises = testCases.map(([position, expected]) => provider.provideCompletionItems(editor.document, position, null).then(items => {
 				const labels = items.items.map(x => x.label);
-				assert.equal(expected.length, labels.length, `expected number of completions: ${expected.length} Actual: ${labels.length} at position(${position.line},${position.character}) ${labels}`);
+				assert.equal(expected.length, labels.length, `expected number of completions: ${expected.length} Actual: ${labels.length} at position(${position.line+1},${position.character+1}) ${labels}`);
 				expected.forEach((entry, index) => {
 					assert.equal(entry, labels[index], `mismatch in comment completion list Expected: ${entry} Actual: ${labels[index]}`);
 				});


### PR DESCRIPTION
- Allow integration tests to run with the default GOPATH of ~/go.
- Display user-friendly positions in test failures

Updates #2805
 