### PR TITLE
Support relative paths in debug symbol information

### DIFF
--- a/package.json
+++ b/package.json
@@ -609,6 +609,16 @@
                 "description": "If remote debugging, the path to the source code on the remote machine, if different from the local machine.",
                 "default": ""
               },
+              "useRelativePaths": {
+                "type": "boolean",
+                "description": "Specify that source file paths in debugging information of a targeted binary are relative, rather than absolute, paths. This is useful with 'attach' mode when the binary is produced by deterministic build system like Bazel.",
+                "default": false
+              },
+              "pathSeparator": {
+                "type": "string",
+                "description": "Specify type of path separator (windows or unix path) used in debug information in a binary that debugger attaches to.",
+                "default": "auto"
+              },
               "port": {
                 "type": "number",
                 "description": "The port that the delve debugger will be listening on.",


### PR DESCRIPTION
When Bazel produces go binary in debug mode, it strips out absolute paths from source file paths to make artifacts deterministic. This means, though, that VS Code is unable to correctly set breakpoints for such a binary, and in general, unable to match sources in the binary being debugged with the local sources. This all because vscode-go plugin expects go binary to contain absolute paths.

The plugin has support for "remotePath" property but it can't be left empty to strip out absolute path, so a separate property is introduced "useRelativePaths"; if set to true the plugin would use relative source file path to match with debugging symbol information.

Another property 'pathSeparator' allows to specify the separator type (windows `\` or unix `/`). This simplifies remote debugging of binaries compiled for the platform not identical to the one which runs VS Code. Default value 'auto' resembles the current behavior where remote path separator is inferred from `remotePath` parameter if one is specified.

This change also refactors a potentially dangerous handling of `remotePath` parameter - instead of string replace it uses a safer variant of prefix match.