### PR TITLE
Remove support for github.com/sourcegraph/go-langserver

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -277,7 +277,7 @@ export function installTools(missing: Tool[], goVersion: GoVersion): Promise<voi
 			outputChannel.appendLine(''); // Blank line for spacing
 			const failures = res.filter((x) => x != null);
 			if (failures.length === 0) {
-				if (containsString(missing, 'go-langserver') || containsString(missing, 'gopls')) {
+				if (containsString(missing, 'gopls')) {
 					outputChannel.appendLine('Reload VS Code window to use the Go language server');
 				}
 				outputChannel.appendLine('All tools successfully installed. You are ready to Go :).');

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -344,10 +344,10 @@ export function parseLanguageServerConfig(): LanguageServerConfig {
 }
 
 /**
- * Get the absolute path to the language server to be used.
- * If the required tool is not available, then user is prompted to install it.
- * This supports the language servers from both Google and Sourcegraph with the
- * former getting a precedence over the latter
+ *
+ * If the user has enabled the language server, return the absolute path to the
+ * correct binary. If the required tool is not available, prompt the user to
+ * install it. Only gopls is officially supported.
  */
 export function getLanguageServerToolPath(): string {
 	// If language server is not enabled, return
@@ -363,40 +363,32 @@ export function getLanguageServerToolPath(): string {
 		);
 		return;
 	}
-
-	// Get the path to gopls or any alternative that the user might have set for gopls.
+	// Get the path to gopls (getBinPath checks for alternate tools).
 	const goplsBinaryPath = getBinPath('gopls');
 	if (path.isAbsolute(goplsBinaryPath)) {
 		return goplsBinaryPath;
 	}
-
-	// Get the path to go-langserver or any alternative that the user might have set for go-langserver.
-	const golangserverBinaryPath = getBinPath('go-langserver');
-	if (path.isAbsolute(golangserverBinaryPath)) {
-		return golangserverBinaryPath;
-	}
-
-	// If no language server path has been found, notify the user.
-	let languageServerOfChoice = 'gopls';
-	if (goConfig['alternateTools']) {
-		const goplsAlternate = goConfig['alternateTools']['gopls'];
-		const golangserverAlternate = goConfig['alternateTools']['go-langserver'];
-		if (typeof goplsAlternate === 'string') {
-			languageServerOfChoice = getToolFromToolPath(goplsAlternate);
-		} else if (typeof golangserverAlternate === 'string') {
-			languageServerOfChoice = getToolFromToolPath(golangserverAlternate);
+	const alternateTools = goConfig['alternateTools'];
+	if (alternateTools) {
+		// The user's alternate language server was not found.
+		const goplsAlternate = alternateTools['gopls'];
+		if (goplsAlternate) {
+			vscode.window.showErrorMessage(
+				`Cannot find the alternate tool ${goplsAlternate} configured for gopls.
+Please install it and reload this VS Code window.`
+			);
+			return;
 		}
-	}
-	// Only gopls and go-langserver are supported.
-	if (languageServerOfChoice !== 'gopls' && languageServerOfChoice !== 'go-langserver') {
-		vscode.window.showErrorMessage(
-			`Cannot find the language server ${languageServerOfChoice}. Please install it and reload this VS Code window`
-		);
+		// Check if the user has the deprecated "go-langserver" setting.
+		// Suggest deleting it if the alternate tool is gopls.
+		if (alternateTools['go-langserver']) {
+			vscode.window.showErrorMessage(`Support for "go-langserver" has been deprecated.
+The recommended language server is gopls. Delete this setting to use gopls, or change "go-langserver" to "gopls" in your settings.json and reload the VS Code window.`);
+		}
 		return;
 	}
-	// Otherwise, prompt the user to install the language server.
-	promptForMissingTool(languageServerOfChoice);
-	vscode.window.showInformationMessage('Reload VS Code window after installing the Go language server.');
+	// Prompt the user to install gopls.
+	promptForMissingTool('gopls');
 }
 
 function allFoldersHaveSameGopath(): boolean {

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -383,7 +383,7 @@ Please install it and reload this VS Code window.`
 		// Suggest deleting it if the alternate tool is gopls.
 		if (alternateTools['go-langserver']) {
 			vscode.window.showErrorMessage(`Support for "go-langserver" has been deprecated.
-The recommended language server is gopls. Delete this setting to use gopls, or change "go-langserver" to "gopls" in your settings.json and reload the VS Code window.`);
+The recommended language server is gopls. Delete the alternate tool setting for "go-langserver" to use gopls, or change "go-langserver" to "gopls" in your settings.json and reload the VS Code window.`);
 		}
 		return;
 	}

--- a/src/goTools.ts
+++ b/src/goTools.ts
@@ -121,7 +121,7 @@ export function getConfiguredTools(goVersion: GoVersion): Tool[] {
 	// Add the linter that was chosen by the user.
 	maybeAddTool(goConfig['lintTool']);
 
-	// Add the language server for Go versions > 1.10 if user has choosen to do so
+	// Add the language server for Go versions > 1.10 if user has choosen to do so.
 	if (goConfig['useLanguageServer'] && goVersion.gt('1.10')) {
 		maybeAddTool('gopls');
 	}
@@ -259,12 +259,6 @@ const allToolsInformation: { [key: string]: Tool } = {
 		importPath: 'github.com/mgechev/revive',
 		isImportant: true,
 		description: 'Linter'
-	},
-	'go-langserver': {
-		name: 'go-langserver',
-		importPath: 'github.com/sourcegraph/go-langserver',
-		isImportant: false,
-		description: 'Language Server from Sourcegraph'
 	},
 	'gopls': {
 		name: 'gopls',


### PR DESCRIPTION
PR in Go Nightly: https://github.com/golang/vscode-go/pull/2

I improved the error messages for the `go-langserver` alternate tools setting, but I figured that it might be too much effort to add buttons to make automatic changes for users. I would imagine that most people have already made the switch, and if not, it's quite a small amount of manual work to justify the extra code for different buttons. Once a user changes the setting and reloads their editor, they will be prompted to install `gopls` anyway.

@ramya-rao-a: If you disagree, I'd be happy to add the buttons anyway. If I do that, could you point me to an API reference for how the buttons would work? I got as far as adding items to `vscode.window.showErrorMessage`, but I couldn't figure out how to connect them to functions when they are clicked or how to programmatically modify a user's settings.

Fixes https://github.com/microsoft/vscode-go/issues/3028

/cc @hyangah 