### PR TITLE
Refactor telemetry handling

### DIFF
--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -9,8 +9,9 @@ import vscode = require('vscode');
 import path = require('path');
 import { promptForMissingTool } from './goInstallTools';
 import { getFromGlobalState, updateGlobalState } from './stateUtils';
-import { getBinPath, getCurrentGoPath, getGoConfig, getToolsEnvVars, sendTelemetryEvent } from './util';
+import { getBinPath, getCurrentGoPath, getGoConfig, getToolsEnvVars } from './util';
 import { packagePathToGoModPathMap } from './goModules';
+import { sendTelemetryEventForDebugConfiguration } from './telemetry';
 
 export class GoDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 
@@ -30,22 +31,7 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 
 	public resolveDebugConfiguration?(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.DebugConfiguration {
 		if (debugConfiguration) {
-			/* __GDPR__
-				"debugConfiguration" : {
-					"request" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-					"mode" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-					"useApiV<NUMBER>": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-					"apiVersion": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-					"stopOnEntry": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-				}
-			*/
-			sendTelemetryEvent('debugConfiguration', {
-				request: debugConfiguration.request,
-				mode: debugConfiguration.mode,
-				useApiV1: debugConfiguration.useApiV1,
-				apiVersion: debugConfiguration.apiVersion,
-				stopOnEntry: debugConfiguration.stopOnEntry
-			});
+			sendTelemetryEventForDebugConfiguration(debugConfiguration);
 		}
 
 		const activeEditor = vscode.window.activeTextEditor;

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -9,7 +9,8 @@ import vscode = require('vscode');
 import cp = require('child_process');
 import path = require('path');
 import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
-import { getBinPath, getGoConfig, getToolsEnvVars, killTree, sendTelemetryEvent } from './util';
+import { getBinPath, getGoConfig, getToolsEnvVars, killTree } from './util';
+import { sendTelemetryEventForFormatting } from './telemetry';
 
 export class GoDocumentFormattingEditProvider implements vscode.DocumentFormattingEditProvider {
 
@@ -89,13 +90,7 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 				const textEdits: vscode.TextEdit[] = [new vscode.TextEdit(new vscode.Range(fileStart, fileEnd), stdout)];
 
 				const timeTaken = Date.now() - t0;
-				/* __GDPR__
-				   "format" : {
-					  "tool" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-					  "timeTaken": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true }
-				   }
-				 */
-				sendTelemetryEvent('format', { tool: formatTool }, { timeTaken });
+				sendTelemetryEventForFormatting(formatTool, timeTaken);
 				if (timeTaken > 750) {
 					console.log(`Formatting took too long(${timeTaken}ms). Format On Save feature could be aborted.`);
 				}

--- a/src/goImport.ts
+++ b/src/goImport.ts
@@ -11,7 +11,8 @@ import { promptForMissingTool } from './goInstallTools';
 import { documentSymbols, GoOutlineImportsOptions } from './goOutline';
 import { getImportablePackages } from './goPackages';
 import { envPath } from './goPath';
-import { getBinPath, getImportPath, getToolsEnvVars, parseFilePrelude, sendTelemetryEvent } from './util';
+import { getBinPath, getImportPath, getToolsEnvVars, parseFilePrelude } from './util';
+import { sendTelemetryEventForAddImportCmd } from './telemetry';
 
 const missingToolMsg = 'Missing tool: ';
 
@@ -112,12 +113,7 @@ export function getTextEditForAddImport(arg: string): vscode.TextEdit[] {
 export function addImport(arg: { importPath: string, from: string }) {
 	const p = (arg && arg.importPath) ? Promise.resolve(arg.importPath) : askUserForImport();
 	p.then(imp => {
-		/* __GDPR__
-		"addImportCmd" : {
-			"from" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-		}
-		*/
-		sendTelemetryEvent('addImportCmd', { from: (arg && arg.from) || 'cmd' });
+		sendTelemetryEventForAddImportCmd(arg);
 		const edits = getTextEditForAddImport(imp);
 		if (edits && edits.length > 0) {
 			const edit = new vscode.WorkspaceEdit();

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -47,6 +47,7 @@ interface LanguageServerConfig {
 // registerLanguageFeatures registers providers for all the language features.
 // It looks to either the language server or the standard providers for these features.
 export async function registerLanguageFeatures(ctx: vscode.ExtensionContext) {
+	console.log('hi~');
 	// Subscribe to notifications for changes to the configuration of the language server.
 	ctx.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => watchLanguageServerConfiguration(e)));
 

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -47,7 +47,6 @@ interface LanguageServerConfig {
 // registerLanguageFeatures registers providers for all the language features.
 // It looks to either the language server or the standard providers for these features.
 export async function registerLanguageFeatures(ctx: vscode.ExtensionContext) {
-	console.log('hi~');
 	// Subscribe to notifications for changes to the configuration of the language server.
 	ctx.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => watchLanguageServerConfiguration(e)));
 

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -34,7 +34,8 @@ import { testAtCursor, testCurrentFile, testCurrentPackage, testPrevious, testWo
 import { vetCode } from './goVet';
 import { setGlobalState, getFromGlobalState, updateGlobalState } from './stateUtils';
 import { cancelRunningTests, showTestOutput } from './testUtils';
-import { cleanupTempDir, disposeTelemetryReporter, getBinPath, getGoConfig, getCurrentGoPath, getExtensionCommands, getGoVersion, getToolsEnvVars, getToolsGopath, getWorkspaceFolderPath, handleDiagnosticErrors, isGoPathSet, sendTelemetryEvent } from './util';
+import { cleanupTempDir, getBinPath, getGoConfig, getCurrentGoPath, getExtensionCommands, getGoVersion, getToolsEnvVars, getToolsGopath, getWorkspaceFolderPath, handleDiagnosticErrors, isGoPathSet } from './util';
+import { disposeTelemetryReporter, sendTelemetryEventForConfig } from './telemetry';
 
 export let buildDiagnosticCollection: vscode.DiagnosticCollection;
 export let lintDiagnosticCollection: vscode.DiagnosticCollection;
@@ -420,90 +421,6 @@ function addOnChangeTextDocumentListeners(ctx: vscode.ExtensionContext) {
 function addOnChangeActiveTextEditorListeners(ctx: vscode.ExtensionContext) {
 	vscode.window.onDidChangeActiveTextEditor(showHideStatus, null, ctx.subscriptions);
 	vscode.window.onDidChangeActiveTextEditor(applyCodeCoverage, null, ctx.subscriptions);
-}
-
-function sendTelemetryEventForConfig(goConfig: vscode.WorkspaceConfiguration) {
-	/* __GDPR__
-	   "goConfig" : {
-		  "buildOnSave" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "buildFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "buildTags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "formatTool": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "formatFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "generateTestsFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "lintOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "lintFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "lintTool": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "vetOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "vetFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "testOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "testFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "coverOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "coverOnTestPackage": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "coverageDecorator": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "coverageOptions": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "gopath": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "goroot": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "inferGopath": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "toolsGopath": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "gocodeAutoBuild": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "gocodePackageLookupMode": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "useCodeSnippetsOnFunctionSuggest": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "useCodeSnippetsOnFunctionSuggestWithoutType": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "autocompleteUnimportedPackages": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "docsTool": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "useLanguageServer": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "languageServerExperimentalFeatures": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "includeImports": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "addTags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "removeTags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "editorContextMenuCommands": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "liveErrors": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "codeLens": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-		  "alternateTools": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
-		  "useGoProxyToCheckForToolUpdates": { "classification": "CustomerContent", "purpose": "FeatureInsight" }
-	   }
-	 */
-	sendTelemetryEvent('goConfig', {
-		buildOnSave: goConfig['buildOnSave'] + '',
-		buildFlags: goConfig['buildFlags'],
-		buildTags: goConfig['buildTags'],
-		formatOnSave: goConfig['formatOnSave'] + '',
-		formatTool: goConfig['formatTool'],
-		formatFlags: goConfig['formatFlags'],
-		lintOnSave: goConfig['lintOnSave'] + '',
-		lintFlags: goConfig['lintFlags'],
-		lintTool: goConfig['lintTool'],
-		generateTestsFlags: goConfig['generateTestsFlags'],
-		vetOnSave: goConfig['vetOnSave'] + '',
-		vetFlags: goConfig['vetFlags'],
-		testOnSave: goConfig['testOnSave'] + '',
-		testFlags: goConfig['testFlags'],
-		coverOnSave: goConfig['coverOnSave'] + '',
-		coverOnTestPackage: goConfig['coverOnTestPackage'] + '',
-		coverageDecorator: goConfig['coverageDecorator'],
-		coverageOptions: goConfig['coverageOptions'],
-		gopath: goConfig['gopath'] ? 'set' : '',
-		goroot: goConfig['goroot'] ? 'set' : '',
-		inferGopath: goConfig['inferGopath'] + '',
-		toolsGopath: goConfig['toolsGopath'] ? 'set' : '',
-		gocodeAutoBuild: goConfig['gocodeAutoBuild'] + '',
-		gocodePackageLookupMode: goConfig['gocodePackageLookupMode'] + '',
-		useCodeSnippetsOnFunctionSuggest: goConfig['useCodeSnippetsOnFunctionSuggest'] + '',
-		useCodeSnippetsOnFunctionSuggestWithoutType: goConfig['useCodeSnippetsOnFunctionSuggestWithoutType'] + '',
-		autocompleteUnimportedPackages: goConfig['autocompleteUnimportedPackages'] + '',
-		docsTool: goConfig['docsTool'],
-		useLanguageServer: goConfig['useLanguageServer'] + '',
-		languageServerExperimentalFeatures: JSON.stringify(goConfig['languageServerExperimentalFeatures']),
-		includeImports: goConfig['gotoSymbol'] && goConfig['gotoSymbol']['includeImports'] + '',
-		addTags: JSON.stringify(goConfig['addTags']),
-		removeTags: JSON.stringify(goConfig['removeTags']),
-		editorContextMenuCommands: JSON.stringify(goConfig['editorContextMenuCommands']),
-		liveErrors: JSON.stringify(goConfig['liveErrors']),
-		codeLens: JSON.stringify(goConfig['enableCodeLens']),
-		alternateTools: JSON.stringify(goConfig['alternateTools']),
-		useGoProxyToCheckForToolUpdates: goConfig['useGoProxyToCheckForToolUpdates'] + '',
-	});
 }
 
 function checkToolExists(tool: string) {

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -7,10 +7,11 @@ import { installTools } from './goInstallTools';
 import { envPath, fixDriveCasingInWindows } from './goPath';
 import { getTool } from './goTools';
 import { getFromGlobalState, updateGlobalState } from './stateUtils';
-import { getBinPath, getGoConfig, getGoVersion, getModuleCache, getToolsEnvVars, sendTelemetryEvent } from './util';
+import { getBinPath, getGoConfig, getGoVersion, getModuleCache, getToolsEnvVars } from './util';
 import path = require('path');
 import cp = require('child_process');
 import vscode = require('vscode');
+import { sendTelemetryEventForModulesUsage } from './telemetry';
 
 export let GO111MODULE: string;
 
@@ -92,10 +93,7 @@ function logModuleUsage() {
 		return;
 	}
 	moduleUsageLogged = true;
-	/* __GDPR__
-		"modules" : {}
-	*/
-	sendTelemetryEvent('modules');
+	sendTelemetryEventForModulesUsage();
 }
 
 const promptedToolsForCurrentSession = new Set<string>();

--- a/src/goPackages.ts
+++ b/src/goPackages.ts
@@ -8,7 +8,8 @@ import cp = require('child_process');
 import path = require('path');
 import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
 import { envPath, fixDriveCasingInWindows, getCurrentGoWorkspaceFromGOPATH } from './goPath';
-import { getBinPath, getCurrentGoPath, getGoVersion, getToolsEnvVars, isVendorSupported, sendTelemetryEvent } from './util';
+import { getBinPath, getCurrentGoPath, getGoVersion, getToolsEnvVars, isVendorSupported } from './util';
+import { sendTelemetryEventForGopkgs } from './telemetry';
 
 type GopkgsDone = (res: Map<string, PackageInfo>) => void;
 interface Cache {
@@ -98,13 +99,7 @@ function gopkgs(workDir?: string): Promise<Map<string, PackageInfo>> {
 				});
 			});
 			const timeTaken = Date.now() - t0;
-			/* __GDPR__
-				"gopkgs" : {
-					"tool" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-					"timeTaken": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true }
-				}
-			*/
-			sendTelemetryEvent('gopkgs', {}, { timeTaken });
+			sendTelemetryEventForGopkgs(timeTaken);
 			cacheTimeout = timeTaken > 5000 ? timeTaken : 5000;
 			return resolve(pkgs);
 		});

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -5,7 +5,6 @@
 
 import vscode = require('vscode');
 import TelemetryReporter from 'vscode-extension-telemetry';
-import { GoVersion } from './util';
 
 export const extensionId: string = 'ms-vscode.Go';
 const extensionVersion: string = vscode.extensions.getExtension(extensionId).packageJSON.version;
@@ -160,14 +159,13 @@ export function sendTelemetryEventForKillingProcess(msg: any, matches: any) {
 	sendTelemetryEvent('errorKillingProcess', { message: msg, stack: matches });
 }
 
-export function sendTelemetryEventForGoVersion(goVersion: GoVersion) {
+export function sendTelemetryEventForGoVersion(goVersion: string) {
 	/* __GDPR__
 		"getGoVersion" : {
 			"version" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 		}
 	*/
-	sendTelemetryEvent('getGoVersion', { version: `${goVersion.format()}` });
-	return Promise.resolve(goVersion);
+	sendTelemetryEvent('getGoVersion', { version: `${goVersion}` });
 }
 
 export function disposeTelemetryReporter(): Promise<any> {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,185 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------*/
+
+import vscode = require('vscode');
+import TelemetryReporter from 'vscode-extension-telemetry';
+import { GoVersion } from './util';
+
+export const extensionId: string = 'ms-vscode.Go';
+const extensionVersion: string = vscode.extensions.getExtension(extensionId).packageJSON.version;
+const aiKey: string = 'AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217';
+
+export function sendTelemetryEventForModulesUsage() {
+	/* __GDPR__
+		"modules" : {}
+	*/
+	sendTelemetryEvent('modules');
+}
+
+export function sendTelemetryEventForAddImportCmd(arg: { importPath: string, from: string }) {
+	/* __GDPR__
+		"addImportCmd" : {
+			"from" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+		}
+	*/
+	sendTelemetryEvent('addImportCmd', { from: (arg && arg.from) || 'cmd' });
+}
+
+export function sendTelemetryEventForGopkgs(timeTaken: number) {
+	/* __GDPR__
+		"gopkgs" : {
+			"tool" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"timeTaken": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true }
+		}
+	*/
+	sendTelemetryEvent('gopkgs', {}, { timeTaken });
+}
+
+export function sendTelemetryEventForFormatting(formatTool: string, timeTaken: number) {
+	/* __GDPR__
+		"format" : {
+			"tool" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"timeTaken": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true }
+		}
+	*/
+	sendTelemetryEvent('format', { tool: formatTool }, { timeTaken });
+}
+
+export function sendTelemetryEventForDebugConfiguration(debugConfiguration: vscode.DebugConfiguration) {
+	/* __GDPR__
+		"debugConfiguration" : {
+			"request" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"mode" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"useApiV<NUMBER>": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"apiVersion": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"stopOnEntry": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+		}
+	*/
+	sendTelemetryEvent('debugConfiguration', {
+		request: debugConfiguration.request,
+		mode: debugConfiguration.mode,
+		useApiV1: debugConfiguration.useApiV1,
+		apiVersion: debugConfiguration.apiVersion,
+		stopOnEntry: debugConfiguration.stopOnEntry
+	});
+}
+
+export function sendTelemetryEventForConfig(goConfig: vscode.WorkspaceConfiguration) {
+	/* __GDPR__
+		"goConfig" : {
+			"buildOnSave" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"buildFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"buildTags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"formatTool": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"formatFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"generateTestsFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"lintOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"lintFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"lintTool": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"vetOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"vetFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"testOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"testFlags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"coverOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"coverOnTestPackage": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"coverageDecorator": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"coverageOptions": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"gopath": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"goroot": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"inferGopath": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"toolsGopath": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"gocodeAutoBuild": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"gocodePackageLookupMode": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"useCodeSnippetsOnFunctionSuggest": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"useCodeSnippetsOnFunctionSuggestWithoutType": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"autocompleteUnimportedPackages": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"docsTool": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"useLanguageServer": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"languageServerExperimentalFeatures": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"includeImports": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"addTags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"removeTags": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"editorContextMenuCommands": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"liveErrors": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"codeLens": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+			"alternateTools": { "classification": "CustomerContent", "purpose": "FeatureInsight" },
+			"useGoProxyToCheckForToolUpdates": { "classification": "CustomerContent", "purpose": "FeatureInsight" }
+		}
+	*/
+	sendTelemetryEvent('goConfig', {
+		buildOnSave: goConfig['buildOnSave'] + '',
+		buildFlags: goConfig['buildFlags'],
+		buildTags: goConfig['buildTags'],
+		formatOnSave: goConfig['formatOnSave'] + '',
+		formatTool: goConfig['formatTool'],
+		formatFlags: goConfig['formatFlags'],
+		lintOnSave: goConfig['lintOnSave'] + '',
+		lintFlags: goConfig['lintFlags'],
+		lintTool: goConfig['lintTool'],
+		generateTestsFlags: goConfig['generateTestsFlags'],
+		vetOnSave: goConfig['vetOnSave'] + '',
+		vetFlags: goConfig['vetFlags'],
+		testOnSave: goConfig['testOnSave'] + '',
+		testFlags: goConfig['testFlags'],
+		coverOnSave: goConfig['coverOnSave'] + '',
+		coverOnTestPackage: goConfig['coverOnTestPackage'] + '',
+		coverageDecorator: goConfig['coverageDecorator'],
+		coverageOptions: goConfig['coverageOptions'],
+		gopath: goConfig['gopath'] ? 'set' : '',
+		goroot: goConfig['goroot'] ? 'set' : '',
+		inferGopath: goConfig['inferGopath'] + '',
+		toolsGopath: goConfig['toolsGopath'] ? 'set' : '',
+		gocodeAutoBuild: goConfig['gocodeAutoBuild'] + '',
+		gocodePackageLookupMode: goConfig['gocodePackageLookupMode'] + '',
+		useCodeSnippetsOnFunctionSuggest: goConfig['useCodeSnippetsOnFunctionSuggest'] + '',
+		useCodeSnippetsOnFunctionSuggestWithoutType: goConfig['useCodeSnippetsOnFunctionSuggestWithoutType'] + '',
+		autocompleteUnimportedPackages: goConfig['autocompleteUnimportedPackages'] + '',
+		docsTool: goConfig['docsTool'],
+		useLanguageServer: goConfig['useLanguageServer'] + '',
+		languageServerExperimentalFeatures: JSON.stringify(goConfig['languageServerExperimentalFeatures']),
+		includeImports: goConfig['gotoSymbol'] && goConfig['gotoSymbol']['includeImports'] + '',
+		addTags: JSON.stringify(goConfig['addTags']),
+		removeTags: JSON.stringify(goConfig['removeTags']),
+		editorContextMenuCommands: JSON.stringify(goConfig['editorContextMenuCommands']),
+		liveErrors: JSON.stringify(goConfig['liveErrors']),
+		codeLens: JSON.stringify(goConfig['enableCodeLens']),
+		alternateTools: JSON.stringify(goConfig['alternateTools']),
+		useGoProxyToCheckForToolUpdates: goConfig['useGoProxyToCheckForToolUpdates'] + '',
+	});
+}
+
+export function sendTelemetryEventForKillingProcess(msg: any, matches: any) {
+	/* __GDPR__
+		"errorKillingProcess" : {
+			"message" : { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth" },
+			"stack": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth" }
+		}
+	*/
+	sendTelemetryEvent('errorKillingProcess', { message: msg, stack: matches });
+}
+
+export function sendTelemetryEventForGoVersion(goVersion: GoVersion) {
+	/* __GDPR__
+		"getGoVersion" : {
+			"version" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+		}
+	*/
+	sendTelemetryEvent('getGoVersion', { version: `${goVersion.format()}` });
+	return Promise.resolve(goVersion);
+}
+
+export function disposeTelemetryReporter(): Promise<any> {
+	if (telemtryReporter) {
+		return telemtryReporter.dispose();
+	}
+	return Promise.resolve(null);
+}
+
+let telemtryReporter: TelemetryReporter;
+
+function sendTelemetryEvent(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }): void {
+	telemtryReporter = telemtryReporter ? telemtryReporter : new TelemetryReporter(extensionId, extensionVersion, aiKey);
+	telemtryReporter.sendTelemetryEvent(eventName, properties, measures);
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -83,7 +83,7 @@ export class GoVersion {
 			this.isDevel = true;
 			this.commit = matchesDevel[0];
 		}
-		sendTelemetryEventForGoVersion(goVersion.format());
+		sendTelemetryEventForGoVersion(this.format());
 	}
 
 	format(): string {

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,7 +14,7 @@ import { outputChannel } from './goStatus';
 import cp = require('child_process');
 import fs = require('fs');
 import os = require('os');
-import { extensionId, sendTelemetryEventForGoVersion, sendTelemetryEventForKillingProcess } from './telemetry';
+import { sendTelemetryEventForGoVersion, sendTelemetryEventForKillingProcess, extensionId } from './telemetry';
 
 let userNameHash: number = 0;
 
@@ -83,7 +83,7 @@ export class GoVersion {
 			this.isDevel = true;
 			this.commit = matchesDevel[0];
 		}
-		sendTelemetryEventForGoVersion(goVersion);
+		sendTelemetryEventForGoVersion(goVersion.format());
 	}
 
 	format(): string {
@@ -280,7 +280,7 @@ export async function getGoVersion(): Promise<GoVersion> {
 		return Promise.resolve(null);
 	}
 	if (goVersion && (goVersion.sv || goVersion.isDevel)) {
-		sendTelemetryEventForGoVersion(goVersion);
+		sendTelemetryEventForGoVersion(goVersion.format());
 		return Promise.resolve(goVersion);
 	}
 	return new Promise<GoVersion>((resolve) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,6 @@
 import vscode = require('vscode');
 import semver = require('semver');
 import path = require('path');
-import TelemetryReporter from 'vscode-extension-telemetry';
 import { NearestNeighborDict, Node } from './avlTree';
 import { buildDiagnosticCollection, lintDiagnosticCollection, vetDiagnosticCollection } from './goMain';
 import { getCurrentPackage } from './goModules';
@@ -15,10 +14,8 @@ import { outputChannel } from './goStatus';
 import cp = require('child_process');
 import fs = require('fs');
 import os = require('os');
+import { extensionId, sendTelemetryEventForGoVersion, sendTelemetryEventForKillingProcess } from './telemetry';
 
-const extensionId: string = 'ms-vscode.Go';
-const extensionVersion: string = vscode.extensions.getExtension(extensionId).packageJSON.version;
-const aiKey: string = 'AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217';
 let userNameHash: number = 0;
 
 export const goKeywords: string[] = [
@@ -86,12 +83,7 @@ export class GoVersion {
 			this.isDevel = true;
 			this.commit = matchesDevel[0];
 		}
-		/* __GDPR__
-            "getGoVersion" : {
-	  			"version" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-   			}
- 		*/
-		sendTelemetryEvent('getGoVersion', { version: this.format() });
+		sendTelemetryEventForGoVersion(goVersion);
 	}
 
 	format(): string {
@@ -122,7 +114,6 @@ export class GoVersion {
 
 let goVersion: GoVersion = null;
 let vendorSupport: boolean = null;
-let telemtryReporter: TelemetryReporter;
 let toolsGopath: string;
 
 export function getGoConfig(uri?: vscode.Uri): vscode.WorkspaceConfiguration {
@@ -288,14 +279,8 @@ export async function getGoVersion(): Promise<GoVersion> {
 		console.warn(`Failed to run "go version" as the "go" binary cannot be found in either GOROOT(${process.env['GOROOT']}) or PATH(${envPath})`);
 		return Promise.resolve(null);
 	}
-
 	if (goVersion && (goVersion.sv || goVersion.isDevel)) {
-		/* __GDPR__
-		   "getGoVersion" : {
-			  "version" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-		   }
-		 */
-		sendTelemetryEvent('getGoVersion', { version: `${goVersion.format()}` });
+		sendTelemetryEventForGoVersion(goVersion);
 		return Promise.resolve(goVersion);
 	}
 	return new Promise<GoVersion>((resolve) => {
@@ -353,19 +338,6 @@ export function isGoPathSet(): boolean {
 	}
 
 	return true;
-}
-
-export function sendTelemetryEvent(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }): void {
-
-	telemtryReporter = telemtryReporter ? telemtryReporter : new TelemetryReporter(extensionId, extensionVersion, aiKey);
-	telemtryReporter.sendTelemetryEvent(eventName, properties, measures);
-}
-
-export function disposeTelemetryReporter(): Promise<any> {
-	if (telemtryReporter) {
-		return telemtryReporter.dispose();
-	}
-	return Promise.resolve(null);
 }
 
 export function isPositionInString(document: vscode.TextDocument, position: vscode.Position): boolean {
@@ -824,13 +796,7 @@ export function killProcess(p: cp.ChildProcess) {
 			if (e && e.message && e.stack) {
 				const matches = e.stack.match(/(src.go[a-z,A-Z]+\.js)/g);
 				if (matches) {
-					/* __GDPR__
-					   "errorKillingProcess" : {
-						  "message" : { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth" },
-						  "stack": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth" }
-					   }
-					 */
-					sendTelemetryEvent('errorKillingProcess', { message: e.message, stack: matches });
+					sendTelemetryEventForKillingProcess(e.message, matches);
 				}
 			}
 


### PR DESCRIPTION
This change moves all of the telemetry-related code into a separate file, in order centralize it and make it clear what telemetry events the extension sends.