### PR TITLE
Map remote go module cache to local module cache

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -854,6 +854,21 @@ class GoDebugSession extends LoggingDebugSession {
 			if (goroot && index > 0) {
 				return path.join(goroot, pathToConvert.substr(index));
 			}
+
+			const indexGoModCache = pathToConvert.indexOf(
+				`${this.remotePathSeparator}pkg${this.remotePathSeparator}mod${this.remotePathSeparator}`
+			);
+			const gopath = process.env['GOPATH'];
+
+			if (gopath && indexGoModCache > 0) {
+				return path.join(
+					gopath,
+					pathToConvert
+						.substr(indexGoModCache)
+						.split(this.remotePathSeparator)
+						.join(this.localPathSeparator)
+				);
+			}
 		}
 		return pathToConvert
 			.replace(this.delve.remotePath, this.delve.program)

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -846,9 +846,9 @@ class GoDebugSession extends LoggingDebugSession {
 			return this.convertDebuggerPathToClient(pathToConvert);
 		}
 
-		// Fix for https://github.com/Microsoft/vscode-go/issues/1178
-		// When the pathToConvert is under GOROOT, replace the remote GOROOT with local GOROOT
+		// When the pathToConvert is under GOROOT or Go module cache, replace path appropriately
 		if (!pathToConvert.startsWith(this.delve.remotePath)) {
+			// Fix for https://github.com/Microsoft/vscode-go/issues/1178
 			const index = pathToConvert.indexOf(`${this.remotePathSeparator}src${this.remotePathSeparator}`);
 			const goroot = process.env['GOROOT'];
 			if (goroot && index > 0) {
@@ -858,7 +858,7 @@ class GoDebugSession extends LoggingDebugSession {
 			const indexGoModCache = pathToConvert.indexOf(
 				`${this.remotePathSeparator}pkg${this.remotePathSeparator}mod${this.remotePathSeparator}`
 			);
-			const gopath = process.env['GOPATH'];
+			const gopath = (process.env['GOPATH'] || '').split(path.delimiter)[0];
 
 			if (gopath && indexGoModCache > 0) {
 				return path.join(


### PR DESCRIPTION
This is similar to another scenario: https://github.com/microsoft/vscode-go/pull/1179

When using the remote debug feature, the paths to remote go module cache might not match the paths to local go module cache.

The idea here is to check if the remote path includes the go module cache sub string, for example: 

`/go/pkg/mod/github.com/account/package`

In this case, it would be a match for the go module cache substring: 

`/pkg/mod/`

And in this case, the path would be replaced by: 

`/Users/someuser/go/pkg/mod/github.com/account/package`

Considering a local gopath like this: 

`$GOPATH="/Users/someuser/go"`.

By doing that, vscode-go can find all source files during debug, including cached modules.

I've made the minimal required changes to make it work for the scenario that I was facing, but I'm happy to make improvements based on feedback.

If I missed any guidelines, please let me know.

Also, I'm curious to know if this is the right approach to deal with this, or there is a better alternative.