### PR TITLE
checking setting 'go.buildTags' to contain build tags from file fixing #1497

### DIFF
--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import vscode = require('vscode');
 import { browsePackages } from './goBrowsePackage';
 import { buildCode } from './goBuild';
-import { check, notifyIfGeneratedFile, removeTestStatus } from './goCheck';
+import { check, checksOnFileEdit, removeTestStatus } from './goCheck';
 import { GoCodeActionProvider } from './goCodeAction';
 import {
 	applyCodeCoverage,
@@ -556,7 +556,7 @@ function addOnSaveTextDocumentListeners(ctx: vscode.ExtensionContext) {
 function addOnChangeTextDocumentListeners(ctx: vscode.ExtensionContext) {
 	vscode.workspace.onDidChangeTextDocument(removeCodeCoverageOnFileChange, null, ctx.subscriptions);
 	vscode.workspace.onDidChangeTextDocument(removeTestStatus, null, ctx.subscriptions);
-	vscode.workspace.onDidChangeTextDocument(notifyIfGeneratedFile, ctx, ctx.subscriptions);
+	vscode.workspace.onDidChangeTextDocument(checksOnFileEdit, ctx, ctx.subscriptions);
 }
 
 function addOnChangeActiveTextEditorListeners(ctx: vscode.ExtensionContext) {


### PR DESCRIPTION
If the current file has build tags which are not present in `go.buildtags` the user is now prompted to update the `go.buildtags` setting. "Don't show again" and  "Open settings" were implemented on the prompt.

**Example**
```
// +build linux,386 darwin,!cgo
// +build development
``` 
translates to condition `((linux AND 386) OR (darwin AND (NOT cgo))) AND development` therefore go.buildtags should contain values `linux 386 development` OR `darwin cgo development`

Implementation is based on previous work of @urohit001