### PR TITLE
remove obsolete enableBreakpointsFor

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,11 +325,6 @@
       {
         "type": "go",
         "label": "Go",
-        "enableBreakpointsFor": {
-          "languageIds": [
-            "go"
-          ]
-        },
         "program": "./out/src/debugAdapter/goDebug.js",
         "runtime": "node",
         "languages": [

--- a/package.json
+++ b/package.json
@@ -321,6 +321,7 @@
         "description": "Restart the running instance of the language server"
       }
     ],
+    "breakpoints": [{ "language": "go" }],
     "debuggers": [
       {
         "type": "go",


### PR DESCRIPTION
This suppresses the lint warning.
There is already the "languages" field.

Context: See github.com/microsoft/vscode/issues/9037