### PR TITLE
Use  mod file to determine module mode when debugging

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -232,6 +232,7 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 
 	showGlobalVariables?: boolean;
 	currentFile: string;
+	packagePathToGoModPathMap: Map<string, string>;
 }
 
 interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
@@ -434,7 +435,7 @@ class Delve {
 				dlvArgs.push(mode || 'debug');
 				if (mode === 'exec') {
 					dlvArgs.push(program);
-				} else if (currentGOWorkspace && env['GO111MODULE'] !== 'on') {
+				} else if (currentGOWorkspace && !launchArgs.packagePathToGoModPathMap.get(dirname)) {
 					dlvArgs.push(dirname.substr(currentGOWorkspace.length + 1));
 				}
 				dlvArgs.push('--headless=true', `--listen=${launchArgs.host}:${launchArgs.port}`);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -232,7 +232,7 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 
 	showGlobalVariables?: boolean;
 	currentFile: string;
-	packagePathToGoModPathMap: Map<string, string>;
+	packagePathToGoModPathMap: {[key: string]: string};
 }
 
 interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
@@ -435,7 +435,7 @@ class Delve {
 				dlvArgs.push(mode || 'debug');
 				if (mode === 'exec') {
 					dlvArgs.push(program);
-				} else if (currentGOWorkspace && !launchArgs.packagePathToGoModPathMap.get(dirname)) {
+				} else if (currentGOWorkspace && !launchArgs.packagePathToGoModPathMap[dirname]) {
 					dlvArgs.push(dirname.substr(currentGOWorkspace.length + 1));
 				}
 				dlvArgs.push('--headless=true', `--listen=${launchArgs.host}:${launchArgs.port}`);

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -10,6 +10,7 @@ import path = require('path');
 import { promptForMissingTool } from './goInstallTools';
 import { getFromGlobalState, updateGlobalState } from './stateUtils';
 import { getBinPath, getCurrentGoPath, getGoConfig, getToolsEnvVars, sendTelemetryEvent } from './util';
+import { packagePathToGoModPathMap } from './goModules';
 
 export class GoDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 
@@ -61,6 +62,8 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 				'program': activeEditor.document.fileName
 			};
 		}
+
+		debugConfiguration['packagePathToGoModPathMap'] = packagePathToGoModPathMap;
 
 		const gopath = getCurrentGoPath(folder ? folder.uri : null);
 		if (!debugConfiguration['env']) {

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -24,7 +24,7 @@ import { registerLanguageFeatures } from './goLanguageServer';
 import { lintCode } from './goLint';
 import { GO_MODE } from './goMode';
 import { addTags, removeTags } from './goModifytags';
-import { GO111MODULE } from './goModules';
+import { GO111MODULE, isModSupported } from './goModules';
 import { clearCacheForTools } from './goPath';
 import { playgroundCommand } from './goPlayground';
 import { GoReferencesCodeLensProvider } from './goReferencesCodelens';
@@ -90,7 +90,10 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		await registerLanguageFeatures(ctx);
 
 		if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.languageId === 'go' && isGoPathSet()) {
-			runBuilds(vscode.window.activeTextEditor.document, getGoConfig());
+			// Check mod status so that cache is updated and then run build/lint/vet
+			isModSupported(vscode.window.activeTextEditor.document.uri).then(() => {
+				runBuilds(vscode.window.activeTextEditor.document, getGoConfig());
+			});
 		}
 
 	});

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -38,12 +38,12 @@ export function isModSupported(fileuri: vscode.Uri): Promise<boolean> {
 	return getModFolderPath(fileuri).then(modPath => !!modPath);
 }
 
-export const packagePathToGoModPathMap = new Map<string, string>();
+export const packagePathToGoModPathMap: {[key: string]: string} = {};
 
 export async function getModFolderPath(fileuri: vscode.Uri): Promise<string> {
 	const pkgPath = path.dirname(fileuri.fsPath);
-	if (packagePathToGoModPathMap.has(pkgPath)) {
-		return packagePathToGoModPathMap.get(pkgPath);
+	if (packagePathToGoModPathMap[pkgPath]) {
+		return packagePathToGoModPathMap[pkgPath];
 	}
 
 	// We never would be using the path under module cache for anything
@@ -82,7 +82,7 @@ export async function getModFolderPath(fileuri: vscode.Uri): Promise<string> {
 			await promptToUpdateToolForModules('switchFormatToolToGoimports', promptMsgForFormatTool, goConfig);
 		}
 	}
-	packagePathToGoModPathMap.set(pkgPath, goModEnvResult);
+	packagePathToGoModPathMap[pkgPath] = goModEnvResult;
 	return goModEnvResult;
 }
 

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -38,7 +38,7 @@ export function isModSupported(fileuri: vscode.Uri): Promise<boolean> {
 	return getModFolderPath(fileuri).then(modPath => !!modPath);
 }
 
-const packagePathToGoModPathMap = new Map<string, string>();
+export const packagePathToGoModPathMap = new Map<string, string>();
 
 export async function getModFolderPath(fileuri: vscode.Uri): Promise<string> {
 	const pkgPath = path.dirname(fileuri.fsPath);


### PR DESCRIPTION
This PR attempts to fix the issue in #2828 where code under GOPATH gets debugged under the assumption that we are not in module mode if GO111MODULE is not `on`.