### PR TITLE
Relativize source files passed to delve if possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -410,6 +410,11 @@
           "launch": {
             "required": [],
             "properties": {
+              "sourceRoot": {
+                "type": "string",
+                "description": "Path with which to relativize source file paths. Required to debug binaries built with trim-paths e.g. with Bazel",
+                "default": "${workspaceFolder}"
+              },
               "program": {
                 "type": "string",
                 "description": "Path to the program folder (or any file within that folder) when in 'debug' or 'test' mode, and to the pre-built binary file to debug in 'exec' mode.",

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -235,7 +235,7 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	currentFile: string;
 	packagePathToGoModPathMap: {[key: string]: string};
 	/** Used to relativize source files passed to delve - required to debug binaries built with bazel */
-	sourceRoot?: string
+	sourceRoot?: string;
 }
 
 interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
@@ -262,7 +262,7 @@ interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
 	showGlobalVariables?: boolean;
 	currentFile: string;
 	/** Used to relativize source files passed to delve - required to debug binaries built with bazel */
-	sourceRoot?: string
+	sourceRoot?: string;
 }
 
 process.on('uncaughtException', (err: any) => {
@@ -312,7 +312,7 @@ class Delve {
 	isRemoteDebugging: boolean;
 	request: 'attach' | 'launch';
 	/** Used to relativize source files passed to delve - required to debug binaries built with bazel */
-	sourceRoot?: string
+	sourceRoot?: string;
 
 	constructor(launchArgs: LaunchRequestArguments | AttachRequestArguments, program: string) {
 		this.sourceRoot = launchArgs.sourceRoot;
@@ -870,7 +870,11 @@ class GoDebugSession extends LoggingDebugSession {
 
 	protected toLocalPath(pathToConvert: string): string {
 		if (this.delve.remotePath.length === 0) {
-			return this.convertDebuggerPathToClient(pathToConvert);
+			if (!!this.delve.sourceRoot) {
+				return this.convertDebuggerPathToClient(this.delve.sourceRoot + pathToConvert);
+			} else {
+				return this.convertDebuggerPathToClient(pathToConvert);
+			}
 		}
 
 		// Fix for https://github.com/Microsoft/vscode-go/issues/1178

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -854,7 +854,8 @@ class GoDebugSession extends LoggingDebugSession {
 	protected toLocalPath(pathToConvert: string): string {
 		if (this.delve.remotePath.length === 0) {
 			if (!!this.delve.sourceRoot) {
-				return this.convertDebuggerPathToClient(this.delve.sourceRoot + this.findPathSeperator(pathToConvert) + pathToConvert);
+				return this.convertDebuggerPathToClient(
+					this.delve.sourceRoot + this.findPathSeperator(pathToConvert) + pathToConvert);
 			} else {
 				return this.convertDebuggerPathToClient(pathToConvert);
 			}

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -857,7 +857,7 @@ class GoDebugSession extends LoggingDebugSession {
 		}
 	}
 
-	protected toDebuggerPath(clientPath: string, sourceRoot?: string): string {
+	protected toDebuggerPath(clientPath: string): string {
 		if (this.delve.remotePath.length === 0) {
 			if (!!this.delve.sourceRoot && clientPath.startsWith(this.delve.sourceRoot)) {
 				return this.convertClientPathToDebugger(path.relative(this.delve.sourceRoot, clientPath));
@@ -871,7 +871,7 @@ class GoDebugSession extends LoggingDebugSession {
 	protected toLocalPath(pathToConvert: string): string {
 		if (this.delve.remotePath.length === 0) {
 			if (!!this.delve.sourceRoot) {
-				return this.convertDebuggerPathToClient(this.delve.sourceRoot + pathToConvert);
+				return this.convertDebuggerPathToClient(this.delve.sourceRoot + this.findPathSeperator(pathToConvert) + pathToConvert);
 			} else {
 				return this.convertDebuggerPathToClient(pathToConvert);
 			}
@@ -914,7 +914,7 @@ class GoDebugSession extends LoggingDebugSession {
 		if (!this.breakpoints.get(file)) {
 			this.breakpoints.set(file, []);
 		}
-		const remoteFile = this.toDebuggerPath(file, this.delve.sourceRoot);
+		const remoteFile = this.toDebuggerPath(file);
 
 		return Promise.all(this.breakpoints.get(file).map(existingBP => {
 			log('Clearing: ' + existingBP.id);
@@ -1236,7 +1236,7 @@ class GoDebugSession extends LoggingDebugSession {
 		if (!debugState.currentThread || !debugState.currentThread.file) {
 			return Promise.resolve(null);
 		}
-		const dir = path.dirname(this.delve.remotePath.length ? this.toLocalPath(debugState.currentThread.file) : debugState.currentThread.file);
+		const dir = path.dirname(this.toLocalPath(debugState.currentThread.file));
 		if (this.packageInfo.has(dir)) {
 			return Promise.resolve(this.packageInfo.get(dir));
 		}


### PR DESCRIPTION
- add 'sourceRoot' launch configuration property
- fixes failure to set breakpoint when binary is built with trim-paths, e.g. via bazel
- possibly related to #1307

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/vscode-go/2908)
<!-- Reviewable:end -->
