### PR TITLE
tslint: add no-empty

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1601,6 +1601,7 @@ function killTree(processId: number): void {
 		try {
 			execSync(`${TASK_KILL} /F /T /PID ${processId}`);
 		} catch (err) {
+			logError(`Error killing process tree: ${err.toString() || ''}`);
 		}
 	} else {
 		// on linux and OS X we kill all direct and indirect child processes as well
@@ -1608,6 +1609,7 @@ function killTree(processId: number): void {
 			const cmd = path.join(__dirname, '../../../scripts/terminateProcess.sh');
 			spawnSync(cmd, [processId.toString()]);
 		} catch (err) {
+			logError(`Error killing process tree: ${err.toString() || ''}`);
 		}
 	}
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -839,6 +839,7 @@ export function killTree(processId: number): void {
 		try {
 			cp.execSync(`${TASK_KILL} /F /T /PID ${processId}`);
 		} catch (err) {
+			console.log('Error killing process tree: ' + err);
 		}
 	} else {
 		// on linux and OS X we kill all direct and indirect child processes as well
@@ -846,6 +847,7 @@ export function killTree(processId: number): void {
 			const cmd = path.join(__dirname, '../../../scripts/terminateProcess.sh');
 			cp.spawnSync(cmd, [processId.toString()]);
 		} catch (err) {
+			console.log('Error killing process tree: ' + err);
 		}
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -75,7 +75,7 @@
 		"no-debugger": true,
 		"no-duplicate-super": true,
 		"no-duplicate-variable": true,
-		// "no-empty": true,
+		"no-empty": true,
 		"no-empty-interface": true,
 		"no-eval": true,
 		"no-internal-module": true,


### PR DESCRIPTION
Part of fixing #2333.

I've tried to handle errors in the same way as other areas of each file.
I've operated under the assumption that logging errors is better than
silently dropping them.