### PR TITLE
Logic for gopls updater to accept a pre-release version

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -8,6 +8,7 @@
 import cp = require('child_process');
 import fs = require('fs');
 import path = require('path');
+import { SemVer } from 'semver';
 import vscode = require('vscode');
 import { getLanguageServerToolPath } from './goLanguageServer';
 import { envPath, getToolFromToolPath } from './goPath';
@@ -18,6 +19,7 @@ import {
 	disableModulesForWildcard,
 	getConfiguredTools,
 	getImportPath,
+	getImportPathWithVersion,
 	getTool,
 	hasModSuffix,
 	isGocode,
@@ -89,11 +91,21 @@ export async function installAllTools(updateExistingToolsOnly: boolean = false) 
 }
 
 /**
+ * ToolAtVersion is a Tool with version annotation.
+ * Lack of version implies the latest version
+ */
+export interface ToolAtVersion extends Tool {
+	version?: SemVer;
+}
+
+/**
  * Installs given array of missing tools. If no input is given, the all tools are installed
  *
- * @param string[] array of tool names to be installed
+ * @param missing array of tool names and optionally, their versions to be installed.
+ *                If a tool's version is not specified, it will install the latest.
+ * @param goVersion version of Go that affects how to install the tool. (e.g. modules vs legacy GOPATH mode)
  */
