### PR TITLE
Add support for running an individual subtest

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,11 @@
         "description": "Runs a unit test at the cursor."
       },
       {
+        "command": "go.subtest.cursor",
+        "title": "Go: Subtest At Cursor",
+        "description": "Runs a sub test at the cursor."
+      },
+      {
         "command": "go.benchmark.cursor",
         "title": "Go: Benchmark Function At Cursor",
         "description": "Runs a benchmark at the cursor."

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -46,7 +46,7 @@ import { playgroundCommand } from './goPlayground';
 import { GoReferencesCodeLensProvider } from './goReferencesCodelens';
 import { GoRunTestCodeLensProvider } from './goRunTestCodelens';
 import { outputChannel, showHideStatus } from './goStatus';
-import { testAtCursor, subTestAtCursor, testCurrentFile, testCurrentPackage, testPrevious, testWorkspace } from './goTest';
+import { subTestAtCursor, testAtCursor, testCurrentFile, testCurrentPackage, testPrevious, testWorkspace } from './goTest';
 import { getConfiguredTools } from './goTools';
 import { vetCode } from './goVet';
 import {
@@ -277,7 +277,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 			testAtCursor(goConfig, 'test', args);
 		})
 	);
-	
+
 	ctx.subscriptions.push(
 		vscode.commands.registerCommand('go.subtest.cursor', (args) => {
 			const goConfig = getGoConfig();

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -46,7 +46,7 @@ import { playgroundCommand } from './goPlayground';
 import { GoReferencesCodeLensProvider } from './goReferencesCodelens';
 import { GoRunTestCodeLensProvider } from './goRunTestCodelens';
 import { outputChannel, showHideStatus } from './goStatus';
-import { testAtCursor, testCurrentFile, testCurrentPackage, testPrevious, testWorkspace } from './goTest';
+import { testAtCursor, subTestAtCursor, testCurrentFile, testCurrentPackage, testPrevious, testWorkspace } from './goTest';
 import { getConfiguredTools } from './goTools';
 import { vetCode } from './goVet';
 import {
@@ -275,6 +275,13 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand('go.test.cursor', (args) => {
 			const goConfig = getGoConfig();
 			testAtCursor(goConfig, 'test', args);
+		})
+	);
+	
+	ctx.subscriptions.push(
+		vscode.commands.registerCommand('go.subtest.cursor', (args) => {
+			const goConfig = getGoConfig();
+			subTestAtCursor(goConfig, 'test', args);
 		})
 	);
 

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -124,6 +124,10 @@ export function subTestAtCursor(goConfig: vscode.WorkspaceConfiguration, cmd: Te
 		vscode.window.showInformationMessage('No tests found. Current file is not a test file.');
 		return;
 	}
+	if (cmd !== 'test') {
+		vscode.window.showInformationMessage('Only the "test" is command supported for subtests');
+		return;
+	}
 
 	editor.document.save().then(async () => {
 		try {
@@ -142,7 +146,7 @@ export function subTestAtCursor(goConfig: vscode.WorkspaceConfiguration, cmd: Te
 			}
 
 			const testFunction = currentTestFunctions[0];
-			const runRegex = /t.Run\("(.*)"/;
+			const runRegex = /t.Run\("([^"]+)",/;
 			let lineText: string;
 			let match: RegExpMatchArray | null;
 			for (let i = editor.selection.start.line; i >= testFunction.range.start.line; i--) {
@@ -154,17 +158,13 @@ export function subTestAtCursor(goConfig: vscode.WorkspaceConfiguration, cmd: Te
 			}
 
 			if (!match) {
-				vscode.window.showInformationMessage('No sub test function found at cursor.');
+				vscode.window.showInformationMessage('No subtest function with a simple subtest name found at cursor');
 				return;
 			}
 
 			const subTestName = testFunctionName + '/' + match[1];
 
-			if (cmd === 'test') {
-				await runTestAtCursor(editor, subTestName, testFunctions, goConfig, cmd, args);
-			} else {
-				throw new Error('Unsupported command.');
-			}
+			await runTestAtCursor(editor, subTestName, testFunctions, goConfig, cmd, args);
 		} catch (err) {
 			console.error(err);
 		}

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -20,7 +20,6 @@ import {
 	TestConfig
 } from './testUtils';
 import { getTempFilePath } from './util';
-import { Range } from 'vscode';
 
 // lastTestConfig holds a reference to the last executed TestConfig which allows
 // the last test to be easily re-executed.
@@ -109,12 +108,12 @@ async function runTestAtCursor(
 }
 
 /**
-* Executes the sub unit test at the primary cursor using `go test`. Output
-* is sent to the 'Go' channel.
-*
-* @param goConfig Configuration for the Go extension.
-* @param cmd Whether the command is test , benchmark or debug.
-*/
+ * Executes the sub unit test at the primary cursor using `go test`. Output
+ * is sent to the 'Go' channel.
+ *
+ * @param goConfig Configuration for the Go extension.
+ * @param cmd Whether the command is test , benchmark or debug.
+ */
 export function subTestAtCursor(goConfig: vscode.WorkspaceConfiguration, cmd: TestAtCursorCmd, args: any) {
 	const editor = vscode.window.activeTextEditor;
 	if (!editor) {
@@ -131,34 +130,35 @@ export function subTestAtCursor(goConfig: vscode.WorkspaceConfiguration, cmd: Te
 			const testFunctions = await getTestFunctions(editor.document, null);
 			// We use functionName if it was provided as argument
 			// Otherwise find any test function containing the cursor.
-			const currentTestFunctions = testFunctions.filter(func => func.range.contains(editor.selection.start))
+			const currentTestFunctions = testFunctions.filter((func) => func.range.contains(editor.selection.start));
 			const testFunctionName = args && args.functionName
 				? args.functionName
 				: currentTestFunctions
-					.map(el => el.name)[0];
+					.map((el) => el.name)[0];
 
 			if (!testFunctionName) {
 				vscode.window.showInformationMessage('No test function found at cursor.');
 				return;
 			}
 
-			const testFunction = currentTestFunctions[0]
-			const runRegex = /t.Run\("(.*)"/
-			var lineText: String
-			var match: RegExpMatchArray | null
-			for (var i = editor.selection.start.line; i >= testFunction.range.start.line; i--) {
-				lineText = editor.document.lineAt(i).text
-				match = lineText.match(runRegex)
+			const testFunction = currentTestFunctions[0];
+			const runRegex = /t.Run\("(.*)"/;
+			let lineText: string;
+			let match: RegExpMatchArray | null;
+			for (let i = editor.selection.start.line; i >= testFunction.range.start.line; i--) {
+				lineText = editor.document.lineAt(i).text;
+				match = lineText.match(runRegex);
 				if (match) {
-					break
+					break;
 				}
 			}
-			if (!match){
+
+			if (!match) {
 				vscode.window.showInformationMessage('No sub test function found at cursor.');
 				return;
 			}
 
-			const subTestName = testFunctionName + "/" + match[1]
+			const subTestName = testFunctionName + '/' + match[1];
 
 			if (cmd === 'test') {
 				await runTestAtCursor(editor, subTestName, testFunctions, goConfig, cmd, args);

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -455,7 +455,7 @@ function targetArgs(testconfig: TestConfig): Array<string> {
 			// in running all the test methods, but one of them should call testify's `suite.Run(...)`
 			// which will result in the correct thing to happen
 			if (testFunctions.length > 0) {
-				if (testFunctions.length = 1) {
+				if (testFunctions.length === 1) {
 					params = params.concat(['-run', util.format('^%s$', testFunctions.pop())]);
 				} else {
 					params = params.concat(['-run', util.format('^(%s)$', testFunctions.join('|'))]);

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -455,7 +455,11 @@ function targetArgs(testconfig: TestConfig): Array<string> {
 			// in running all the test methods, but one of them should call testify's `suite.Run(...)`
 			// which will result in the correct thing to happen
 			if (testFunctions.length > 0) {
-				params = params.concat(['-run', util.format('^(%s)$', testFunctions.join('|'))]);
+				if (testFunctions.length = 1) {
+					params = params.concat(['-run', util.format('^%s$', testFunctions.pop())]);
+				} else {
+					params = params.concat(['-run', util.format('^(%s)$', testFunctions.join('|'))]);
+				}
 			}
 			if (testifyMethods.length > 0) {
 				params = params.concat(['-testify.m', util.format('^(%s)$', testifyMethods.join('|'))]);


### PR DESCRIPTION
Being able to run subtests is something that has been brought up a [couple](https://github.com/microsoft/vscode-go/issues/2850) of [times](https://github.com/microsoft/vscode-go/issues/1748) and something that I would find useful.

I've enabled running subtests through a command only - adding a CodeLens would be nice but as mentioned in the other issues, is tricky because there isn't currently a way to list subtests. While this doesn't go as far as allowing retries of a failed test, it does allow targeting a specific subtest which would get us some access to subtest functionality.

**Approach**
Similar to `Test function at cursor`, this approach allows running a test by placing the cursor inside the test function or on the `t.Run` call. It will search back from the current cursor position within the current outer test function for a line that contains `t.Run`. If a subtest is found, an appropriate call to `runTestAtCursor` is constructed and the test is executed by existing `go test` functionality.

I guess my main question for this PR is whether or not checking for a line with specific text (i.e. `t.Run()`) is a reasonable thing to do to allow this feature.

If you're happy to include this or some variation of it, I'm happy to fix up any style issues and add any tests that are required.

This is a simple example that I used for testing the change
```go
package blah

import (
        "fmt"
        "testing"
)

func TestThingss(t *testing.T) {
        t.Run("heres a test", func(t *testing.T) {
                fmt.Println("here's a test")
        })

        t.Run("some other test", func(t *testing.T) {
                fmt.Println("some other test")
                t.FailNow()
        })
}
```