### PR TITLE
Remove references to gometalinter that's deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Read the [Changelog](https://github.com/Microsoft/vscode-go/blob/master/CHANGELO
 
 - Build-on-save to compile code and show build errors. (using `go build` and `go test`)
 - Vet-on-save to run `go vet` and show errors as warnings
-- Lint-on-save to show linting errors as warnings (using `golint`, `gometalinter`, `staticcheck`, `golangci-lint` or `revive`)
+- Lint-on-save to show linting errors as warnings (using `golint`, `staticcheck`, `golangci-lint` or `revive`)
 - Semantic/Syntactic error reporting as you type (using `gotype-live`)
 
 ### Testing

--- a/package.json
+++ b/package.json
@@ -781,8 +781,7 @@
             "golint",
             "golangci-lint",
             "revive",
-            "staticcheck",
-            "gometalinter"
+            "staticcheck"
           ]
         },
         "go.lintFlags": {
@@ -1443,11 +1442,6 @@
               "type": "string",
               "default": "go",
               "description": "Alternate tool to use instead of the go binary or alternate path to use for the go binary."
-            },
-            "gometalinter": {
-              "type": "string",
-              "default": "gometalinter",
-              "description": "Alternate tool to use instead of the gometalinter binary or alternate path to use for the gometalinter binary."
             },
             "gocode": {
               "type": "string",


### PR DESCRIPTION
The actual code to support the gometalinter was removed
https://github.com/microsoft/vscode-go/pull/2726

This PR removes it from the go.lintTool options so it
no longer appears in the suggested alternative lint tool list
in Go extension setting.