### PR TITLE
^ outline to include constant & interface

### DIFF
--- a/src/goOutline.ts
+++ b/src/goOutline.ts
@@ -116,9 +116,11 @@ const goKindToCodeKind: { [key: string]: vscode.SymbolKind } = {
 	'package': vscode.SymbolKind.Package,
 	'import': vscode.SymbolKind.Namespace,
 	'variable': vscode.SymbolKind.Variable,
-	'type': vscode.SymbolKind.Interface,
+	'constant': vscode.SymbolKind.Constant,
+	'type': vscode.SymbolKind.TypeParameter,
 	'function': vscode.SymbolKind.Function,
 	'struct': vscode.SymbolKind.Struct,
+	'interface': vscode.SymbolKind.Interface,
 };
 
 function convertToCodeSymbols(
@@ -151,8 +153,10 @@ function convertToCodeSymbols(
 
 		if (decl.type === 'type') {
 			const line = document.lineAt(document.positionAt(start));
-			const regex = new RegExp(`^\\s*type\\s+${decl.label}\\s+struct\\b`);
-			decl.type = regex.test(line.text) ? 'struct' : 'type';
+			const regexStruct = new RegExp(`^\\s*type\\s+${decl.label}\\s+struct\\b`);
+			const regexInterface = new RegExp(`^\\s*type\\s+${decl.label}\\s+interface\\b`);
+			decl.type = regexStruct.test(line.text) ? 'struct' :
+						regexInterface.test(line.text) ? 'interface' : 'type';
 		}
 
 		const symbolInfo = new vscode.DocumentSymbol(

--- a/test/fixtures/outlineTest/test.go
+++ b/test/fixtures/outlineTest/test.go
@@ -6,6 +6,12 @@ import (
 
 var _ string = "foobar"
 
+// const constFoo = "constBar"
+
+type circle struct {
+	radius float64
+}
+
 func print(txt string) {
 	fmt.Println(txt)
 }

--- a/test/fixtures/outlineTest/test.go
+++ b/test/fixtures/outlineTest/test.go
@@ -8,10 +8,6 @@ var _ string = "foobar"
 
 // const constFoo = "constBar"
 
-type circle interface {
-	radius float64
-}
-
 func print(txt string) {
 	fmt.Println(txt)
 }
@@ -22,3 +18,8 @@ func main() {
 type foo struct {
 	bar int
 }
+
+type circle interface {
+	radius float64
+}
+

--- a/test/fixtures/outlineTest/test.go
+++ b/test/fixtures/outlineTest/test.go
@@ -8,7 +8,7 @@ var _ string = "foobar"
 
 // const constFoo = "constBar"
 
-type circle struct {
+type circle interface {
 	radius float64
 }
 

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -507,6 +507,7 @@ It returns the number of bytes written and any write error encountered.
 				const variables = outlines[0].children.filter((x: any) => x.kind === vscode.SymbolKind.Variable);
 				const functions = outlines[0].children.filter((x: any) => x.kind === vscode.SymbolKind.Function);
 				const structs = outlines[0].children.filter((x: any) => x.kind === vscode.SymbolKind.Struct);
+				const interfaces = outlines[0].children.filter((x: any) => x.kind === vscode.SymbolKind.Interface);
 
 				assert.equal(packages[0].name, 'main');
 				assert.equal(variables.length, 0);
@@ -514,6 +515,8 @@ It returns the number of bytes written and any write error encountered.
 				assert.equal(functions[1].name, 'main');
 				assert.equal(structs.length, 1);
 				assert.equal(structs[0].name, 'foo');
+				assert.equal(interfaces.length, 1);
+				assert.equal(interfaces[0].name, "circle");
 			});
 		}).then(() => done(), done);
 	});

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -516,7 +516,7 @@ It returns the number of bytes written and any write error encountered.
 				assert.equal(structs.length, 1);
 				assert.equal(structs[0].name, 'foo');
 				assert.equal(interfaces.length, 1);
-				assert.equal(interfaces[0].name, "circle");
+				assert.equal(interfaces[0].name, 'circle');
 			});
 		}).then(() => done(), done);
 	});


### PR DESCRIPTION
* pending merge by github.com/ramya-rao-a/go-outline, sent pull request at https://github.com/ramya-rao-a/go-outline/pull/10.
* `interface` to follow `struct`'s regex approach
* maybe the SymbolKind for type should be TypeParameter