### PR TITLE
Raise error if GOOS/GOARC is not compatible with host machine in debug

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -419,6 +419,17 @@ class Delve {
 					// Not applicable to exec mode in which case `program` need not point to source code under GOPATH
 					env['GOPATH'] = getInferredGopath(dirname) || env['GOPATH'];
 				}
+				if (
+					(env['GOOS'] && env['GOOS'] !== process.platform) ||
+					(env['GOARCH'] && env['GOARCH'] !== process.arch)
+				) {
+					logError(
+						`The debugger failed to launch because GOOS/GOARCH in go.toolsEnvVars is incompatible with this host`
+					);
+					return reject(
+						'The debugger failed to launch because GOOS/GOARCH in go.toolsEnvVars is incompatible with this host'
+					);
+				}
 				this.dlvEnv = env;
 				log(`Using GOPATH: ${env['GOPATH']}`);
 


### PR DESCRIPTION
As it is specified on the issue of #2696, while debugging an application, if `GOOS` or `GOARCH` value under `go.toolsEnvVars` is specified a value different than the host machine value, a nonexplanatory error is raised. The changes in this PR compares both environment variables with the ones on the host machine, if there is an incompatibility, it raises a meaningful error.

Closes #2696 

**A show case on mac:**
![goos-check](https://user-images.githubusercontent.com/58530683/80893181-c7bb8000-8cd8-11ea-9bbe-c1dc95445aa7.gif)


