### PR TITLE
golangci-lint  --out-format=colored-line-number

### DIFF
--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -120,6 +120,11 @@ export function goLint(
 			// print only file:number:column
 			args.push('--print-issued-lines=false');
 		}
+		if (args.indexOf('--out-format=colored-line-number') === -1) {
+			// print file:number:column. 
+			// Explicit override in case .golangci.yml calls for a format we don't understand
+			args.push('--out-format=colored-line-number');
+		}
 	}
 
 	if (scope === 'workspace' && currentWorkspace) {

--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -121,7 +121,7 @@ export function goLint(
 			args.push('--print-issued-lines=false');
 		}
 		if (args.indexOf('--out-format=colored-line-number') === -1) {
-			// print file:number:column. 
+			// print file:number:column.
 			// Explicit override in case .golangci.yml calls for a format we don't understand
 			args.push('--out-format=colored-line-number');
 		}


### PR DESCRIPTION
What Problem
===============

In a project with `.golancci.yml` containing `output: format: checkstyle` (many formats other than checkstyle probably cause the same bug.) vscode will fail to parse warning output from golangci-lint with no discernible error message other than the usual `No problems have been detected in the workspace so far.` in the problems view.  Output in the `Output view > Go tab` shows only the normal `Finished running tool: /home/user/go/bin/golangci-lint run  --print-issued-lines=false`


Solution
--------------

 Let's be explicit about a format that we do understand. I chose `colored-line-number` because that's golangci-lint's default according to `golangci-lint run --help`.

Testing
-------------

I approximated tested by setting `"go.lintFlags": ["--out-format=colored-line-number"],` in `settings.json` and watching the command come up in the *Output view > Go tab*. Unfortunately, I don't currently have time to build the extension, sideload it, write tests, run tests, etc.