### PR TITLE
debug: use fileDirname for the default launch configuration

### DIFF
--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -52,7 +52,7 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 				type: 'go',
 				request: 'launch',
 				mode: 'auto',
-				program: activeEditor.document.fileName
+				program: path.dirname(activeEditor.document.fileName)  // matches ${fileDirname}
 			});
 		}
 


### PR DESCRIPTION
When "Start Debugging" or "Run without Debugging" runs without
an explicit launch configuration (launch.json), we need to use
the directory of the file as the program. That is consistent
with the default GoDebugConfigurationProvider provides as the
default DebugConfigurations. (${fileDirname}).

Update microsoft/vscode-go#1229 and microsoft/vscode-go#3096