### PR TITLE
Prompt transform value while adding tags

### DIFF
--- a/src/goModifytags.ts
+++ b/src/goModifytags.ts
@@ -128,7 +128,14 @@ function getTagsAndOptions(config: GoTagsConfig, commandArgs: GoTagsConfig): The
 					prompt: 'Enter comma separated options'
 				})
 				.then((inputOptions) => {
-					return [inputTags, inputOptions, transformValue];
+					return vscode.window
+						.showInputBox({
+							value: transformValue,
+							prompt: 'Enter transform value'
+						})
+						.then((transformOption) => {
+							return [inputTags, inputOptions, transformOption];
+						});
 				});
 		});
 }


### PR DESCRIPTION
In the current version, Go: Add Tags prompts to get user input for only tags and options if `go.addTags.promptForTags` is true. With the following changes, it will also prompt for transform value too.

Closes #2546

![NxOF5PNwXB](https://user-images.githubusercontent.com/58530683/80874408-270e9580-8cc3-11ea-9d1d-b56f9b2da28d.gif)

