### PR TITLE
test/integration: fix Build Tags checking test

### DIFF
--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -1438,8 +1438,8 @@ encountered.
 					diagnostics[0].errors.length,
 					'check without buildtags failed. Unexpected errors found'
 				);
-				assert.equal(
-					diagnostics[0].errors[0].msg.indexOf(`can't load package: package test/testfixture/buildTags`) > -1,
+				const errMsg = diagnostics[0].errors[0].msg;
+				assert.equal(errMsg.includes(`can't load package: package test/testfixture/buildTags`) || errMsg.includes(`build constraints exclude all Go files`),
 					true,
 					`check without buildtags failed. Go files not excluded. ${diagnostics[0].errors[0].msg}`
 				);


### PR DESCRIPTION
The error message when there are no Go files to build is changed
in go1.15. That broke this test that includes the diagnostics
message string checking. Adds the message from go1.15 in the
match set.

Fixes microsoft/vscode-go#3130