### PR TITLE
replace . by current file when running without debugging

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -427,15 +427,15 @@ class Delve {
 					if (mode === 'debug') {
 						this.noDebug = true;
 						const runArgs = ['run'];
-						const runOptions: { [key: string]: any } = { env };
+						const runOptions: { [key: string]: any } = { cwd: dirname, env };
 						if (launchArgs.buildFlags) {
 							runArgs.push(launchArgs.buildFlags);
 						}
-						runArgs.push(program);
 						if (isProgramDirectory) {
-							runOptions.cwd = program;
-						} else {
-							runOptions.cwd = dirname;
+							runArgs.push("*.go");
+						}
+						else {
+							runArgs.push(program);
 						}
 						if (launchArgs.args) {
 							runArgs.push(...launchArgs.args);
@@ -472,7 +472,7 @@ class Delve {
 				if (!existsSync(launchArgs.dlvToolPath)) {
 					log(
 						`Couldn't find dlv at the Go tools path, ${process.env['GOPATH']}${
-							env['GOPATH'] ? ', ' + env['GOPATH'] : ''
+						env['GOPATH'] ? ', ' + env['GOPATH'] : ''
 						} or ${envPath}`
 					);
 					return reject(
@@ -1360,8 +1360,8 @@ class GoDebugSession extends LoggingDebugSession {
 			args.trace === 'verbose'
 				? Logger.LogLevel.Verbose
 				: args.trace === 'log'
-				? Logger.LogLevel.Log
-				: Logger.LogLevel.Error;
+					? Logger.LogLevel.Log
+					: Logger.LogLevel.Error;
 		const logPath =
 			this.logLevel !== Logger.LogLevel.Error ? path.join(os.tmpdir(), 'vscode-go-debug.txt') : undefined;
 		logger.setup(this.logLevel, logPath);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -433,8 +433,7 @@ class Delve {
 						}
 						if (isProgramDirectory) {
 							runArgs.push('.');
-						}
-						else {
+						} else {
 							runArgs.push(program);
 						}
 						if (launchArgs.args) {
@@ -472,7 +471,7 @@ class Delve {
 				if (!existsSync(launchArgs.dlvToolPath)) {
 					log(
 						`Couldn't find dlv at the Go tools path, ${process.env['GOPATH']}${
-						env['GOPATH'] ? ', ' + env['GOPATH'] : ''
+							env['GOPATH'] ? ', ' + env['GOPATH'] : ''
 						} or ${envPath}`
 					);
 					return reject(
@@ -1360,8 +1359,8 @@ class GoDebugSession extends LoggingDebugSession {
 			args.trace === 'verbose'
 				? Logger.LogLevel.Verbose
 				: args.trace === 'log'
-					? Logger.LogLevel.Log
-					: Logger.LogLevel.Error;
+				? Logger.LogLevel.Log
+				: Logger.LogLevel.Error;
 		const logPath =
 			this.logLevel !== Logger.LogLevel.Error ? path.join(os.tmpdir(), 'vscode-go-debug.txt') : undefined;
 		logger.setup(this.logLevel, logPath);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -431,12 +431,11 @@ class Delve {
 						if (launchArgs.buildFlags) {
 							runArgs.push(launchArgs.buildFlags);
 						}
+						runArgs.push(program);
 						if (isProgramDirectory) {
 							runOptions.cwd = program;
-							runArgs.push('.');
 						} else {
 							runOptions.cwd = dirname;
-							runArgs.push(program);
 						}
 						if (launchArgs.args) {
 							runArgs.push(...launchArgs.args);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -432,7 +432,7 @@ class Delve {
 							runArgs.push(launchArgs.buildFlags);
 						}
 						if (isProgramDirectory) {
-							runArgs.push("*.go");
+							runArgs.push('.');
 						}
 						else {
 							runArgs.push(program);


### PR DESCRIPTION
i have read the issue https://github.com/microsoft/vscode-go/issues/3096 about adding 'go run .' support and i think the commit https://github.com/microsoft/vscode-go/commit/78518d7e9736670d75fe2cd648c7c3eb23413157 has some stuff to work on @ramya-rao-a :

1. the owner of https://github.com/microsoft/vscode-go/issues/3096 just want to solve the problem which can not run a go file without debugging, i think there is no need to pass '.' to `go run` to solve this problem, pass current dir to `cwd` is fine.

2. if pass the '.' to `go run`, users will not check the process, because the executable file will by named as the directory name by go compiler, it's not consistent.





