### PR TITLE
Place the go runtime base path to the front of PATH

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -416,7 +416,8 @@ export function updateGoPathGoRootFromConfig(): Promise<void> {
 		process.env[pathEnvVar] &&
 		(<string>process.env[pathEnvVar]).split(path.delimiter).indexOf(goRuntimeBasePath) === -1
 	) {
-		process.env[pathEnvVar] += path.delimiter + goRuntimeBasePath;
+		// Place the goRuntimeBasePath to the front so tools use the same version of go.
+		process.env[pathEnvVar] = goRuntimeBasePath + path.delimiter + process.env[pathEnvVar];
 	}
 
 	return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Users can specify the go command to use by setting GOROOT env var,
`go.goroot` vscode setting, or PATH env var. getBinPath('go') is
used to choose the right version of 'go' whenever the extension
tries to invoke the go commands. However, this does not affect
other tools that invoke the go command underneath.

For example, delve, gopls, and many tools simply pick a version of
go from PATH. If the GOROOT env var and the version of go found in
the PATH don't match, this can lead to errors.

This CL places the go runtime base bin path as the first element of
the PATH env var. That ensures any tools invoked by the extension
to pick the same version of go, as long as they stick with the usual
PATH-based executable search.

Note this process.env mutation does not affect the environment variable
settings the integrated terminal would see, but this is not a new
problem.

Fixes microsoft/vscode-go#3152