### PR TITLE
Considering if launch.json's program attribute resolves to a file in debug mode

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -475,7 +475,7 @@ class Delve {
 
 				const currentGOWorkspace = getCurrentGoWorkspaceFromGOPATH(env['GOPATH'], dirname);
 				dlvArgs.push(mode || 'debug');
-				if (mode === 'exec') {
+				if (mode === 'exec' || (mode === 'debug' && !isProgramDirectory)) {
 					dlvArgs.push(program);
 				} else if (currentGOWorkspace && !launchArgs.packagePathToGoModPathMap[dirname]) {
 					dlvArgs.push(dirname.substr(currentGOWorkspace.length + 1));

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -24,7 +24,7 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 				type: 'go',
 				request: 'launch',
 				mode: 'auto',
-				program: '${file}',
+				program: '${fileDirname}',
 				env: {},
 				args: []
 			}

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -24,7 +24,7 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 				type: 'go',
 				request: 'launch',
 				mode: 'auto',
-				program: '${fileDirname}',
+				program: '${file}',
 				env: {},
 				args: []
 			}


### PR DESCRIPTION
Fixing #1229 

Implemented intial proposal by @ramya-rao-a 

When the `program` attribute points to a file (${file} or absolute path), the filepath is now passed to the delve debug command. Thus debugging also works if multiple main files exist in the package. Launching debug from active editor file with no main function (Program = ${file}) will result in following error "Can not debug non-main package". 

Program ${fileDirname} configuration works as before. 

Updated the default value for program attribute in goDebugConfiguration.ts file to be {$file} instead of ${fileDirname}

Documentation [https://github.com/Microsoft/vscode-go/wiki/Debugging-Go-code-using-VS-Code] (url) should be updated e.g. first launch.json example. Since I'm not a native English speaker so not the best person to help.