### PR TITLE
Always use a fake mod file and fresh temp directory for installation

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -125,17 +125,11 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 	outputChannel.appendLine(''); // Blank line for spacing.
 
 	// Install tools in a temporary directory, to avoid altering go.mod files.
-	const toolsTmpDir = getTempFilePath('go-tools');
-	if (!fs.existsSync(toolsTmpDir)) {
-		fs.mkdirSync(toolsTmpDir);
-	}
-	// Write a temporary go.mod file to support Go 1.11.
-	if (goVersion.lt('1.12')) {
-		const tmpGoModFile = path.join(toolsTmpDir, 'go.mod');
-		if (!fs.existsSync(tmpGoModFile)) {
-			fs.writeFileSync(tmpGoModFile, 'module tools');
-		}
-	}
+	const toolsTmpDir = fs.mkdtempSync(getTempFilePath('go-tools-'));
+
+	// Write a temporary go.mod file.
+	const tmpGoModFile = path.join(toolsTmpDir, 'go.mod');
+	fs.writeFileSync(tmpGoModFile, 'module tools');
 
 	return missing.reduce((res: Promise<string[]>, tool: Tool) => {
 		// Disable modules for tools which are installed with the "..." wildcard.


### PR DESCRIPTION
Running other `go` commands in the installation directory requires a `go.mod` file (this fixes the issue described in https://github.com/microsoft/vscode-go/issues/2811#issuecomment-544101197).

We should always use a fresh directory for installations in case versions change across multiple installations.

Fixes https://github.com/stamblerre/gocode/issues/40