### PR TITLE
src/goLanguageServer: fix missing gopls detection logic

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -544,9 +544,7 @@ function getMissingTools(goVersion: GoVersion): Promise<Tool[]> {
 			(tool) =>
 				new Promise<Tool>((resolve, reject) => {
 					const toolPath = getBinPath(tool.name);
-					fs.exists(toolPath, (exists) => {
-						resolve(exists ? null : tool);
-					});
+					resolve(path.isAbsolute(toolPath) ? null : tool);
 				})
 		)
 	).then((res) => {

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -298,9 +298,11 @@ Please install it and reload this VS Code window.`
 		if (alternateTools['go-langserver']) {
 			vscode.window.showErrorMessage(`Support for "go-langserver" has been deprecated.
 The recommended language server is gopls. Delete the alternate tool setting for "go-langserver" to use gopls, or change "go-langserver" to "gopls" in your settings.json and reload the VS Code window.`);
+			return;
 		}
-		return;
 	}
+
+	console.log('promptForMissingTools(gopls)');
 	// Prompt the user to install gopls.
 	promptForMissingTool('gopls');
 }

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -302,7 +302,6 @@ The recommended language server is gopls. Delete the alternate tool setting for 
 		}
 	}
 
-	console.log('promptForMissingTools(gopls)');
 	// Prompt the user to install gopls.
 	promptForMissingTool('gopls');
 }


### PR DESCRIPTION
Also, update getMissingTools to check the tool's existence
by simply checking whether the resolved tool path is absolute.
getBinPath already ran the existence check before returning
the absolute path for the tool.

Fixes microsoft/vscode-go#3194