### PR TITLE
Fixes #2122 tools are also found at GOBIN path

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -144,12 +144,12 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 		return;
 	}
 
-	let binpath = toolsGopath + path.sep + "bin";
-	if(envForTools['GOBIN'] != undefined && envForTools['GOBIN'] != ''){
-		binpath = "GOBIN path " + envForTools['GOBIN']
+	let installingMsg = `Installing ${missing.length} ${missing.length > 1 ? 'tools' : 'tool'} at `;
+	if (envForTools['GOBIN']) {
+		installingMsg += `the configured GOBIN: ${envForTools['GOBIN']}`;
+	} else {
+		installingMsg += toolsGopath + path.sep + 'bin';
 	}
-
-	let installingMsg = `Installing ${missing.length} ${missing.length > 1 ? 'tools' : 'tool'} at ${binpath}`;
 
 	// If the user is on Go >= 1.11, tools should be installed with modules enabled.
 	// This ensures that users get the latest tagged version, rather than master,

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -144,9 +144,12 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 		return;
 	}
 
-	let installingMsg = `Installing ${missing.length} ${missing.length > 1 ? 'tools' : 'tool'} at ${toolsGopath}${
-		path.sep
-	}bin`;
+	let binpath = toolsGopath + path.sep + "bin";
+	if(envForTools['GOBIN'] != undefined && envForTools['GOBIN'] != ''){
+		binpath = "GOBIN path " + envForTools['GOBIN']
+	}
+
+	let installingMsg = `Installing ${missing.length} ${missing.length > 1 ? 'tools' : 'tool'} at ${binpath}`;
 
 	// If the user is on Go >= 1.11, tools should be installed with modules enabled.
 	// This ensures that users get the latest tagged version, rather than master,

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -46,7 +46,7 @@ export function getBinPathWithPreferredGopath(toolName: string, preferredGopaths
 		binPathCache[toolName] = pathFromGoBin;
 		return pathFromGoBin;
 	}
-	
+
 	for (const preferred of preferredGopaths) {
 		if (typeof preferred === 'string') {
 			// Search in the preferred GOPATH workspace's bin folder

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -41,15 +41,12 @@ export function getBinPathWithPreferredGopath(toolName: string, preferredGopaths
 	}
 
 	const binname = alternateTool && !path.isAbsolute(alternateTool) ? alternateTool : toolName;
-	const env = Object.assign({}, process.env);
-	if (env['GOBIN'] != undefined){
-		const path = getBinPathFromEnvVar(binname, env['GOBIN'], false);
-		if (path) {
-			binPathCache[toolName] = path;
-			return path;
-		}
+	const pathFromGoBin = getBinPathFromEnvVar(binname, process.env['GOBIN'], false);
+	if (pathFromGoBin) {
+		binPathCache[toolName] = pathFromGoBin;
+		return pathFromGoBin;
 	}
-
+	
 	for (const preferred of preferredGopaths) {
 		if (typeof preferred === 'string') {
 			// Search in the preferred GOPATH workspace's bin folder

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -41,6 +41,15 @@ export function getBinPathWithPreferredGopath(toolName: string, preferredGopaths
 	}
 
 	const binname = alternateTool && !path.isAbsolute(alternateTool) ? alternateTool : toolName;
+	const env = Object.assign({}, process.env);
+	if (env['GOBIN'] != undefined){
+		const path = getBinPathFromEnvVar(binname, env['GOBIN'], false);
+		if (path) {
+			binPathCache[toolName] = path;
+			return path;
+		}
+	}
+
 	for (const preferred of preferredGopaths) {
 		if (typeof preferred === 'string') {
 			// Search in the preferred GOPATH workspace's bin folder


### PR DESCRIPTION
1)
If `go.toolsGopath` setting is set, `goInstallTools.installTools` was already setting GOBIN env to ''. With no  `go.toolsGopath` set but GOBIN defined the tools are installed in GOBIN path already. The log message had to be corrected (Installing x tools at ...).

2)
GOBIN was added to the list of places where the extension looks for the tools