-export function installTools(missing: Tool[], goVersion: GoVersion): Promise<void> {
+export function installTools(missing: ToolAtVersion[], goVersion: GoVersion): Promise<void> {
 	const goRuntimePath = getBinPath('go');
 	if (!goRuntimePath) {
 		vscode.window.showErrorMessage(
@@ -169,6 +181,10 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 
 	outputChannel.appendLine(installingMsg);
 	missing.forEach((missingTool) => {
+		let toolName = missingTool.name;
+		if (missingTool.version) {
+			toolName += '@' + missingTool.version;
+		}
 		outputChannel.appendLine('  ' + missingTool.name);
 	});
 
@@ -178,7 +194,7 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 	const toolsTmpDir = fs.mkdtempSync(getTempFilePath('go-tools-'));
 
 	return missing
-		.reduce((res: Promise<string[]>, tool: Tool) => {
+		.reduce((res: Promise<string[]>, tool: ToolAtVersion) => {
 			return res.then(
 				(sofar) =>
 					new Promise<string[]>((resolve, reject) => {
@@ -199,18 +215,18 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 							env: envForTools,
 							cwd: toolsTmpDir
 						};
-
 						const callback = (err: Error, stdout: string, stderr: string) => {
 							// Make sure to delete the temporary go.mod file, if it exists.
 							if (tmpGoModFile && fs.existsSync(tmpGoModFile)) {
 								fs.unlinkSync(tmpGoModFile);
 							}
+							const importPath = getImportPathWithVersion(tool, tool.version, goVersion);
 							if (err) {
-								outputChannel.appendLine('Installing ' + getImportPath(tool, goVersion) + ' FAILED');
+								outputChannel.appendLine('Installing ' + importPath + ' FAILED');
 								const failureReason = tool.name + ';;' + err + stdout.toString() + stderr.toString();
 								resolve([...sofar, failureReason]);
 							} else {
-								outputChannel.appendLine('Installing ' + getImportPath(tool, goVersion) + ' SUCCEEDED');
+								outputChannel.appendLine('Installing ' + importPath + ' SUCCEEDED');
 								resolve([...sofar, null]);
 							}
 						};
@@ -246,11 +262,17 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 							if (hasModSuffix(tool)) {
 								args.push('-d');
 							}
-							args.push(getImportPath(tool, goVersion));
+							let importPath: string;
+							if (modulesOffForTool) {
+								importPath = getImportPath(tool, goVersion);
+							} else {
+								importPath = getImportPathWithVersion(tool, tool.version, goVersion);
+							}
+							args.push(importPath);
 							cp.execFile(goRuntimePath, args, opts, (err, stdout, stderr) => {
 								if (stderr.indexOf('unexpected directory layout:') > -1) {
 									outputChannel.appendLine(
-										`Installing ${tool.name} failed with error "unexpected directory layout". Retrying...`
+										`Installing ${importPath} failed with error "unexpected directory layout". Retrying...`
 									);
 									cp.execFile(goRuntimePath, args, opts, callback);
 								} else if (!err && hasModSuffix(tool)) {
@@ -352,23 +374,27 @@ export async function promptForMissingTool(toolName: string) {
 	});
 }
 
-export async function promptForUpdatingTool(toolName: string) {
+export async function promptForUpdatingTool(toolName: string, newVersion?: SemVer) {
 	const tool = getTool(toolName);
+	const toolVersion = {...tool, version: newVersion}; // ToolWithVersion
 
 	// If user has declined to update, then don't prompt.
 	if (containsTool(declinedUpdates, tool)) {
 		return;
 	}
 	const goVersion = await getGoVersion();
-	const updateMsg = `Your version of ${tool.name} appears to be out of date. Please update for an improved experience.`;
+	let updateMsg = `Your version of ${tool.name} appears to be out of date. Please update for an improved experience.`;
 	const choices: string[] = ['Update'];
 	if (toolName === `gopls`) {
-		choices.push('Release Notes'); // TODO(hyangah): pass more info such as version, release note location.
+		choices.push('Release Notes');
+	}
+	if (newVersion) {
+		updateMsg = `New version of ${tool.name} (${newVersion}) is available. Please update for an improved experience.`;
 	}
 	vscode.window.showInformationMessage(updateMsg, ...choices).then((selected) => {
 		switch (selected) {
 			case 'Update':
-				installTools([tool], goVersion);
+				installTools([toolVersion], goVersion);
 				break;
 			case 'Release Notes':
 				vscode.commands.executeCommand(

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -185,7 +185,7 @@ export function installTools(missing: ToolAtVersion[], goVersion: GoVersion): Pr
 		if (missingTool.version) {
 			toolName += '@' + missingTool.version;
 		}
-		outputChannel.appendLine('  ' + missingTool.name);
+		outputChannel.appendLine('  ' + toolName);
 	});
 
 	outputChannel.appendLine(''); // Blank line for spacing.

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -91,9 +91,10 @@ export async function registerLanguageFeatures(ctx: vscode.ExtensionContext) {
 
 	// If installed, check. The user may not have the most up-to-date version of the language server.
 	const tool = getTool(toolName);
-	const update = await shouldUpdateLanguageServer(tool, languageServerToolPath, config.checkForUpdates);
-	if (update) {
-		promptForUpdatingTool(toolName);
+	const versionToUpdate = await shouldUpdateLanguageServer(tool, languageServerToolPath, config.checkForUpdates);
+
+	if (versionToUpdate) {
+		promptForUpdatingTool(toolName, versionToUpdate);
 	}
 
 	const c = new LanguageClient(
@@ -428,10 +429,10 @@ async function shouldUpdateLanguageServer(
 	tool: Tool,
 	languageServerToolPath: string,
 	makeProxyCall: boolean
-): Promise<boolean> {
+): Promise<semver.SemVer> {
 	// Only support updating gopls for now.
 	if (tool.name !== 'gopls') {
-		return false;
+		return null;
 	}
 
 	// First, run the "gopls version" command and parse its results.
@@ -439,12 +440,12 @@ async function shouldUpdateLanguageServer(
 	// or its version doesn't match our expectations, prompt the user to download.
 	const usersVersion = await goplsVersion(languageServerToolPath);
 	if (!usersVersion) {
-		return true;
+		return null;
 	}
 
 	// We might have a developer version. Don't make the user update.
 	if (usersVersion === '(devel)') {
-		return false;
+		return null;
 	}
 
 	// Get the latest gopls version.
@@ -464,12 +465,12 @@ async function shouldUpdateLanguageServer(
 		if (!latestTime) {
 			latestTime = defaultLatestVersionTime;
 		}
-		return usersTime.isBefore(latestTime);
+		return usersTime.isBefore(latestTime) ? latestVersion : null;
 	}
 
 	// If the user's version does not contain a timestamp,
 	// default to a semver comparison of the two versions.
-	return semver.lt(usersVersion, latestVersion);
+	return semver.lt(usersVersion, latestVersion) ? latestVersion : null;
 }
 
 // Copied from src/cmd/go/internal/modfetch.

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -436,12 +436,7 @@ async function shouldUpdateLanguageServer(
 	}
 
 	// First, run the "gopls version" command and parse its results.
-	// If "gopls" is so old that it doesn't have the "gopls version" command,
-	// or its version doesn't match our expectations, prompt the user to download.
 	const usersVersion = await goplsVersion(languageServerToolPath);
-	if (!usersVersion) {
-		return null;
-	}
 
 	// We might have a developer version. Don't make the user update.
 	if (usersVersion === '(devel)') {
@@ -454,6 +449,13 @@ async function shouldUpdateLanguageServer(
 	// If we failed to get the gopls version, pick the one we know to be latest at the time of this extension's last update
 	if (!latestVersion) {
 		latestVersion = defaultLatestVersion;
+	}
+
+	// If "gopls" is so old that it doesn't have the "gopls version" command,
+	// or its version doesn't match our expectations, usersVersion will be empty.
+	// Suggest the latestVersion.
+	if (!usersVersion) {
+		return latestVersion;
 	}
 
 	// The user may have downloaded golang.org/x/tools/gopls@master,

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -421,6 +421,7 @@ function registerUsualProviders(ctx: vscode.ExtensionContext) {
 	vscode.workspace.onDidChangeTextDocument(parseLiveFile, null, ctx.subscriptions);
 }
 
+const acceptGoplsPrerelease = false;
 const defaultLatestVersion = semver.coerce('0.3.1');
 const defaultLatestVersionTime = moment('2020-02-04', 'YYYY-MM-DD');
 async function shouldUpdateLanguageServer(
@@ -544,6 +545,9 @@ async function latestGopls(tool: Tool): Promise<semver.SemVer> {
 	}
 	versions.sort(semver.rcompare);
 
+	if (acceptGoplsPrerelease) {
+		return versions[0];  // The first one (newest one).
+	}
 	// The first version in the sorted list without a prerelease tag.
 	return versions.find((version) => !version.prerelease || !version.prerelease.length);
 }

--- a/src/goTools.ts
+++ b/src/goTools.ts
@@ -5,6 +5,7 @@
 
 'use strict';
 
+import { SemVer } from 'semver';
 import { goLiveErrorsEnabled } from './goLiveErrors';
 import { getGoConfig, GoVersion } from './util';
 
@@ -28,6 +29,13 @@ export function getImportPath(tool: Tool, goVersion: GoVersion): string {
 	return tool.importPath;
 }
 
+export function getImportPathWithVersion(tool: Tool, version: SemVer, goVersion: GoVersion): string {
+	const importPath = getImportPath(tool, goVersion);
+	if (version) {
+		return importPath + '@v' + version;
+	}
+	return importPath;
+}
 /**
  * Returns boolean denoting if the import path for the given tool ends with `/...`
  * and if the version of Go supports installing wildcard paths in module mode.


### PR DESCRIPTION
acceptGoplsPrerelease is a const set to false.
We are currently discussing what's the best way to expose this knob to users. 
Meanwhile, developers can flip the var to test whether Gopls picks up the newest version including prerelease. 