### PR TITLE
Remove format setting from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1110,11 +1110,6 @@
         "go.languageServerExperimentalFeatures": {
           "type": "object",
           "properties": {
-            "format": {
-              "type": "boolean",
-              "default": false,
-              "description": "If true, gofmt is used by the language server to format files."
-            },
             "diagnostics": {
               "type": "boolean",
               "default": true,
@@ -1127,7 +1122,6 @@
             }
           },
           "default": {
-            "format": true,
             "diagnostics": true,
             "documentLink": true
           },


### PR DESCRIPTION
Now that it is no longer supported, don't let users configure it.