### PR TITLE
Exclude prerelease tagged versions when fetching latest gopls version

### DIFF
--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -518,15 +518,8 @@ async function latestGopls(tool: Tool): Promise<semver.SemVer> {
 	}
 	versions.sort(semver.rcompare);
 
-	let latestNonPreRelease: semver.SemVer;
-	for (const version of versions) {
-		// The first version in the sorted list without a prerelease tag.
-		if (version.prerelease.length === 0) {
-			latestNonPreRelease = version;
-			break;
-		}
-	}
-	return latestNonPreRelease;
+	// The first version in the sorted list without a prerelease tag.
+	return versions.find(version => !version.prerelease || !version.prerelease.length);
 }
 
 async function goplsVersion(goplsPath: string): Promise<string> {

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -507,13 +507,26 @@ async function latestGopls(tool: Tool): Promise<semver.SemVer> {
 	// Coerce the versions into SemVers so that they can be sorted correctly.
 	const versions = [];
 	for (const version of data.trim().split('\n')) {
-		versions.push(semver.coerce(version));
+		const parsed = semver.parse(version, {
+			includePrerelease: true,
+			loose: true,
+		});
+		versions.push(parsed);
 	}
 	if (versions.length === 0) {
 		return null;
 	}
 	versions.sort(semver.rcompare);
-	return versions[0];
+
+	var latestNonPreRelease: semver.SemVer;
+	for (const version of versions) {
+		// The first version in the sorted list without a prerelease tag.
+		if (version.prerelease.length == 0) {
+			latestNonPreRelease = version;
+			break;
+		}
+	}
+	return latestNonPreRelease;
 }
 
 async function goplsVersion(goplsPath: string): Promise<string> {
@@ -594,7 +607,7 @@ async function goProxyRequest(tool: Tool, endpoint: string): Promise<any> {
 	return null;
 }
 
-function goProxy(): string[]  {
+function goProxy(): string[] {
 	const output: string = process.env['GOPROXY'];
 	if (!output || !output.trim()) {
 		return [];

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -518,10 +518,10 @@ async function latestGopls(tool: Tool): Promise<semver.SemVer> {
 	}
 	versions.sort(semver.rcompare);
 
-	var latestNonPreRelease: semver.SemVer;
+	let latestNonPreRelease: semver.SemVer;
 	for (const version of versions) {
 		// The first version in the sorted list without a prerelease tag.
-		if (version.prerelease.length == 0) {
+		if (version.prerelease.length === 0) {
 			latestNonPreRelease = version;
 			break;
 		}


### PR DESCRIPTION
This change makes sure that we don't update users to pre-release versions of `gopls`.