### PR TITLE
refactor handling for go-langserver installation

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -271,8 +271,8 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 			outputChannel.appendLine(''); // Blank line for spacing
 			const failures = res.filter((x) => x != null);
 			if (failures.length === 0) {
-				if (containsString(missing, 'go-langserver') || containsString(missing, 'gopls')) {
-					outputChannel.appendLine('Reload VS Code window to use the Go language server');
+				if (containsString(missing, 'gopls')) {
+					outputChannel.appendLine('Reload VS Code window to use the Go language server.');
 				}
 				outputChannel.appendLine('All tools successfully installed. You are ready to Go :).');
 				return;

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -314,7 +314,6 @@ export async function promptForMissingTool(toolName: string) {
 			return;
 		}
 	}
-
 	const installOptions = ['Install'];
 	let missing = await getMissingTools(goVersion);
 	if (!containsTool(missing, tool)) {

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -307,7 +307,8 @@ export function getLanguageServerToolPath(): string {
 		// Check if the user has set the deprecated "go-langserver" setting.
 		const golangserverAlternate = goConfig['alternateTools']['go-langserver'];
 		if (golangserverAlternate) {
-			vscode.window.showErrorMessage(`The "go.alternateTools" setting for "go-langserver" has been deprecated. Please use "gopls" instead.`);
+			vscode.window.showErrorMessage(`The "go.alternateTools" setting for "go-langserver" has been deprecated.
+Please set "gopls" instead, and then reload the VS Code window.`);
 			return;
 		}
 		if (goplsAlternate) {

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -305,8 +305,7 @@ export function getLanguageServerToolPath(): string {
 		const goplsAlternate = goConfig['alternateTools']['gopls'];
 
 		// Check if the user has set the deprecated "go-langserver" setting.
-		const golangserverAlternate = goConfig['alternateTools']['go-langserver'];
-		if (golangserverAlternate) {
+		if (goConfig['alternateTools']['go-langserver']) {
 			vscode.window.showErrorMessage(`The "go.alternateTools" setting for "go-langserver" has been deprecated.
 Please set "gopls" instead, and then reload the VS Code window.`);
 			return;
@@ -325,8 +324,7 @@ Please set "gopls" instead, and then reload the VS Code window.`);
 		return languageServerBinPath;
 	}
 
-	// Installation of gopls and go-langserver is supported.
-	// Other language servers must be installed manually.
+	// Installation of gopls is supported. Other language servers must be installed manually.
 	if (languageServerOfChoice !== 'gopls') {
 		vscode.window.showErrorMessage(
 			`Cannot find the language server ${languageServerOfChoice}. Please install it and reload this VS Code window.`

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -282,7 +282,7 @@ export function parseLanguageServerConfig(): LanguageServerConfig {
 /**
  * If the user has enabled the language server, return the absolute path to the
  * correct binary. If the required tool is not available, prompt the user to
- * install it. Only gopls (Google) and go-langserver (Sourcegraph) are supported.
+ * install it. Only gopls is officially supported.
  */
 export function getLanguageServerToolPath(): string {
 	const goConfig = getGoConfig();

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -327,7 +327,7 @@ Please set "gopls" instead, and then reload the VS Code window.`);
 
 	// Installation of gopls and go-langserver is supported.
 	// Other language servers must be installed manually.
-	if (languageServerOfChoice !== 'gopls' && languageServerOfChoice !== 'go-langserver') {
+	if (languageServerOfChoice !== 'gopls') {
 		vscode.window.showErrorMessage(
 			`Cannot find the language server ${languageServerOfChoice}. Please install it and reload this VS Code window.`
 		);

--- a/src/goTools.ts
+++ b/src/goTools.ts
@@ -261,12 +261,6 @@ const allToolsInformation: { [key: string]: Tool } = {
 		isImportant: true,
 		description: 'Linter'
 	},
-	'go-langserver': {
-		name: 'go-langserver',
-		importPath: 'github.com/sourcegraph/go-langserver',
-		isImportant: false,
-		description: 'Language Server from Sourcegraph'
-	},
 	'gopls': {
 		name: 'gopls',
 		importPath: 'golang.org/x/tools/gopls',

--- a/src/goTools.ts
+++ b/src/goTools.ts
@@ -121,9 +121,14 @@ export function getConfiguredTools(goVersion: GoVersion): Tool[] {
 	// Add the linter that was chosen by the user.
 	maybeAddTool(goConfig['lintTool']);
 
-	// Add the language server for Go versions > 1.10 if user has choosen to do so
+	// Add the language server for Go versions > 1.10 if user has choosen to do so.
+	// Respect the go.alternateTools setting.
 	if (goConfig['useLanguageServer'] && goVersion.gt('1.10')) {
-		maybeAddTool('gopls');
+		if (goConfig['alternateTools']['gopls']) {
+			maybeAddTool(goConfig['alternateTools']['gopls']);
+		} else {
+			maybeAddTool('gopls');
+		}
 	}
 
 	if (goLiveErrorsEnabled()) {

--- a/src/goTools.ts
+++ b/src/goTools.ts
@@ -124,11 +124,7 @@ export function getConfiguredTools(goVersion: GoVersion): Tool[] {
 	// Add the language server for Go versions > 1.10 if user has choosen to do so.
 	// Respect the go.alternateTools setting.
 	if (goConfig['useLanguageServer'] && goVersion.gt('1.10')) {
-		if (goConfig['alternateTools']['gopls']) {
-			maybeAddTool(goConfig['alternateTools']['gopls']);
-		} else {
-			maybeAddTool('gopls');
-		}
+		maybeAddTool('gopls');
 	}
 
 	if (goLiveErrorsEnabled()) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-go/issues/3028.

I thought that we actually supported the "go.alternateTools" settings for the "go-langserver", but it seems it's been deprecated. Remove the code that handled this in the language server installation, and be careful to only install the tool specified by the user.

Also, remove some unused import lines in the `goLanguageServer.ts` file.

/cc @hyangah 