### PR TITLE
Considering receiverType on function test creation issue-2282

### DIFF
--- a/src/goGenerateTests.ts
+++ b/src/goGenerateTests.ts
@@ -98,17 +98,13 @@ export async function generateTestCurrentFunction(): Promise<boolean> {
 		return Promise.resolve(false);
 	}
 	let funcName = currentFunction.name;
-	if (funcName.includes('.')) {  // receiverType specified
-		let funcNameParts = funcName.match(/^\(\*?(.*)\)\.(.*)$/);
-		if(funcNameParts != null && funcNameParts.length === 3){
-			let rType = funcNameParts[1].replace(/^\w/, c => c.toUpperCase());
-			let fName = funcNameParts[2].replace(/^\w/, c => c.toUpperCase());
-			funcName = rType + fName;
-		} else {
-			funcName = funcName.split('.')[1];
-		}
+	let funcNameParts = funcName.match(/^\(\*?(.*)\)\.(.*)$/);
+	if(funcNameParts != null && funcNameParts.length === 3){  // receiver type specified
+		let rType = funcNameParts[1].replace(/^\w/, c => c.toUpperCase());
+		let fName = funcNameParts[2].replace(/^\w/, c => c.toUpperCase());
+		funcName = rType + fName;
+	} 
 		
-	}
 	return generateTests({ dir: editor.document.uri.fsPath, func: funcName }, getGoConfig(editor.document.uri));
 }
 

--- a/src/goGenerateTests.ts
+++ b/src/goGenerateTests.ts
@@ -98,8 +98,16 @@ export async function generateTestCurrentFunction(): Promise<boolean> {
 		return Promise.resolve(false);
 	}
 	let funcName = currentFunction.name;
-	if (funcName.includes('.')) {
-		funcName = funcName.split('.')[1];
+	if (funcName.includes('.')) {  // receiverType specified
+		let funcNameParts = funcName.match(/^\(\*?(.*)\)\.(.*)$/);
+		if(funcNameParts != null && funcNameParts.length === 3){
+			let rType = funcNameParts[1].replace(/^\w/, c => c.toUpperCase());
+			let fName = funcNameParts[2].replace(/^\w/, c => c.toUpperCase());
+			funcName = rType + fName;
+		} else {
+			funcName = funcName.split('.')[1];
+		}
+		
 	}
 	return generateTests({ dir: editor.document.uri.fsPath, func: funcName }, getGoConfig(editor.document.uri));
 }

--- a/src/goGenerateTests.ts
+++ b/src/goGenerateTests.ts
@@ -98,13 +98,13 @@ export async function generateTestCurrentFunction(): Promise<boolean> {
 		return Promise.resolve(false);
 	}
 	let funcName = currentFunction.name;
-	let funcNameParts = funcName.match(/^\(\*?(.*)\)\.(.*)$/);
-	if(funcNameParts != null && funcNameParts.length === 3){  // receiver type specified
-		let rType = funcNameParts[1].replace(/^\w/, c => c.toUpperCase());
-		let fName = funcNameParts[2].replace(/^\w/, c => c.toUpperCase());
+	const funcNameParts = funcName.match(/^\(\*?(.*)\)\.(.*)$/);
+	if (funcNameParts != null && funcNameParts.length === 3) {  // receiver type specified
+		const rType = funcNameParts[1].replace(/^\w/, (c) => c.toUpperCase());
+		const fName = funcNameParts[2].replace(/^\w/, (c) => c.toUpperCase());
 		funcName = rType + fName;
-	} 
-		
+	}
+
 	return generateTests({ dir: editor.document.uri.fsPath, func: funcName }, getGoConfig(editor.document.uri));
 }
 


### PR DESCRIPTION
The receiver type for a method is now considered. So, if there are >= 1 method names in the same file, then clicking "generate unit tests for function" creates test functions only for the selected method.

funcName like "(*Point).Move" will results in "gotests -w -only ^PointMove$ calls.