### PR TITLE
test/gopls: fix the lint error

### DIFF
--- a/test/gopls/extension.test.ts
+++ b/test/gopls/extension.test.ts
@@ -87,7 +87,7 @@ async function sleep(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-suite('Go Extension Tests With Gopls', function() {
+suite('Go Extension Tests With Gopls', function () {
 	this.timeout(1000000);
 	const projectDir = path.join(__dirname, '..', '..', '..');
 	const env = new Env(projectDir);


### PR DESCRIPTION
The lint rule was changed since PR microsoft/vscode-go#3157
so the newly added code broke the lint test.

Change-Id: Ic58dfa62e19cb61600b45fe10b43811eb00bc28d
Reviewed-on: https://go-review.googlesource.com/c/vscode-go/+/230297
Reviewed-by: Rebecca Stambler <rstambler@golang.org>