### PR TITLE
Add note about needing WSL 2 on Windows 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ A few of these are available in the editor context menu as an experimental featu
 
 ### _Optional_: Debugging
 
-To use the debugger, you must currently manually install `delve`.  See the [Installation Instructions](https://github.com/derekparker/delve/tree/master/Documentation/installation) for full details.  On MacOS it requires creating a self-signed cert to sign the `dlv` binary.
+To use the debugger, you must currently manually install `delve`.  See the [Installation Instructions](https://github.com/derekparker/delve/tree/master/Documentation/installation) for full details.  On MacOS it requires creating a self-signed cert to sign the `dlv` binary.  If using WSL on Windows, you will need the WSL 2 Linux kernel.  See [WSL 2 Installation](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install) and note the Window 10 build version requirements. 
 
 For more read [Debugging Go Code Using VS Code](https://github.com/Microsoft/vscode-go/wiki/Debugging-Go-code-using-VS-Code).
 

--- a/docs/Debugging-Go-code-using-VS-Code.md
+++ b/docs/Debugging-Go-code-using-VS-Code.md
@@ -234,7 +234,7 @@ You may see this in the debug console, while trying to run in the `test` mode. T
 
 **_Solution_**: Ensure that the `program` attribute points to the folder that contains the test files you want to run.
 
-#### delve/launch hangs with no messages
+#### delve/launch hangs with no messages when using WSL
 Try running ```delve debug ./main``` at the WSL command line and see if you get a prompt
 
 **_Solution_**: Ensure you are running the WSL 2 Kernel, which (as of 4/15/2020) requires an early release of the Windows 10 OS.  This is available to anyone via the Windows Insider program.  See [WSL 2 Installation](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install)

--- a/docs/Debugging-Go-code-using-VS-Code.md
+++ b/docs/Debugging-Go-code-using-VS-Code.md
@@ -234,6 +234,11 @@ You may see this in the debug console, while trying to run in the `test` mode. T
 
 **_Solution_**: Ensure that the `program` attribute points to the folder that contains the test files you want to run.
 
+#### delve/launch hangs with no messages
+Try running ```delve debug ./main``` at the WSL command line and see if you get a prompt
+
+**_Solution_**: Ensure you are running the WSL 2 Kernel, which (as of 4/15/2020) requires an early release of the Windows 10 OS.  This is available to anyone via the Windows Insider program.  See [WSL 2 Installation](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install)
+
 #### could not launch process: could not fork/exec
 
 ##### OSX 


### PR DESCRIPTION
delve will hang on the WSL 1 kernel due to trace system call issues.    Just adding a note to that effect.  Would be nice to put in the Wiki under troubleshooting as well.  @ramya-rao-a 