### PR TITLE
debug: fix 'run without debugging'

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -435,6 +435,7 @@ class Delve {
 							runOptions.cwd = program;
 							runArgs.push('.');
 						} else {
+							runOptions.cwd = dirname;
 							runArgs.push(program);
 						}
 						if (launchArgs.args) {

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -47,13 +47,13 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 				return;
 			}
 
-			debugConfiguration = {
+			debugConfiguration = Object.assign(debugConfiguration, {
 				name: 'Launch',
 				type: 'go',
 				request: 'launch',
 				mode: 'auto',
 				program: activeEditor.document.fileName
-			};
+			});
 		}
 
 		debugConfiguration['packagePathToGoModPathMap'] = packagePathToGoModPathMap;

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -47,7 +47,7 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 				return;
 			}
 
-			debugConfiguration = Object.assign(debugConfiguration, {
+			debugConfiguration = Object.assign(debugConfiguration || {}, {
 				name: 'Launch',
 				type: 'go',
 				request: 'launch',


### PR DESCRIPTION
Bug 1: when generating the default debug configuration
because there is no user-configured one, the extension
dropped noDebug field and caused the program to run with
debugging enabled. Fix it (goDebugConfiguration.ts)

Bug 2: when debug adapter receives noDebug request, it
runs the program with `go run` instead of invoking the
program through dlv. The `go run` will not work in modules
mode if the command runs outside the main module. Set
cwd accordingly.

Fixes microsoft/vscode-go#3121

TESTED=manually with the example attached in #3121