### PR TITLE
installAllTools: skip tools specified in go.alternateTools

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -42,7 +42,13 @@ const declinedInstalls: Tool[] = [];
 
 export async function installAllTools(updateExistingToolsOnly: boolean = false) {
 	const goVersion = await getGoVersion();
-	const allTools = getConfiguredTools(goVersion);
+	let allTools = getConfiguredTools(goVersion);
+
+	// exclude tools replaced by alternateTools.
+	const alternateTools: { [key: string]: string } = getGoConfig().get('alternateTools');
+	allTools = allTools.filter((tool) => {
+		return !alternateTools[tool.name];
+	});
 
 	// Update existing tools by finding all tools the user has already installed.
 	if (updateExistingToolsOnly) {


### PR DESCRIPTION
Skip them from the Install/Update Tools command.

Tools listed in go.alternateTools are supposed to be maintained
by the users.

Fixes #3024
