### PR TITLE
fix lint error

### DIFF
--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -20,8 +20,8 @@ import {
 	generateTestCurrentPackage
 } from '../../src/goGenerateTests';
 import { getTextEditForAddImport, listPackages } from '../../src/goImport';
-import { goLint } from '../../src/goLint';
 import { updateGoPathGoRootFromConfig } from '../../src/goInstallTools';
+import { goLint } from '../../src/goLint';
 import { documentSymbols, GoDocumentSymbolProvider, GoOutlineImportsOptions } from '../../src/goOutline';
 import { getAllPackages } from '../../src/goPackages';
 import { goPlay } from '../../src/goPlayground';


### PR DESCRIPTION
Import sources within a group must be alphabetized.
Probably we broke it accidentally while merging two commits back to back.