### PR TITLE
src/goLanguageServer.ts: remove fallbacks for features that cannot be opted-out of

### DIFF
--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -17,20 +17,10 @@ import {
 	HandleDiagnosticsSignature,
 	LanguageClient,
 	ProvideCompletionItemsSignature,
-	ProvideDefinitionSignature,
 	ProvideDocumentFormattingEditsSignature,
-	ProvideDocumentHighlightsSignature,
 	ProvideDocumentLinksSignature,
-	ProvideDocumentSymbolsSignature,
-	ProvideHoverSignature,
-	ProvideReferencesSignature,
-	ProvideRenameEditsSignature,
-	ProvideSignatureHelpSignature,
-	ProvideWorkspaceSymbolsSignature,
 	RevealOutputChannelOn
 } from 'vscode-languageclient';
-import { ProvideImplementationSignature } from 'vscode-languageclient/lib/implementation';
-import { ProvideTypeDefinitionSignature } from 'vscode-languageclient/lib/typeDefinition';
 import WebRequest = require('web-request');
 import { GoDefinitionProvider } from './goDeclaration';
 import { GoHoverProvider } from './goExtraInfo';
@@ -208,61 +198,10 @@ export async function registerLanguageFeatures(ctx: vscode.ExtensionContext) {
 				'The language server is not able to serve any features at the moment.'
 			);
 		}
-
 		// Fallback to default providers for unsupported or disabled features.
-
-		if (!capabilities.completionProvider) {
-			const provider = new GoCompletionItemProvider(ctx.globalState);
-			ctx.subscriptions.push(provider);
-			ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(GO_MODE, provider, '.', '"'));
-		}
 		if (!config.features.format || !capabilities.documentFormattingProvider) {
 			ctx.subscriptions.push(
 				vscode.languages.registerDocumentFormattingEditProvider(GO_MODE, new GoDocumentFormattingEditProvider())
-			);
-		}
-
-		if (!capabilities.renameProvider) {
-			ctx.subscriptions.push(vscode.languages.registerRenameProvider(GO_MODE, new GoRenameProvider()));
-		}
-
-		if (!capabilities.typeDefinitionProvider) {
-			ctx.subscriptions.push(
-				vscode.languages.registerTypeDefinitionProvider(GO_MODE, new GoTypeDefinitionProvider())
-			);
-		}
-
-		if (!capabilities.hoverProvider) {
-			ctx.subscriptions.push(vscode.languages.registerHoverProvider(GO_MODE, new GoHoverProvider()));
-		}
-
-		if (!capabilities.definitionProvider) {
-			ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(GO_MODE, new GoDefinitionProvider()));
-		}
-
-		if (!capabilities.referencesProvider) {
-			ctx.subscriptions.push(vscode.languages.registerReferenceProvider(GO_MODE, new GoReferenceProvider()));
-		}
-
-		if (!capabilities.documentSymbolProvider) {
-			ctx.subscriptions.push(
-				vscode.languages.registerDocumentSymbolProvider(GO_MODE, new GoDocumentSymbolProvider())
-			);
-		}
-
-		if (!capabilities.signatureHelpProvider) {
-			ctx.subscriptions.push(
-				vscode.languages.registerSignatureHelpProvider(GO_MODE, new GoSignatureHelpProvider(), '(', ',')
-			);
-		}
-
-		if (!capabilities.workspaceSymbolProvider) {
-			ctx.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new GoWorkspaceSymbolProvider()));
-		}
-
-		if (!capabilities.implementationProvider) {
-			ctx.subscriptions.push(
-				vscode.languages.registerImplementationProvider(GO_MODE, new GoImplementationProvider())
 			);
 		}
 	});
@@ -336,7 +275,6 @@ export function parseLanguageServerConfig(): LanguageServerConfig {
 			diagnostics: goConfig['languageServerExperimentalFeatures']['diagnostics'],
 			format: goConfig['languageServerExperimentalFeatures']['format'],
 			documentLink: goConfig['languageServerExperimentalFeatures']['documentLink'],
-			highlight: goConfig['languageServerExperimentalFeatures']['highlight']
 		},
 		checkForUpdates: goConfig['useGoProxyToCheckForToolUpdates']
 	};

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -45,7 +45,6 @@ interface LanguageServerConfig {
 	flags: string[];
 	features: {
 		diagnostics: boolean;
-		format: boolean;
 		documentLink: boolean;
 	};
 	checkForUpdates: boolean;
@@ -104,17 +103,6 @@ export async function registerLanguageFeatures(ctx: vscode.ExtensionContext) {
 			},
 			revealOutputChannelOn: RevealOutputChannelOn.Never,
 			middleware: {
-				provideDocumentFormattingEdits: (
-					document: vscode.TextDocument,
-					options: FormattingOptions,
-					token: vscode.CancellationToken,
-					next: ProvideDocumentFormattingEditsSignature
-				) => {
-					if (!config.features.format) {
-						return [];
-					}
-					return next(document, options, token);
-				},
 				handleDiagnostics: (
 					uri: vscode.Uri,
 					diagnostics: vscode.Diagnostic[],
@@ -198,12 +186,6 @@ export async function registerLanguageFeatures(ctx: vscode.ExtensionContext) {
 				'The language server is not able to serve any features at the moment.'
 			);
 		}
-		// Fallback to default providers for unsupported or disabled features.
-		if (!config.features.format || !capabilities.documentFormattingProvider) {
-			ctx.subscriptions.push(
-				vscode.languages.registerDocumentFormattingEditProvider(GO_MODE, new GoDocumentFormattingEditProvider())
-			);
-		}
 	});
 
 	let languageServerDisposable = c.start();
@@ -220,12 +202,6 @@ export async function registerLanguageFeatures(ctx: vscode.ExtensionContext) {
 			ctx.subscriptions.push(languageServerDisposable);
 		})
 	);
-
-	// gopls is the only language server that provides live diagnostics on type,
-	// so use gotype if it's not enabled.
-	if (!(toolName === 'gopls' && config.features['diagnostics'])) {
-		vscode.workspace.onDidChangeTextDocument(parseLiveFile, null, ctx.subscriptions);
-	}
 }
 
 function watchLanguageServerConfiguration(e: vscode.ConfigurationChangeEvent) {
@@ -273,7 +249,6 @@ export function parseLanguageServerConfig(): LanguageServerConfig {
 			// TODO: We should have configs that match these names.
 			// Ultimately, we should have a centralized language server config rather than separate fields.
 			diagnostics: goConfig['languageServerExperimentalFeatures']['diagnostics'],
-			format: goConfig['languageServerExperimentalFeatures']['format'],
 			documentLink: goConfig['languageServerExperimentalFeatures']['documentLink'],
 		},
 		checkForUpdates: goConfig['useGoProxyToCheckForToolUpdates']


### PR DESCRIPTION
We should only have fallbacks for the features that we support opting out of.
Also, remove a few unused imports.

/cc @hyangah 