### PR TITLE
Use 'entry' as stopped event reason when stopping on entry

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -821,8 +821,8 @@ class GoDebugSession extends LoggingDebugSession {
 	): Promise<void> {
 		log('ConfigurationDoneRequest');
 		if (this.stopOnEntry) {
-			this.sendEvent(new StoppedEvent('breakpoint', 1));
-			log('StoppedEvent("breakpoint")');
+			this.sendEvent(new StoppedEvent('entry', 1));
+			log('StoppedEvent("entry")');
 			this.sendResponse(response);
 		} else {
 			this.debugState = await this.delve.getDebugState();


### PR DESCRIPTION
The DAP spec allows us to differentiate between stopping on entry and on a breakpoint. 
This is what the UI looked like before:
<img width="231" alt="before" src="https://user-images.githubusercontent.com/51177946/78400132-fb589c80-75aa-11ea-89bd-b71c2ce2ad3f.png">
This is after this change.
<img width="231" alt="after" src="https://user-images.githubusercontent.com/51177946/78400147-014e7d80-75ab-11ea-8bec-6975f6cf67cb.png">
