### PR TITLE
Show warning if 'program' attribute is used in 'remote'

### DIFF
--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -118,7 +118,9 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 				`Request type of 'launch' with mode 'remote' is deprecated, please use request type 'attach' with mode 'remote' instead.`);
 		}
 
-		if (debugConfiguration.request === 'launch' && debugConfiguration['mode'] === 'remote') {
+		if (debugConfiguration.request === 'attach'
+			&& debugConfiguration['mode'] === 'remote'
+			&& debugConfiguration['program']) {
 			this.showWarning(
 				'ignoreUsingRemotePathAndProgramWarning',
 				`Request type of 'attach' with mode 'remote' does not work with 'program' attribute, please use 'cwd' attribute instead.`);

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -112,26 +112,6 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 		debugConfiguration['currentFile'] =
 			activeEditor && activeEditor.document.languageId === 'go' && activeEditor.document.fileName;
 
-		const neverAgain = { title: `Don't Show Again` };
-		const ignoreWarningKey = 'ignoreDebugLaunchRemoteWarning';
-		const ignoreWarning = getFromGlobalState(ignoreWarningKey);
-		if (
-			ignoreWarning !== true &&
-			debugConfiguration.request === 'launch' &&
-			debugConfiguration['mode'] === 'remote'
-		) {
-			vscode.window
-				.showWarningMessage(
-					`Request type of 'launch' with mode 'remote' is deprecated, please use request type 'attach' with mode 'remote' instead.`,
-					neverAgain
-				)
-				.then((result) => {
-					if (result === neverAgain) {
-						updateGlobalState(ignoreWarningKey, true);
-					}
-				});
-		}
-
 		if (debugConfiguration.request === 'launch' && debugConfiguration['mode'] === 'remote') {
 			this.showWarning(
 				'ignoreDebugLaunchRemoteWarning',

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -131,6 +131,32 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 					}
 				});
 		}
+
+		if (debugConfiguration.request === 'launch' && debugConfiguration['mode'] === 'remote') {
+			this.showWarning(
+				'ignoreDebugLaunchRemoteWarning',
+				`Request type of 'launch' with mode 'remote' is deprecated, please use request type 'attach' with mode 'remote' instead.`);
+		}
+
+		if (debugConfiguration.request === 'launch' && debugConfiguration['mode'] === 'remote') {
+			this.showWarning(
+				'ignoreUsingRemotePathAndProgramWarning',
+				`Request type of 'attach' with mode 'remote' does not work with 'program' attribute, please use 'cwd' attribute instead.`);
+		}
 		return debugConfiguration;
+	}
+
+	private showWarning(ignoreWarningKey: string, warningMessage: string) {
+		const ignoreWarning = getFromGlobalState(ignoreWarningKey);
+		if (ignoreWarning) {
+			return;
+		}
+
+		const neverAgain = { title: 'Don\'t Show Again' };
+		vscode.window.showWarningMessage(warningMessage, neverAgain).then((result) => {
+			if (result === neverAgain) {
+				updateGlobalState(ignoreWarningKey, true);
+			}
+		});
 	}
 }


### PR DESCRIPTION
When using the debugger in remote attach mode, users have to use `cwd` instead of `program`. This can be confusing so we should show a warning message.