### PR TITLE
Update to latest vscode-languageclient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1480,39 +1480,32 @@
       }
     },
     "vscode-jsonrpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+      "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
     },
     "vscode-languageclient": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz",
-      "integrity": "sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.0.1.tgz",
+      "integrity": "sha512-7yZaSHichTJEyOJykI2RLQEECf9MqNLoklzC/1OVi/M8ioIsWQ1+lkN1nTsUhd6+F7p9ar9dNmPiEhL0i5uUBA==",
       "requires": {
-        "semver": "^5.5.0",
-        "vscode-languageserver-protocol": "3.14.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
+        "semver": "^6.3.0",
+        "vscode-languageserver-protocol": "^3.15.1"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-      "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.1.tgz",
+      "integrity": "sha512-wJAo06VM9ZBnRqslplDjfz6Tdive0O7z44yNxBFA3x0/YZkXBIL6I+9rwQ/9Y//0X0eCh12FQrj+KmEXf2L5eA==",
       "requires": {
-        "vscode-jsonrpc": "^4.0.0",
-        "vscode-languageserver-types": "3.14.0"
+        "vscode-jsonrpc": "^5.0.1",
+        "vscode-languageserver-types": "3.15.0"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0.tgz",
+      "integrity": "sha512-AXteNagMhBWnZ6gNN0UB4HTiD/7TajgfHl6jaM6O7qz3zDJw0H3Jf83w05phihnBRCML+K6Ockh8f8bL0OObPw=="
     },
     "vscode-test": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "vscode-debugadapter": "^1.36.0",
     "vscode-debugprotocol": "^1.36.0",
     "vscode-extension-telemetry": "^0.1.2",
-    "vscode-languageclient": "~5.2.1",
+    "vscode-languageclient": "^6.0.1",
     "web-request": "^1.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
This reverts commit 5f15c237c71e527d983d29d351597838868c4b1b.

This effectively brings in the commit 3b02de0 back again.
Originally reverted because it requires vscode 1.41.x,
which was just released at the time of Go extension 0.13.0
release. Currently 1.42.x is the latest version, and we expect
another cycle of vscode release when the next version of Go
extension is out.

We need more up-to-date version of vscode-languageclient to
bring in various fixes to problems such as
https://github.com/microsoft/vscode-languageserver-node/issues/442

Considered only minor version upgrade but I couldn't find a suitable
newer version than 5.2.1
(https://www.npmjs.com/package/vscode-languageclient)