### PR TITLE
Allow for 'export' in environment variable file.

### DIFF
--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -144,7 +144,14 @@ export function parseEnvFile(envFilePath: string): { [key: string]: string } {
 	try {
 		const buffer = stripBOM(fs.readFileSync(envFilePath, 'utf8'));
 		buffer.split('\n').forEach((line) => {
-			const r = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
+			// Allow envFile to contain an export command, but remove it for processing
+			let l;
+			if (line.trim().substring(0,6) == 'export') {
+				l = line.replace("export ", '')
+			} else{
+				l = line
+			}
+			const r = l.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
 			if (r !== null) {
 				let value = r[2] || '';
 				if (value.length > 0 && value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') {

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -146,10 +146,10 @@ export function parseEnvFile(envFilePath: string): { [key: string]: string } {
 		buffer.split('\n').forEach((line) => {
 			// Allow envFile to contain an export command, but remove it for processing
 			let l;
-			if (line.trim().substring(0,6) == 'export') {
-				l = line.replace("export ", '')
-			} else{
-				l = line
+			if (line.trim().substring(0, 6) == 'export') {
+				l = line.replace('export ', '');
+			} else {
+				l = line;
 			}
 			const r = l.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
 			if (r !== null) {

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -146,7 +146,7 @@ export function parseEnvFile(envFilePath: string): { [key: string]: string } {
 		buffer.split('\n').forEach((line) => {
 			// Allow envFile to contain an export command, but remove it for processing
 			let l;
-			if (line.trim().substring(0, 6) == 'export') {
+			if (line.trim().substring(0, 6) === 'export') {
 				l = line.replace('export ', '');
 			} else {
 				l = line;


### PR DESCRIPTION
Hi Folks,

I was using the `envFile` parameter to process an environment variable file, and discovered that if lines were prefixed with the `export` command, the regex was not picking them up.  This change would process files containing an `export` command at the beginning of a line.