### PR TITLE
run `go mod tidy` between tool installations

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -155,7 +155,9 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 			const callback = (err: Error, stdout: string, stderr: string) => {
 				// Make sure to run `go mod tidy` between tool installations.
 				// This avoids us having to create a fresh go.mod file for each tool.
-				cp.execFileSync(goRuntimePath, ['mod', 'tidy'], opts);
+				if (!modulesOff) {
+					cp.execFileSync(goRuntimePath, ['mod', 'tidy'], opts);
+				}
 				if (err) {
 					outputChannel.appendLine('Installing ' + getImportPath(tool, goVersion) + ' FAILED');
 					const failureReason = tool.name + ';;' + err + stdout.toString() + stderr.toString();

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -162,7 +162,7 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 				});
 			}
 
-			let success = await closeToolPromise;
+			const success = await closeToolPromise;
 			if (!success) {
 				resolve([...sofar, null]);
 				return;

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -152,7 +152,6 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 				env: envForTools,
 				cwd: toolsTmpDir,
 			};
-
 			const callback = (err: Error, stdout: string, stderr: string) => {
 				// Make sure to run `go mod tidy` between tool installations.
 				// This avoids us having to create a fresh go.mod file for each tool.
@@ -197,7 +196,6 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 					args.push('-d');
 				}
 				args.push(getImportPath(tool, goVersion));
-
 				cp.execFile(goRuntimePath, args, opts, (err, stdout, stderr) => {
 					if (stderr.indexOf('unexpected directory layout:') > -1) {
 						outputChannel.appendLine(`Installing ${tool.name} failed with error "unexpected directory layout". Retrying...`);


### PR DESCRIPTION
This prevents modifications to the `go.mod` file from affecting other tool installations.