### PR TITLE
Handle unexpected proxy query results gracefully

### DIFF
--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -454,7 +454,9 @@ async function latestGopls(tool: Tool): Promise<semver.SemVer> {
 			includePrerelease: true,
 			loose: true
 		});
-		versions.push(parsed);
+		if (parsed) {
+			versions.push(parsed);
+		}
 	}
 	if (versions.length === 0) {
 		return null;


### PR DESCRIPTION
When the proxy contacted for the released gopls version list does not
respond following the Go module proxy protocol but return unexpected
contents (e.g. login page) semver parsing will fail, trigger an exception,
and cause the language server client not to start.
 
Fixes #3204