### PR TITLE
README: fix broken links, a few cosmetic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 [![Slack](https://img.shields.io/badge/slack-gophers-green.svg?style=flat)](https://gophers.slack.com/messages/vscode/) [![Build Status](https://travis-ci.org/Microsoft/vscode-go.svg?branch=master)](https://travis-ci.org/Microsoft/vscode-go)
 
+> We're moving! Read more [here](#we-are-moving) and subscribe to [microsoft/vscode-go#3247](https://github.com/microsoft/vscode-go/issues/3247) for updates.
+
 This extension adds rich language support for the [Go language](https://golang.org/) to VS Code.
 
 See the [Changelog](https://github.com/Microsoft/vscode-go/blob/master/CHANGELOG.md) to know what has changed over the last few versions of this extension.
 
-> Read the [We are moving!](#we-are-moving!) section to learn about the new home for this extension.
-
 ## Table of Contents
 
-- [We are moving!](#we-are-moving!)
+[**We are moving!**](#we-are-moving)
+
 - [Language Features](#language-features)
 	- [IntelliSense](#intellisense)
 	- [Code Navigation](#code-navigation)
@@ -35,9 +36,7 @@ See the [Changelog](https://github.com/Microsoft/vscode-go/blob/master/CHANGELOG
 - [Code of Conduct](#code-of-conduct)
 - [License](#license)
 
-## We are moving!
-
-🏡 🚚 🏡 
+## We are moving! 🏡 🚚 🏡 
 
 Our new home will be https://github.com/golang/vscode-go.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Slack](https://img.shields.io/badge/slack-gophers-green.svg?style=flat)](https://gophers.slack.com/messages/vscode/) [![Build Status](https://travis-ci.org/Microsoft/vscode-go.svg?branch=master)](https://travis-ci.org/Microsoft/vscode-go)
 
-> We're moving! Read more [here](#we-are-moving) and subscribe to [microsoft/vscode-go#3247](https://github.com/microsoft/vscode-go/issues/3247) for updates.
+> We're moving! Read more [here](#we-are-moving---) and subscribe to [microsoft/vscode-go#3247](https://github.com/microsoft/vscode-go/issues/3247) for updates.
 
 This extension adds rich language support for the [Go language](https://golang.org/) to VS Code.
 
@@ -10,7 +10,7 @@ See the [Changelog](https://github.com/Microsoft/vscode-go/blob/master/CHANGELOG
 
 ## Table of Contents
 
-[**We are moving!**](#we-are-moving)
+[**We are moving!**](#we-are-moving---)
 
 - [Language Features](#language-features)
 	- [IntelliSense](#intellisense)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Slack](https://img.shields.io/badge/slack-gophers-green.svg?style=flat)](https://gophers.slack.com/messages/vscode/) [![Build Status](https://travis-ci.org/Microsoft/vscode-go.svg?branch=master)](https://travis-ci.org/Microsoft/vscode-go)
 
-> We're moving! Read more [here](#we-are-moving---) and subscribe to [microsoft/vscode-go#3247](https://github.com/microsoft/vscode-go/issues/3247) for updates.
+> Read the [We are moving 🏡 🚚 🏡](#we-are-moving---) section to learn about the new home for this extension and subscribe to [Microsoft/vscode-go#3247](https://github.com/microsoft/vscode-go/issues/3247) for updates.
 
 This extension adds rich language support for the [Go language](https://golang.org/) to VS Code.
 


### PR DESCRIPTION
The `#we-are-moving!` links should be `#we-are-moving`, but I moved around the emojis and made a few other cosmetics updates so now they are `#we-are-moving---`. Happy to change anything back, I just liked how the emojis looked inline and wanted to make the announcement a little more visible. You can see how it looks here: https://github.com/stamblerre/vscode-go/tree/readme#go-for-visual-studio-code.

/cc @hyangah 